### PR TITLE
Remove hardcoding of `isDevelopingAddon`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,5 @@ module.exports = {
 
     app.import(path.join(app.bowerDirectory, 'bootstrap/js/transition.js'));
 
-  },
-
-  isDevelopingAddon: function () {
-    return true;
   }
 };


### PR DESCRIPTION
By default `isDevelopingAddon` is `true` when running `ember serve`, `ember test`, or `ember test --server` within the addon itself but `false` when running inside consuming applications.

The way this was previously, always forced `isDevelopingAddon` to be `true`, which makes consuming applications fail JSHint because this addon does.