### PR TITLE
useIcons default should be false if a custom control is used

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -427,7 +427,8 @@ export default FormGroup.extend(ComponentChild, {
    * @public
    */
   useIcons: computed('controlType', function() {
-    return !nonTextFieldControlTypes.contains(this.get('controlType'));
+    return !this.get('hasBlock') &&
+           !nonTextFieldControlTypes.contains(this.get('controlType'));
   }),
 
   /**
@@ -534,16 +535,8 @@ export default FormGroup.extend(ComponentChild, {
 
   formElementTemplate: computed('formLayout', 'controlType', function() {
     let formLayout = this.getWithDefault('formLayout', 'vertical');
-    let inputLayout;
     let controlType = this.get('controlType');
-
-    switch (true) {
-      case nonTextFieldControlTypes.contains(controlType):
-        inputLayout = controlType;
-        break;
-      default:
-        inputLayout = 'default';
-    }
+    let inputLayout = nonTextFieldControlTypes.contains(controlType) ? controlType : 'default';
 
     return `components/form-element/${formLayout}/${inputLayout}`;
   }),


### PR DESCRIPTION
`controlType` defaults to `text` even if a custom control is used. Therefore `useIcons` was `true` for custom control types as default. Referring docs that wasn't intended.

`!nonTextFieldControlTypes.contains(this.get('controlType'));` had returned `false` for all controlTypes except `text`. Refactored to less complex code.

This should be considered a breaking change.