### PR TITLE
Implement openAction

### DIFF
--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -392,6 +392,19 @@ export default Ember.Component.extend({
   closedAction: null,
 
   /**
+   * The action to be sent when the modal is opening.
+   * This will be triggered immediately after the modal is shown (so it's safe to access the DOM for
+   * size calculations and the like). This means that if fade=true, it will be shown in between the
+   * backdrop animation and the fade animation.
+   *
+   * @property openAction
+   * @type string
+   * @default null
+   * @public
+   */
+  openAction: null,
+
+  /**
    * The action to be sent after the modal has been completely shown (including the CSS transition).
    *
    * @property openedAction
@@ -471,18 +484,20 @@ export default Ember.Component.extend({
 
       //this.enforceFocus()
 
+      this.sendAction('openAction');
+
       if (this.get('usesTransition')) {
         this.get('modalElement')
           .one('bsTransitionEnd', Ember.run.bind(this, function() {
             this.takeFocus();
+            this.sendAction('openedAction');
           }))
           .emulateTransitionEnd(Modal.TRANSITION_DURATION);
       }
       else {
         this.takeFocus();
+        this.sendAction('openedAction');
       }
-
-      this.sendAction('openedAction');
     };
     Ember.run.scheduleOnce('afterRender', this, this.handleBackdrop, callback);
   },

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -159,7 +159,59 @@ test('size property adds size class', function (assert) {
   assert.ok(this.$('.modal-dialog').hasClass('modal-lg'), 'Modal has size class.');
 });
 
-test('openedAction is called after modal is shown', function (assert) {
+test('openAction/openedAction fire correctly with fade=false', function (assert) {
+  assert.expect(4);
+
+  this.set('open', false);
+  let openActionCount = 0;
+  let openedActionCount = 0;
+  this.on('openAction', () => {
+    openActionCount += 1;
+    assert.notEqual(this.$('.modal-body').width(), 0, "the modal is displayed when openAction is fired");
+    assert.equal(openedActionCount, 0, "openAction doesn't fire before openedAction");
+  });
+  this.on('openedAction', () => {
+    openedActionCount += 1;
+  });
+  this.render(hbs`{{#bs-modal title="Simple Dialog" openAction=(action "openAction") openedAction=(action "openedAction") open=open fade=false}}Hello world!{{/bs-modal}}<div id="ember-bootstrap-modal-container"></div>`);
+
+  this.set('open', true);
+
+  assert.equal(openActionCount, 1, "open action fired after setting open=true");
+  assert.equal(openedActionCount, 1, "opened action fired after setting open=true");
+});
+
+test('openAction/openedAction fire correctly with fade=true', function (assert) {
+  assert.expect(5);
+
+  this.set('open', false);
+  let openActionCount = 0;
+  let openedActionCount = 0;
+  this.on('openAction', () => {
+    openActionCount += 1;
+    assert.notEqual(this.$('.modal-body').width(), 0, "the modal is displayed when openAction is fired");
+  });
+  this.on('openedAction', () => {
+    openedActionCount += 1;
+  });
+  this.render(hbs`{{#bs-modal title="Simple Dialog" openAction=(action "openAction") openedAction=(action "openedAction") open=open}}Hello world!{{/bs-modal}}<div id="ember-bootstrap-modal-container"></div>`);
+
+  this.set('open', true);
+
+  assert.equal(openActionCount, 0, "open action didn't fire immediately");
+  assert.equal(openedActionCount, 0, "opened action didn't fire immediately");
+
+  // wait for fade animation
+  var done = assert.async();
+  setTimeout(() => {
+    assert.equal(openActionCount, 1, "open action fired");
+    assert.equal(openedActionCount, 1, "opened action fired");
+
+    done();
+  }, transitionTimeout);
+});
+
+test('openedAction is called after modal is shown and animation completes', function (assert) {
   assert.expect(1);
 
   this.set('open', false);


### PR DESCRIPTION
openAction will fire just after the modal has been shown, but before the transition animation, and openedAction will fire after the modal is completely shown, including transition animation.

The idea is that openAction can be used to access and manipulate the DOM at a time when it's no longer display: none, so size calculations and the like can be performed, and openedAction can be used to perform actions after the entire show animation is complete, such as setting focus, starting custom in-modal animations, etc.

Note that this technically breaks backwards compatibility, as it changes the timing of when openedAction fires.