### PR TITLE
Perform cleanup with modal willRemoveElement

### DIFF
--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -690,6 +690,7 @@ export default Ember.Component.extend({
   willDestroyElement() {
     Ember.$(window).off('resize.bs.modal');
     Ember.$('body').removeClass('modal-open');
+    this.resetScrollbar();
   }
 
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -502,3 +502,38 @@ test('Renders in place (no wormhole) if renderInPlace is set', function(assert) 
   assert.equal(this.$('.modal').length, 1, 'Modal exists.');
   assert.notEqual(this.$('.modal').parent().attr('id'), 'ember-bootstrap-modal-container');
 });
+
+test('Removes "modal-open" class when component is removed from view', function(assert) {
+  this.set('renderComponent', true);
+  this.render(hbs`{{#if renderComponent}}{{#bs-modal title="Simple Dialog"}}Hello world!{{/bs-modal}}{{/if}}<div id="ember-bootstrap-modal-container"></div>`);
+
+  let done = assert.async();
+
+  // wait for fade animation
+  setTimeout(() => {
+    assert.ok($('body').hasClass('modal-open'), 'body element has "modal-open" class.');
+
+    this.set('renderComponent', false);
+
+    assert.ok(!($('body').hasClass('modal-open')), 'body element does not have "modal-open" class.');
+    done();
+  }, transitionTimeout);
+});
+
+test('Resets scroll bar when component is removed from view', function(assert) {
+  document.body.style.paddingRight = '50px';
+  this.set('renderComponent', true);
+  this.render(hbs`{{#if renderComponent}}{{#bs-modal title="Simple Dialog"}}Hello world!{{/bs-modal}}{{/if}}<div id="ember-bootstrap-modal-container"></div>`);
+
+  let done = assert.async();
+
+  // wait for fade animation
+  setTimeout(() => {
+    document.body.style.paddingRight = '0px';
+    this.set('renderComponent', false);
+
+    assert.equal(document.body.style.paddingRight, '50px', 'paddingRight restored to 50px');
+    document.body.style.paddingRight = '0px';
+    done();
+  }, transitionTimeout);
+});


### PR DESCRIPTION
The removal of the `modal-open` class is handled in the `hideModal` function which also performs proper math to remove padding that was previously added when the modal opened. Since this happens when `hide()` is called (via the `open` property observer) everything works. But if you programmatically remove the modal via ember *without* using the `open` property but using `{{#if …}}` like the docs impart the cleanup is not performed.

Unfortunately the `willRemoveElement` is the only hook and it does not perform the same cleanup that `hide` does and the result is that the scroll bar padding is not reset.

The result was that closing the modal via Ember from the outside of the component caused the right side of the page to squish (`padding-right`) and be compounded each time a modal closes from ember. This was noticed in Firefox but Chrome was not affected (I have no idea why).

An example to reproduce this:

Template
--------

```handlebars
{{#if showModal}}
  {{#bs-modal title="Simple Dialog"}}
    Hello world!
  {{/bs-modal}}
{{/if}}
```

Component
---------

```javascript
import Ember from 'ember';

export default Ember.Component.extend({
  showModal: false,

  infinateModalLoop: Ember.on('didInsertElement', function () {
    this.toggleProperty('showModal');
    Ember.run.later(this, 'infinateModalLoop', 200);
  })
});
```