### PR TITLE
adds support for sr-only label

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -114,11 +114,24 @@ export default FormGroup.extend(ComponentChild, {
   /**
    * Text to display within a `<label>` tag.
    *
+   * You should include a label for every form input cause otherwise screen readers
+   * will have trouble with your forms. Use `invisibleLabel` property if you want
+   * to hide them.
+   *
    * @property label
    * @type string
    * @public
    */
   label: null,
+
+  /**
+   * Controls label visibilty by adding 'sr-only' class.
+   *
+   * @property invisibleLabel
+   * @type boolean
+   * @public
+   */
+  invisibleLabel: false,
 
   /**
    * The type of the control widget.

--- a/app/templates/components/form-element/horizontal/default.hbs
+++ b/app/templates/components/form-element/horizontal/default.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}} {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
         {{#if hasBlock}}
             {{yield value formElementId validation}}

--- a/app/templates/components/form-element/horizontal/select.hbs
+++ b/app/templates/components/form-element/horizontal/select.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}} {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
         {{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled required=required}}
         {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/horizontal/textarea.hbs
+++ b/app/templates/components/form-element/horizontal/textarea.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label {{horizontalLabelGridClass}}" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{horizontalLabelGridClass}} {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
         {{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled required=required}}
         {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/default.hbs
+++ b/app/templates/components/form-element/inline/default.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{#if hasBlock}}
     {{yield value formElementId validation}}

--- a/app/templates/components/form-element/inline/select.hbs
+++ b/app/templates/components/form-element/inline/select.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled required=required}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/textarea.hbs
+++ b/app/templates/components/form-element/inline/textarea.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled required=required}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/vertical/default.hbs
+++ b/app/templates/components/form-element/vertical/default.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{#if hasBlock}}
     {{yield value formElementId validation}}

--- a/app/templates/components/form-element/vertical/select.hbs
+++ b/app/templates/components/form-element/vertical/select.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled required=required}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/vertical/textarea.hbs
+++ b/app/templates/components/form-element/vertical/textarea.hbs
@@ -1,5 +1,5 @@
 {{#if hasLabel}}
-    <label class="control-label" for="{{formElementId}}">{{label}}</label>
+    <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
 {{bs-textarea id=formElementId value=value name=name placeholder=placeholder autofocus=autofocus disabled=disabled required=required cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -185,3 +185,17 @@ test('disabled property propagates - select', function(assert) {
   assert.ok(this.$('.form-group').hasClass('is-disabled'), 'component has is-disabled class');
   assert.equal(this.$('select').attr('disabled'), 'disabled', 'input html5 disabled is true');
 });
+
+test('if invisibleLabel is true sr-only class is added to label', function(assert) {
+  let formLayouts = [
+    'vertical',
+    'horizontal',
+    'inline'
+  ];
+  this.render(hbs`{{bs-form-element label="myLabel"}}`);
+  assert.notOk(this.$('label').hasClass('sr-only'), `sr-only class is not present as defaultText`);
+  formLayouts.forEach((formLayout) => {
+    this.render(hbs`{{#bs-form formLayout=formLayout }}{{bs-form-element label="myLabel" invisibleLabel=true}}{{/bs-form}}`);
+    assert.ok(this.$('label').hasClass('sr-only'), `sr-only class is present for formLayout ${formLayout}`);
+  });
+});


### PR DESCRIPTION
Introduces an option to add an label but hide it except for screen readers.

Motivation:

> Always add labels
> Screen readers will have trouble with your forms if you don't include a label for every input. For these inline forms, you can hide the labels using the .sr-only class. There are further alternative methods of providing a label for assistive technologies, such as the aria-label, aria-labelledby or title attribute. If none of these is present, screen readers may resort to using the placeholder attribute, if present, but note that use of placeholder as a replacement for other labelling methods is not advised.
> http://getbootstrap.com/css/#forms-inline

Not quite sure about the naming. Perhaps `srOnlyLabel` would me better?