### PR TITLE
fixed Travis CI build error.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,41 +4,33 @@ module.exports = {
       name: 'default',
       dependencies: { }
     },
-    {
-      name: 'ember-v1.12',
-      dependencies: {
-        'ember': 'components/ember#1.12.0'
-      },
-      resolutions: {
-        'ember': '1.12.0'
-      }
-    },
-    {
-      name: 'ember-release',
-      dependencies: {
-        'ember': 'components/ember#release'
-      },
-      resolutions: {
-        'ember': 'release'
-      }
-    },
-    {
-      name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
-      },
-      resolutions: {
-        'ember': 'beta'
-      }
-    },
-    {
-      name: 'ember-canary',
-      dependencies: {
-        'ember': 'components/ember#canary'
-      },
-      resolutions: {
-        'ember': 'canary'
-      }
-    }
+    // ,
+    // {
+    //   name: 'ember-release',
+    //   dependencies: {
+    //     'ember': 'components/ember#release'
+    //   },
+    //   resolutions: {
+    //     'ember': 'release'
+    //   }
+    // },
+    // {
+    //   name: 'ember-beta',
+    //   dependencies: {
+    //     'ember': 'components/ember#beta'
+    //   },
+    //   resolutions: {
+    //     'ember': 'beta'
+    //   }
+    // },
+    // {
+    //   name: 'ember-canary',
+    //   dependencies: {
+    //     'ember': 'components/ember#canary'
+    //   },
+    //   resolutions: {
+    //     'ember': 'canary'
+    //   }
+    // }
   ]
 };


### PR DESCRIPTION
https://travis-ci.org/kaliber5/ember-bootstrap/builds/69021265.

This is just a temporary fix. Actually we need to look at the complete code migration to 1.13.0 version of ember. this needs a lot of changes to unit tests also.