### PR TITLE
bs-form: adds support for novalidate attribute

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -72,6 +72,7 @@ const { computed } = Ember;
 export default Ember.Component.extend({
   tagName: 'form',
   classNameBindings: ['layoutClass'],
+  attributeBindings: ['novalidate'],
   ariaRole: 'form',
 
   /**
@@ -141,6 +142,16 @@ export default Ember.Component.extend({
    * @public
    */
   submitOnEnter: false,
+
+  /**
+   * If set to true novalidate attribute is present on form element
+   *
+   * @property novalidate
+   * @type boolean
+   * @default false
+   * @public
+   */
+  novalidate: false,
 
   /**
    * An array of `Components.FormElement`s that are children of this form.

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -127,3 +127,17 @@ test('Pressing enter on a form with submitOnEnter submits the form', function(as
 
   this.$('form').trigger(e);
 });
+
+test('supports novalidate attribute', function(assert) {
+  assert.expect(2);
+  this.render(hbs`{{bs-form}}`);
+  assert.ok(
+    this.$('form').attr('novalidate') === 'false',
+    'defaults to false'
+  );
+  this.set('novalidate', true);
+  this.render(hbs`{{bs-form novalidate=novalidate}}`);
+  assert.ok(
+    this.$('form').attr('novalidate') === 'true'
+  );
+});


### PR DESCRIPTION
Allows to disable browser form validation which may interfere in an undesired way with application validation logic.