### PR TITLE
[bs4] use default button type for modal close button

### DIFF
--- a/addon/templates/components/common/bs-modal/footer.hbs
+++ b/addon/templates/components/common/bs-modal/footer.hbs
@@ -2,7 +2,7 @@
     {{yield}}
 {{else}}
     {{#if hasSubmitButton}}
-        {{#bs-button type="default" onClick=(action onClose)}}{{closeTitle}}{{/bs-button}}
+        {{#bs-button onClick=(action onClose)}}{{closeTitle}}{{/bs-button}}
         {{#bs-button type="primary" onClick=(action onSubmit) disabled=submitDisabled}}{{submitTitle}}{{/bs-button}}
     {{else}}
         {{#bs-button type="primary" onClick=(action onClose)}}{{closeTitle}}{{/bs-button}}


### PR DESCRIPTION
Instead of explicitly specifying type="default", just let the bs-button component use its own default type. This ensures that the button gets the correct default classes in both Bootstrap 3 and 4.