### PR TITLE
adjust position of feedback items if there is an input group

### DIFF
--- a/tests/dummy/app/templates/forms.hbs
+++ b/tests/dummy/app/templates/forms.hbs
@@ -30,7 +30,15 @@
 {{/bs-form}}
 
 <h2>Custom Controls</h2>
-
+{{#bs-form formLayout=formLayout model=this action="submit"}}
+    {{#bs-form-element label="Email" placeholder="Email" property="email" as |value id|}}
+      <div class="input-group">
+        {{bs-input id=id value=value}}
+        <span class="input-group-addon">@example.com</span>
+      </div>
+    {{/bs-form-element}}
+    {{bs-button defaultText="Submit" type="primary" buttonType="submit"}}
+{{/bs-form}}
 
 
 <h2>Disabled Controls</h2>

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -199,3 +199,82 @@ test('if invisibleLabel is true sr-only class is added to label', function(asser
     assert.ok(this.$('label').hasClass('sr-only'), `sr-only class is present for formLayout ${formLayout}`);
   });
 });
+
+test('adjusts validation icon position if there is an input group', function(assert) {
+  assert.expect(6);
+  this.set('validation', 'success');
+  this.set('formLayout', 'vertical');
+  this.render(hbs`
+    {{#bs-form formLayout=formLayout}}
+      {{#bs-form-element validation=validation label='ajusts validation icon position' classNames='addon'}}
+        <div class="input-group">
+          {{bs-input}}
+          <div class="input-group-addon">
+            @example.com
+          </div>
+        </div>
+      {{/bs-form-element}}
+      {{#bs-form-element validation=validation label='ajusts validation icon position' classNames='button'}}
+        <div class="input-group">
+          {{bs-input}}
+          <div class="input-group-btn">
+            <button class="btn btn-default" type="button">foo</button>
+            <button class="btn btn-default" type="button">bar</button>
+          </div>
+        </div>
+      {{/bs-form-element}}
+    {{/bs-form}}
+  `);
+  // assumption on bootstrap defaults:
+  // feedback icons does have right: 0px for vertical forms
+  // https://github.com/twbs/bootstrap/blob/v3.3.6/less/forms.less#L400-L403
+  assert.equal(
+    this.$('.addon .form-control-feedback').css('right'),
+    `${this.$('.addon .input-group-addon').outerWidth()}px`,
+    'works for addon on init'
+  );
+  assert.equal(
+    this.$('.button .form-control-feedback').css('right'),
+    `${this.$('.button .input-group-btn').outerWidth()}px`,
+    'works for button on init'
+  );
+  let expectedRightValue = this.$('.addon .form-control-feedback').css('right');
+  this.set('validation', null);
+  assert.ok(
+    this.$().has('.form-control-feedback').length === 0,
+    'assumption'
+  );
+  this.set('validation', 'error');
+  assert.equal(
+    this.$('.addon .form-control-feedback').css('right'),
+    expectedRightValue,
+    'adjusts correctly after validation changed from null'
+  );
+  this.set('validation', 'success');
+  this.$('.addon input').val('foo').trigger('change');
+  assert.equal(
+    this.$('.addon .form-control-feedback').css('right'),
+    expectedRightValue,
+    'adjusts correctly after validation changed form error to success'
+  );
+  // assumption on bootstrap defaults:
+  // feedback icons does have right: 15px for horizontal forms
+  // https://github.com/twbs/bootstrap/blob/v3.3.6/less/forms.less#L589-L591
+  // https://github.com/twbs/bootstrap/blob/v3.3.6/less/variables.less#L326-L327
+  this.set('formLayout', 'horizontal');
+  /* PhantomJS 1.9 used by travis fails test due to a positioning or rounding issue.
+   * PhantomJS 2.x and all major browsers are fine.
+   * Replace test above by the strict one after travis upgraded PhantomJS finally.
+  assert.equal(
+    this.$('.addon .form-control-feedback').css('right'),
+    `${this.$('.addon .input-group-addon').outerWidth() + 15}px`,
+    'takes bootstrap default positioning into account'
+  );
+  */
+  let gap = parseInt(this.$('.addon .form-control-feedback').css('right')) -
+            this.$('.addon .input-group-addon').outerWidth() - 15;
+  assert.ok(
+    gap === 0 || gap === -1,
+    'takes bootstrap default positioning into account'
+  );
+});


### PR DESCRIPTION
> Icons, labels, and input groups
> Manual positioning of feedback icons is required for [...] input groups with an add-on on the right. [...] For input groups, adjust the right value to an appropriate pixel value depending on the width of your addon.
> Source: http://getbootstrap.com/css/#forms-control-validation