### PR TITLE
Relates to #155

### DIFF
--- a/app/templates/components/bs-modal.hbs
+++ b/app/templates/components/bs-modal.hbs
@@ -4,10 +4,8 @@
   {{yield this}}
 {{/bs-modal-dialog}}
 
-<div>
 {{#if showBackdrop}}
   <div class="modal-backdrop {{if fade "fade"}} {{if in "in"}}" id="{{backdropId}}"></div>
 {{/if}}
-</div>
 
 {{/ember-wormhole}}


### PR DESCRIPTION
Relates to #155

As I've explained in #155, the modal dialog is not closing anymore. Maybe, if you have issues with glimmer2 and you are adding these `div`s inbecause of these, then there can be a way to detect the glimmer version? Modals in Ember `1.13.10` are definitely broken, when adding these `div`s.