### PR TITLE
fix how options are merged

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
     }
     this.app = app;
 
-    let options = extend({}, defaultOptions, app.options['ember-bootstrap']);
+    let options = extend(extend({}, defaultOptions), app.options['ember-bootstrap']);
     if (process.env['BOOTSTRAPVERSION']) {
       // override bootstrapVersion config when environment variable is set
       options.bootstrapVersion = parseInt(process.env['BOOTSTRAPVERSION']);


### PR DESCRIPTION
`util._extend` doesn’t support more than two arguments for merging in values, which was meaning that only the default `ember-bootstrap` options would be used, with any overrides from the app being ignored

this fix ensures that the app’s `ember-bootstrap` options don’t get ignored