### PR TITLE
Create validation hooks for external libs and fix config loader

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import FormGroup from 'ember-bootstrap/components/bs-form-group';
 import Form from 'ember-bootstrap/components/bs-form';
 
-const { computed } = Ember;
+const { computed, defineProperty } = Ember;
 
 const nonTextFieldControlTypes = Ember.A([
   'checkbox',
@@ -108,6 +108,8 @@ const nonTextFieldControlTypes = Ember.A([
  @public
  */
 export default FormGroup.extend({
+  classNameBindings: ['isValidating'],
+
   /**
    * Text to display within a `<label>` tag.
    *
@@ -278,6 +280,16 @@ export default FormGroup.extend({
   hasValidator: computed.notEmpty('model.validate'),
 
   /**
+   * Set a validating state for async validations
+   *
+   * @property isValidating
+   * @type boolean
+   * @default false
+   * @public
+   */
+  isValidating: false,
+
+  /**
    * If `true` form validation markup is rendered (requires a validatable `model`).
    *
    * @property showValidation
@@ -304,8 +316,8 @@ export default FormGroup.extend({
    * @type string
    * @protected
    */
-  validation: computed('hasErrors', 'hasValidator', 'showValidation', function() {
-    if (!this.get('showValidation') || !this.get('hasValidator')) {
+  validation: computed('hasErrors', 'hasValidator', 'showValidation', 'isValidating', function() {
+    if (!this.get('showValidation') || !this.get('hasValidator') || this.get('isValidating')) {
       return null;
     }
     return this.get('hasErrors') ? 'error' : 'success';
@@ -460,11 +472,22 @@ export default FormGroup.extend({
     this.set('showValidation', true);
   },
 
+  /**
+   * Setup validation properties. This method acts as a hook for external validation
+   * libraries to overwrite.
+   *
+   * @method setupValidations
+   * @public
+   */
+  setupValidations() {
+    defineProperty(this, 'errors', computed.readOnly(`model.errors.${this.get('property')}`));
+  },
+
   init() {
     this._super();
     if (!Ember.isBlank(this.get('property'))) {
-      Ember.Binding.from(`model.${this.get('property')}`).to('value').connect(this);
-      Ember.Binding.from(`model.errors.${this.get('property')}`).to('errors').connect(this);
+      defineProperty(this, 'value', computed.alias(`model.${this.get('property')}`));
+      this.setupValidations();
     }
   }
 });

--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -108,8 +108,6 @@ const nonTextFieldControlTypes = Ember.A([
  @public
  */
 export default FormGroup.extend({
-  classNameBindings: ['isValidating'],
-
   /**
    * Text to display within a `<label>` tag.
    *
@@ -278,16 +276,6 @@ export default FormGroup.extend({
    * @protected
    */
   hasValidator: computed.notEmpty('model.validate'),
-
-  /**
-   * Set a validating state for async validations
-   *
-   * @property isValidating
-   * @type boolean
-   * @default false
-   * @public
-   */
-  isValidating: false,
 
   /**
    * If `true` form validation markup is rendered (requires a validatable `model`).

--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -450,6 +450,15 @@ export default FormGroup.extend({
   }),
 
   /**
+   * Setup validation properties. This method acts as a hook for external validation
+   * libraries to overwrite.
+   *
+   * @method setupValidations
+   * @public
+   */
+  setupValidations: Ember.K,
+
+  /**
    * Listen for focusOut events from the control element to automatically set `showValidation` to true to enable
    * form validation markup rendering.
    *
@@ -458,17 +467,6 @@ export default FormGroup.extend({
    */
   focusOut() {
     this.set('showValidation', true);
-  },
-
-  /**
-   * Setup validation properties. This method acts as a hook for external validation
-   * libraries to overwrite.
-   *
-   * @method setupValidations
-   * @public
-   */
-  setupValidations() {
-    defineProperty(this, 'errors', computed.readOnly(`model.errors.${this.get('property')}`));
   },
 
   init() {

--- a/addon/components/bs-form-group.js
+++ b/addon/components/bs-form-group.js
@@ -26,7 +26,7 @@ const { computed } = Ember;
 export default Ember.Component.extend({
 
   classNames: ['form-group'],
-  classNameBindings: ['validationClass', 'hasFeedback'],
+  classNameBindings: ['validationClass', 'hasFeedback', 'isValidating'],
 
   /**
    * Whether to show validation state icons.
@@ -38,6 +38,16 @@ export default Ember.Component.extend({
    * @public
    */
   useIcons: true,
+
+  /**
+   * Set a validating state for async validations
+   *
+   * @property isValidating
+   * @type boolean
+   * @default false
+   * @public
+   */
+  isValidating: false,
 
   /**
    * Computed property which is true if the form group is in a validation state

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -139,16 +139,17 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * Validate hook that will either resolve if the model is valid or reject if it's not
+   * Validate hook that will return a promise that will either resolve if the model is valid
+   * or reject if it's not.
    *
-   * @param Function resolve
-   * @param Function reject
+   * @param Object model
+   * @return Promise
    * @public
    */
-  validate(resolve, reject) {
-    this.get('model').validate().then(() => {
-      return this.get('model.isValid') ? resolve() : reject();
-    }, reject);
+  validate(/* model */) {
+    Ember.deprecate('[ember-bootstrap] Validation support has been moved to 3rd party addons.\n' +
+                    'ember-validations: https://github.com/kaliber5/ember-bootstrap-validations\n' +
+                    'ember-cp-validations: https://github.com/offirgolan/ember-bootstrap-cp-validations\n', false);
   },
 
   /**
@@ -166,15 +167,17 @@ export default Ember.Component.extend({
     if (e) {
       e.preventDefault();
     }
+
     if (!this.get('hasValidator')) {
       return this.sendAction();
     } else {
-      return new Ember.RSVP.Promise((resolve, reject) => this.validate(resolve, reject)).then(() => {
-        return this.sendAction();
-      }, () => {
-        this.get('childFormElements').setEach('showValidation', true);
-        return this.sendAction('invalid');
-      });
+      let validationPromise = this.validate(this.get('model'));
+      if (validationPromise && validationPromise instanceof Ember.RSVP.Promise) {
+        validationPromise.then(() => this.sendAction(), () => {
+          this.get('childFormElements').setEach('showValidation', true);
+          return this.sendAction('invalid');
+        });
+      }
     }
   },
 

--- a/addon/config.js
+++ b/addon/config.js
@@ -1,17 +1,21 @@
-let Config = {
+import Ember from 'ember';
+
+const Config = Ember.Object.extend();
+
+Config.reopenClass({
   formValidationSuccessIcon: 'glyphicon glyphicon-ok',
   formValidationErrorIcon: 'glyphicon glyphicon-remove',
   formValidationWarningIcon: 'glyphicon glyphicon-warning-sign',
   formValidationInfoIcon: 'glyphicon glyphicon-info-sign',
   insertEmberWormholeElementToDom: true,
 
-  load(config) {
-    for (let property in this) {
-      if (this.hasOwnProperty(property) && typeof this[property] !== 'function' && typeof config[property] !== 'undefined') {
+  load(config = {}) {
+    for (let property in config) {
+      if (this.hasOwnProperty(property) && typeof this[property] !== 'function') {
         this[property] = config[property];
       }
     }
   }
-};
+});
 
 export default Config;


### PR DESCRIPTION
Hi There,

Im one of the creators of [ember-cp-validations](https://github.com/offirgolan/ember-cp-validations) and I think this addon is fantastic. Im creating this PR to move some code around into hooks which I can easily create a 3rd party addon for anyone that wants to use ember-bootstrap + ember-cp-validations. I currently have an alpha ([ember-bootstrap-cp-validations](https://github.com/offirgolan/ember-bootstrap-cp-validations)) but I think it's a little messy and will be difficult to maintain without some important changes to this library. 

(also Resolves #68)