### PR TITLE
Addition/readonly attribute

### DIFF
--- a/addon/components/bs-form-element.js
+++ b/addon/components/bs-form-element.js
@@ -206,6 +206,15 @@ export default FormGroup.extend(ComponentChild, {
   disabled: false,
 
   /**
+   * Control element's HTML5 readonly attribute
+   *
+   * @property readonly
+   * @type boolean
+   * @public
+   */
+  readonly: false,
+
+  /**
    * Control element's HTML5 required attribute
    *
    * @property required

--- a/app/templates/components/form-element/horizontal/default.hbs
+++ b/app/templates/components/form-element/horizontal/default.hbs
@@ -4,7 +4,7 @@
         {{#if hasBlock}}
             {{yield value formElementId validation}}
         {{else}}
-            {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled required=required}}
+            {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled readonly=readonly required=required}}
         {{/if}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
@@ -14,7 +14,7 @@
         {{#if hasBlock}}
             {{yield value formElementId validation}}
         {{else}}
-            {{bs-input name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled required=required}}
+            {{bs-input name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled readonly=readonly required=required}}
         {{/if}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/horizontal/textarea.hbs
+++ b/app/templates/components/form-element/horizontal/textarea.hbs
@@ -1,13 +1,13 @@
 {{#if hasLabel}}
     <label class="control-label {{horizontalLabelGridClass}} {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
     <div class="{{horizontalInputGridClass}}">
-        {{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled required=required}}
+        {{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled readonly=readonly required=required}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>
 {{else}}
     <div class="{{horizontalInputGridClass}} {{horizontalInputOffsetGridClass}}">
-        {{bs-textarea name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled required=required}}
+        {{bs-textarea name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled readonly=readonly required=required}}
         {{partial "components/form-element/feedback-icon"}}
         {{partial "components/form-element/errors"}}
     </div>

--- a/app/templates/components/form-element/inline/default.hbs
+++ b/app/templates/components/form-element/inline/default.hbs
@@ -4,6 +4,6 @@
 {{#if hasBlock}}
     {{yield value formElementId validation}}
 {{else}}
-    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled required=required}}
+    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled readonly=readonly required=required}}
 {{/if}}
 {{partial "components/form-element/feedback-icon"}}

--- a/app/templates/components/form-element/inline/textarea.hbs
+++ b/app/templates/components/form-element/inline/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled required=required}}
+{{bs-textarea id=formElementId name=name value=value placeholder=placeholder autofocus=autofocus cols=cols rows=rows disabled=disabled readonly=readonly required=required}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/default.hbs
+++ b/app/templates/components/form-element/vertical/default.hbs
@@ -4,7 +4,7 @@
 {{#if hasBlock}}
     {{yield value formElementId validation}}
 {{else}}
-    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled required=required}}
+    {{bs-input id=formElementId name=name type=controlType value=value placeholder=placeholder autofocus=autofocus disabled=disabled readonly=readonly required=required}}
 {{/if}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/select.hbs
+++ b/app/templates/components/form-element/vertical/select.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled required=required}}
+{{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled readonly=readonly required=required}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/select.hbs
+++ b/app/templates/components/form-element/vertical/select.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled readonly=readonly required=required}}
+{{bs-select id=formElementId name=name content=choices optionValuePath=choiceValueProperty optionLabelPath=choiceLabelProperty value=value disabled=disabled required=required}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/app/templates/components/form-element/vertical/textarea.hbs
+++ b/app/templates/components/form-element/vertical/textarea.hbs
@@ -1,6 +1,6 @@
 {{#if hasLabel}}
     <label class="control-label {{if invisibleLabel "sr-only"}}" for="{{formElementId}}">{{label}}</label>
 {{/if}}
-{{bs-textarea id=formElementId value=value name=name placeholder=placeholder autofocus=autofocus disabled=disabled required=required cols=cols rows=rows}}
+{{bs-textarea id=formElementId value=value name=name placeholder=placeholder autofocus=autofocus disabled=disabled readonly=readonly required=required cols=cols rows=rows}}
 {{partial "components/form-element/feedback-icon"}}
 {{partial "components/form-element/errors"}}

--- a/tests/integration/components/bs-form-element-test.js
+++ b/tests/integration/components/bs-form-element-test.js
@@ -135,6 +135,14 @@ test('disabled property propagates', function(assert) {
   assert.equal(this.$('input').attr('disabled'), 'disabled', 'input html5 disabled is true');
 });
 
+test('readonly property propagates', function(assert) {
+  this.set('model', Ember.Object.create());
+
+  this.render(hbs`{{bs-form-element label="myLabel" property="foo" readonly=true}}`);
+
+  assert.equal(this.$('input').attr('readonly'), 'readonly', 'input html5 readonly is true');
+});
+
 test('if invisibleLabel is true sr-only class is added to label', function(assert) {
   let formLayouts = [
     'vertical',


### PR DESCRIPTION
This PR adds support for the readonly attribute, which differs from the disabled attribute

- A read-only field can't be modified, but, unlike disabled, you can tab into it, highlight it, and copy its contents.
- readonly is only relevant for type text, search, url, tel, email, number, password, and the date/time input types. It is also valid on <textarea>
- readonly is ignored for type hidden, range, color, checkbox, radio, file, button, submit and image