### PR TITLE
Fix: override model on bs-form-element

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -270,7 +270,7 @@ export default FormGroup.extend({
    * @property model
    * @public
    */
-  model: computed.alias('form.model'),
+  model: computed.reads('form.model'),
 
   /**
    * The array of error messages from the `model`'s validation.


### PR DESCRIPTION
`model: computed.alias('form.model')` sets `form.model` to model passed in {{bs-form-element}}.