### PR TITLE
Restore the label for the vertical checkbox form element

### DIFF
--- a/app/templates/components/form-element/vertical/checkbox.hbs
+++ b/app/templates/components/form-element/vertical/checkbox.hbs
@@ -1,6 +1,6 @@
 <div class="checkbox">
     <label>
-        <input type="checkbox" checked={{value}} onclick={{action "change" value="target.checked"}} id={{formElementId}} name={{name}} disabled={{disabled}} required={{required}}>
+        <input type="checkbox" checked={{value}} onclick={{action "change" value="target.checked"}} id={{formElementId}} name={{name}} disabled={{disabled}} required={{required}}> {{label}}
     </label>
 </div>
 {{partial "components/form-element/errors"}}


### PR DESCRIPTION
Restore the label for the vertical checkbox form element that was removed in dda8e3605efe46d9f6583c826dd955e60daafcb8.