### PR TITLE
Fixed the Collapse example in the 1.0.0-release branch

### DIFF
--- a/tests/dummy/app/templates/collapse.hbs
+++ b/tests/dummy/app/templates/collapse.hbs
@@ -1,6 +1,6 @@
 <h1>Collapse</h1>
 
-{{#bs-button toggle=true active=notCollapsed action="toggle"}}{{#if collapsed}}Show{{else}}Hide{{/if}}{{/bs-button}}
+{{#bs-button toggle=true active=notCollapsed click=(action "toggle")}}{{#if collapsed}}Show{{else}}Hide{{/if}}{{/bs-button}}
 
 <hr/>
 

--- a/tests/dummy/app/templates/collapse.hbs
+++ b/tests/dummy/app/templates/collapse.hbs
@@ -1,6 +1,6 @@
 <h1>Collapse</h1>
 
-{{#bs-button toggle=true active=notCollapsed click=(action "toggle")}}{{#if collapsed}}Show{{else}}Hide{{/if}}{{/bs-button}}
+{{#bs-button toggle=true active=notCollapsed onClick=(action "toggle")}}{{#if collapsed}}Show{{else}}Hide{{/if}}{{/bs-button}}
 
 <hr/>
 


### PR DESCRIPTION
**This is intended/targeted for the 1.0.0-release branch**
The collapse example button was not responding to mouse clicks.