### PR TITLE
Use bootstrap theme to override default bootstrap css settings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,13 +26,13 @@ module.exports = {
         var bootstrapPath   = path.join(app.bowerDirectory, 'bootstrap/dist');
 
         // Import css from bootstrap
-        if (options.importBootstrapTheme) {
-            app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
-        }
-
         if (options.importBootstrapCSS) {
             app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
             app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
+        }
+
+        if (options.importBootstrapTheme) {
+            app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
         }
 
         // Import glyphicons


### PR DESCRIPTION
According to project documentation, setting 'importBootstrapTheme' to true should enable the Bootstrap Theme. It is not working, because of the order of attaching the CSS files (first goes the theme, second goes the default Bootstrap CSS file).
This pull request fixes the - imho - bug.