### PR TITLE
Fix FastBoot: don't import transition.js if being called from Node

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ module.exports = {
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff2'), {destDir: '/fonts'});
     }
 
-    app.import('vendor/transition.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import('vendor/transition.js');
+    }
   },
 
   treeForStyles: function treeForStyles(tree) {


### PR DESCRIPTION
FastBoot doesn't need CSS transitions to prerender in Node so if we're in the EMBER_CLI_FASTBOOT environment, let's skip importing transition.js. Fixes #75

This is similar to Ember-Paper's recent fix:
"don't import hammerjs and match media if being called from node"
https://github.com/miguelcobain/ember-paper/pull/347/commits/dbb0c34cab2b3c7d595baff8c469207fe261aa08

We can't have jQuery on the FastBoot prerendering stage because they use a very minimal implementation of DOM there.

Tom Dale has a great recent talk about FastBoot here: https://www.youtube.com/watch?v=xFTDNGZExuU&feature=youtu.be&t=1h21m40s

Part about jQuery contraint: https://www.youtube.com/watch?v=xFTDNGZExuU&feature=youtu.be&t=1h33m45s