### PR TITLE
allow value 0 (Number) as valid value for a bs-button

### DIFF
--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -210,7 +210,7 @@ export default Ember.Component.extend(ComponentParent, SizeClass, {
           value = this.get('activeChildren').mapBy('value');
           break;
       }
-      if (value) {
+      if (typeof value !== 'undefined') {
         this.set('value', value);
       }
       // remember activeChildren, used as a replacement for a before observer as they will be deprecated in the future...


### PR DESCRIPTION
An example like this works now:

    {{#bs-button-group value=opmode type="radio"}}
      {{#bs-button value=0}}AUTO{{/bs-button}}
      {{#bs-button value=1}}REMOTE{{/bs-button}}
      {{#bs-button value=2}}LOCAL{{/bs-button}}
    {{/bs-button-group}}
