### PR TITLE
Implement autofocus support

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -172,6 +172,15 @@ export default FormGroup.extend({
   placeholder: null,
 
   /**
+   * Control element's HTML5 autofocus attribute
+   *
+   * @property autofocus
+   * @type boolean
+   * @public
+   */
+  autofocus: false,
+
+  /**
    * Control element's name attribute
    *
    * @property name

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -101,6 +101,25 @@ var observeOpen = function () {
  The modal component supports this common case by triggering the submit event programmatically on the body's form if
  present whenever the footer's submit button is pressed, so the example above will work as expected.
 
+ ### Auto-focus
+
+ In order to allow key handling to function, the modal's root element is given focus once the modal is shown. If your
+ modal contains an element such as a text input and you would like it to be given focus rather than the modal element,
+ then give it the HTML5 autofocus attribute:
+
+  ```hbs
+ {{#bs-modal title="Form Example" body=false footer=false}}
+   {{#bs-modal-body}}
+     {{#bs-form action=(action "submit") model=this}}
+       {{bs-form-element controlType="text" label="first name" property="firstname" autofocus=true}}
+       {{bs-form-element controlType="text" label="last name" property="lastname"}}
+     {{/bs-form}}
+   {{/bs-modal-body}}
+   {{bs-modal-footer closeTitle=(t "contact.label.cancel") submitTitle=(t "contact.label.ok")}}
+ {{/bs-modal}}
+ ```
+
+
  ### Modals inside wormhole
 
  Modals make use of the [ember-wormhole](https://github.com/yapplabs/ember-wormhole) addon, which will be installed
@@ -407,6 +426,20 @@ export default Ember.Component.extend({
   _observeOpen: Ember.observer('open', observeOpen),
 
   /**
+   * Give the modal (or its autofocus element) focus
+   *
+   * @method takeFocus
+   * @private
+   */
+  takeFocus() {
+    let focusElement = this.$('[autofocus]').first();
+    if (focusElement.length === 0) {
+      focusElement = this.get('modalElement');
+    }
+    focusElement.focus();
+  },
+
+  /**
    * Show the modal
    *
    * @method show
@@ -441,12 +474,12 @@ export default Ember.Component.extend({
       if (this.get('usesTransition')) {
         this.get('modalElement')
           .one('bsTransitionEnd', Ember.run.bind(this, function() {
-            this.get('modalElement').trigger('focus');
+            this.takeFocus();
           }))
           .emulateTransitionEnd(Modal.TRANSITION_DURATION);
       }
       else {
-        this.get('modalElement').trigger('focus');
+        this.takeFocus();
       }
 
       this.sendAction('openedAction');

--- a/app/templates/components/form-element/horizontal/default.hbs
+++ b/app/templates/components/form-element/horizontal/default.hbs
@@ -4,7 +4,7 @@
         {{#if hasBlock}}
             {{yield value formElementId}}
         {{else}}
-            {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder}}
+            {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus}}
         {{/if}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
@@ -14,7 +14,7 @@
         {{#if hasBlock}}
             {{yield value}}
         {{else}}
-            {{bs-input name=name type=controlType value=value placeholder=placeholder}}
+            {{bs-input name=name type=controlType value=value placeholder=placeholder autofocus=autofocus}}
         {{/if}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/horizontal/textarea.hbs
+++ b/app/templates/components/form-element/horizontal/textarea.hbs
@@ -1,13 +1,13 @@
 {{#if hasLabel}}
     <label class="control-label {{horizontalLabelGridClass}}" for="{{formElementId}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{bs-textarea id=formElementId name=name value=value placeholder=placeholder cols=cols rows=rows}}
+        {{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>
 {{else}}
     <div class="{{horizontalInputGridClass}} {{horizontalInputOffsetGridClass}}">
-        {{bs-textarea name=name value=value placeholder=placeholder cols=cols rows=rows}}
+        {{bs-textarea name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/inline/default.hbs
+++ b/app/templates/components/form-element/inline/default.hbs
@@ -4,6 +4,6 @@
 {{#if hasBlock}}
     {{yield value formElementId}}
 {{else}}
-    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder}}
+    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus}}
 {{/if}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/textarea.hbs
+++ b/app/templates/components/form-element/inline/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-textarea id=formElementId name=name value=value placeholder=placeholder cols=cols rows=rows}}
+{{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/default.hbs
+++ b/app/templates/components/form-element/vertical/default.hbs
@@ -4,7 +4,7 @@
 {{#if hasBlock}}
     {{yield value formElementId}}
 {{else}}
-    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder}}
+    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus}}
 {{/if}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/textarea.hbs
+++ b/app/templates/components/form-element/vertical/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-textarea id=formElementId value=value name=name placeholder=placeholder cols=cols rows=rows}}
+{{bs-textarea id=formElementId value=value name=name placeholder=placeholder autofocus=autofocus cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -228,6 +228,47 @@ test('when modal has a form and the submit button is clicked, the form is submit
   this.$('.modal .modal-footer button[type=submit]').click();
 });
 
+test('autofocus element is focused when present and fade=false', function (assert) {
+  assert.expect(1);
+
+  this.set('open', false);
+  this.render(hbs`
+    {{#bs-modal title="Simple Dialog" fade=false open=open}}
+      <input class="my-input" autofocus="autofocus"/> blahblahblah
+    {{/bs-modal}}
+    <div id="ember-bootstrap-modal-container"></div>
+  `);
+
+  this.$('.my-input').focus(() => {
+    assert.ok(true, "focus was triggered on the autofocus element");
+  });
+
+  this.set('open', true);
+});
+
+test('autofocus element is focused when present and fade=true', function (assert) {
+  assert.expect(1);
+
+  this.set('open', false);
+  this.render(hbs`
+    {{#bs-modal title="Simple Dialog" fade=true open=open}}
+      <input class="my-input" autofocus="autofocus"/>
+    {{/bs-modal}}
+    <div id="ember-bootstrap-modal-container"></div>
+  `);
+
+  this.$('.my-input').focus(() => {
+    assert.ok(true, "focus was triggered on the autofocus element");
+  });
+
+  this.set('open', true);
+
+  // wait for fade animation
+  var done = assert.async();
+  setTimeout(() => {
+    done();
+  }, transitionTimeout);
+});
 
 test('Pressing escape key will close the modal if keyboard=true', function(assert) {
   assert.expect(3);
@@ -235,6 +276,36 @@ test('Pressing escape key will close the modal if keyboard=true', function(asser
     assert.ok(true, 'Action has been called.');
   });
   this.render(hbs`{{#bs-modal title="Simple Dialog" closeAction=(action "testAction") keyboard=true}}Hello world!{{/bs-modal}}<div id="ember-bootstrap-modal-container"></div>`);
+  var done = assert.async();
+
+  // wait for fade animation
+  setTimeout(() => {
+    assert.equal(this.$('.modal').hasClass('in'), true, 'Modal is visible');
+
+    // trigger escape key event
+    var e = Ember.$.Event("keydown");
+    e.which = e.keyCode = 27;
+    this.$('.modal').trigger(e);
+
+    // wait for fade animation
+    setTimeout(() => {
+      assert.equal(this.$('.modal').hasClass('in'), false, 'Modal is hidden');
+      done();
+    }, transitionTimeout);
+  }, transitionTimeout);
+});
+
+test('Pressing escape key will close the modal if keyboard=true and element is autofocused', function (assert) {
+  assert.expect(3);
+  this.on('testAction', () => {
+    assert.ok(true, 'Action has been called.');
+  });
+  this.render(hbs`
+    {{#bs-modal title="Simple Dialog" closeAction=(action "testAction") keyboard=true}}
+      <input autofocus="autofocus"/>
+    {{/bs-modal}}
+    <div id="ember-bootstrap-modal-container"></div>
+  `);
   var done = assert.async();
 
   // wait for fade animation


### PR DESCRIPTION
When a modal is shown, its root element is given focus so keyboard events can be handled. This change allows developers to use the HTML5 autofocus attribute to indicate that an input element should be given focus, instead of the root element.

This also involved propagating the autofocus attribute through a couple of layers of for/input elements.