### PR TITLE
Added insertEmberWormholeElementToDom configuration option

### DIFF
--- a/addon/config.js
+++ b/addon/config.js
@@ -3,6 +3,7 @@ var Config = {
     formValidationErrorIcon: 'glyphicon glyphicon-remove',
     formValidationWarningIcon: 'glyphicon glyphicon-warning-sign',
     formValidationInfoIcon: 'glyphicon glyphicon-info-sign',
+    insertEmberWormholeElementToDom: true,
 
     load: function(config) {
         for (var property in this) {

--- a/addon/initializers/modals-container.js
+++ b/addon/initializers/modals-container.js
@@ -1,3 +1,5 @@
+import Config from 'ember-bootstrap/config';
+
 /*globals document */
 const hasDOM = typeof document !== 'undefined';
 
@@ -13,9 +15,13 @@ function appendContainerElement(rootElementId, id) {
 }
 
 function initialize() {
+  if (!Config.insertEmberWormholeElementToDom) {
+    return;
+  }
+  
   const application = arguments[1] || arguments[0];
   const modalContainerElId = 'ember-bootstrap-modal-container';
-  appendContainerElement(application.rootElement, modalContainerElId);
+  appendContainerElement(application.rootElement, modalContainerElId);  
 }
 
 export default {


### PR DESCRIPTION
I made it possible to disable the automatic creation of the ember-wormhole DOM element. I'm using this addon in a context where the Ember boot process is delayed, and as a result the Ember rootElement doesn't yet exist when the initializer runs. If a developer sets this flag to false, he will need to add that DOM element manually.