### PR TITLE
handle active state while null value for bs-button-group

### DIFF
--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -202,7 +202,7 @@ export default Ember.Component.extend(ComponentParent, SizeClass, {
           } else {
             let lastActive = this.get('lastActiveChildren.firstObject');
             if (lastActive) {
-              lastActive.set('active', true);
+              lastActive.set('active', this.get('value') ? true : false);
             }
           }
           break;

--- a/tests/integration/components/bs-button-group-test.js
+++ b/tests/integration/components/bs-button-group-test.js
@@ -103,3 +103,21 @@ test('when clicking active radio button, button remains active', function(assert
   this.$('button').eq(0).click();
   assert.ok(this.$('button').eq(0).hasClass('active'), 'clicked active button remains active');
 });
+
+
+test('setting radio button group value to null sets buttons active state to false', function(assert) {
+  this.render(hbs`{{#bs-button-group type="radio" value=value}}{{#bs-button value=1}}1{{/bs-button}}{{#bs-button value=2}}2{{/bs-button}}{{#bs-button value=3}}3{{/bs-button}}{{/bs-button-group}}`);
+
+  for (let i = 0; i < 3; i++) {
+    this.set('value', i + 1);
+    
+    this.set('value', null);
+    assert.equal(this.get('value'), null, 'value must be null');
+
+    // check button's active property
+    for (let k = 0; k < 3; k++) {
+      assert.equal(this.$('button').eq(k).hasClass('active'), false, 'button active state is true');
+    }
+  }
+});
+

--- a/tests/integration/components/bs-button-group-test.js
+++ b/tests/integration/components/bs-button-group-test.js
@@ -104,7 +104,6 @@ test('when clicking active radio button, button remains active', function(assert
   assert.ok(this.$('button').eq(0).hasClass('active'), 'clicked active button remains active');
 });
 
-
 test('setting radio button group value to null sets buttons active state to false', function(assert) {
   this.render(hbs`{{#bs-button-group type="radio" value=value}}{{#bs-button value=1}}1{{/bs-button}}{{#bs-button value=2}}2{{/bs-button}}{{#bs-button value=3}}3{{/bs-button}}{{/bs-button-group}}`);
 


### PR DESCRIPTION
```
{{#bs-button-group value=testProp type="radio"}}
    {{#bs-button value=1}}1{{/bs-button}}
    {{#bs-button value=2}}2{{/bs-button}}
    {{#bs-button value=3}}3{{/bs-button}}
{{/bs-button-group}}

```

If I set **testProp** back to null, I'm looking to get the **bs-button-group** to reset so that the active children (in the case of a radio; the single child target) corresponding **bs-button**'s **active** state to false.

Perhaps this is not considered a bug, but either way this PR fixes this use case for me and tests I have performed pass.

P.S; great ember addon