### PR TITLE
Wire up <label> for attribute used in form-element component

### DIFF
--- a/app/templates/components/form-element/horizontal/default.hbs
+++ b/app/templates/components/form-element/horizontal/default.hbs
@@ -1,7 +1,7 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}}" for="{{concat elementId '-' name}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{bs-input name=name type=controlType value=value placeholder=placeholder}}
+        {{bs-input id=(concat elementId '-' name) name=name type=controlType value=value placeholder=placeholder}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/horizontal/select.hbs
+++ b/app/templates/components/form-element/horizontal/select.hbs
@@ -1,7 +1,7 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}}" for="{{concat elementId '-' name}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{bs-select name=name content=choices optionValuePath=selectValueProperty optionLabelPath=selectLabelProperty value=value}}
+        {{bs-select id=(concat elementId '-' name) name=name content=choices optionValuePath=selectValueProperty optionLabelPath=selectLabelProperty value=value}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/horizontal/select2.hbs
+++ b/app/templates/components/form-element/horizontal/select2.hbs
@@ -1,7 +1,7 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}}" for="{{concat elementId '-' name}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{select-2 name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value searchEnabled=false}}
+        {{select-2 id=(concat elementId '-' name) name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value searchEnabled=false}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/horizontal/textarea.hbs
+++ b/app/templates/components/form-element/horizontal/textarea.hbs
@@ -1,7 +1,7 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}}" for="{{concat elementId '-' name}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{bs-textarea name=name value=value placeholder=placeholder cols=cols rows=rows}}
+        {{bs-textarea id=(concat elementId '-' name) name=name value=value placeholder=placeholder cols=cols rows=rows}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/inline/default.hbs
+++ b/app/templates/components/form-element/inline/default.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-input name=name type=controlType value=value placeholder=placeholder}}
+{{bs-input id=(concat elementId '-' name) name=name type=controlType value=value placeholder=placeholder}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/select.hbs
+++ b/app/templates/components/form-element/inline/select.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-select name=name content=choices optionValuePath=selectValueProperty optionLabelPath=selectLabelProperty value=value}}
+{{bs-select id=(concat elementId '-' name) name=name content=choices optionValuePath=selectValueProperty optionLabelPath=selectLabelProperty value=value}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/textarea.hbs
+++ b/app/templates/components/form-element/inline/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-textarea name=name value=value placeholder=placeholder cols=cols rows=rows}}
+{{bs-textarea id=(concat elementId '-' name) name=name value=value placeholder=placeholder cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/default.hbs
+++ b/app/templates/components/form-element/vertical/default.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-input name=name type=controlType value=value placeholder=placeholder}}
+{{bs-input id=(concat elementId '-' name) name=name type=controlType value=value placeholder=placeholder}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/select.hbs
+++ b/app/templates/components/form-element/vertical/select.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-select name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value}}
+{{bs-select id=(concat elementId '-' name) name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/vertical/textarea.hbs
+++ b/app/templates/components/form-element/vertical/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
-    <label class="control-label">{{label}}</label>
+    <label class="control-label" for="{{concat elementId '-' name}}">{{label}}</label>
 {{/if}}
-{{bs-textarea value=value name=name placeholder=placeholder cols=cols rows=rows}}
+{{bs-textarea id=(concat elementId '-' name) value=value name=name placeholder=placeholder cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -42,8 +42,15 @@ function controlTypeSupportTest(assert, controlType, selector, values, getValueF
     });
 }
 
+function labeledControlTest(assert, controlType, selector) {
+    this.set('controlType',controlType);
+    this.render(hbs`{{bs-form-element controlType=controlType label="myLabel"}}`);
+    assert.equal(this.$(selector).attr('id'), this.$('label').attr('for'), 'component id ');
+}
+
 test('controlType "text" is supported', function(assert) {
     controlTypeSupportTest.call(this, assert, 'text', 'input[type=text]', 'myValue');
+    labeledControlTest.call(this, assert, 'text', 'input[type=text]');
 });
 
 test('controlType "checkbox" is supported', function(assert) {
@@ -52,6 +59,7 @@ test('controlType "checkbox" is supported', function(assert) {
 
 test('controlType "textarea" is supported', function(assert) {
     controlTypeSupportTest.call(this, assert, 'textarea', 'textarea', 'myValue');
+    labeledControlTest.call(this, assert, 'textarea', 'textarea');
 });
 
 
@@ -71,6 +79,7 @@ test('controlType "select" is supported', function(assert) {
         choiceValueProperty: 'id'
     };
     controlTypeSupportTest.call(this, assert, 'select', 'select', [options.choices[0], options.choices[1]], function() {return options.choices.findBy('id', this.val());}, options);
+    labeledControlTest.call(this, assert, 'select', 'select');
 });
 
 


### PR DESCRIPTION
Using the strategy from [this stack overflow answer](http://stackoverflow.com/a/32895607/747731?stw=2), form elements within the `form-element` component can become a labeled control.