### PR TITLE
Imports assets from bootstrap's woff2 file

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
             app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.svg'), { destDir: '/fonts' });
             app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });
             app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff'), { destDir: '/fonts' });
+            app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff2'), { destDir: '/fonts' });
         }
 
     }


### PR DESCRIPTION
See: https://github.com/twbs/bootstrap/tree/master/fonts

I'm pretty new to this, but I noticed I had to add this line to my index.js in order to get some of the glyphicons to render, as they were hitting 404s like: 
```GET http://localhost:4200/fonts/glyphicons-halflings-regular.woff2```

Let me know if this is a mistake on my end or if there's a place I can write a test for another import like this