### PR TITLE
[WIP] Assess & improve the blueprint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release-bs4
   - EMBER_TRY_SCENARIO=ember-beta-bs4
   - EMBER_TRY_SCENARIO=fastboot-addon-tests
+  - EMBER_TRY_SCENARIO=blueprint-tests
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ In your application's directory:
 
     ember install ember-bootstrap
     
+This will install Bootstrap 3 and will use the currently installed preprocessor or none if one is not installed.
+To switch Bootstrap version or preprocessor, re-run the default blueprint like
+
+    ember generate ember-bootstrap --bootstrap-version=4 --preprocessor=sass
+    
+The `--bootstrap-version` can be "3" or "4" and defaults to "3" if the option is omitted. The `--preprocessor`
+can be `none`, `less`, or `sass` and will use the currently installed preprocessor as its cue if omitted.
+We explicitly support `ember-cli-less` and `ember-cli-sass`. You will need to install and configure other
+preprocessors yourself.
+
+The default blueprint does the following:
+
+* Removes any unneeded versions of `bootstrap` and `bootstrap-sass` from `package.json` and `bower.json`
+* Installs the appropriate version of `bootstrap` or `bootstrap-sass` as an npm package
+* Removes unneeded dependencies on `ember-cli-less` and `ember-cli-sass`
+* Installs `ember-cli-less` or `ember-cli-sass` if appropriate
+* Creates `app.less` or `app.scss` if appropriate and it doesn't exist
+* Adds the appropriate `@import` statement to your `app.less` or `app.scss` if it's not there
+* Safely edits your `ember-cli-build.js` to ensure the proper ember-bootstrap settings for your configuration
+    
 ### 1.0 alpha
     
 The 1.0 release is currently in alpha stage. While the API is not guaranteed to remain unchanged until the first stable release, 

--- a/README.md
+++ b/README.md
@@ -21,25 +21,8 @@ In your application's directory:
     ember install ember-bootstrap
     
 This will install Bootstrap 3 and will use the currently installed preprocessor or none if one is not installed.
-To switch Bootstrap version or preprocessor, re-run the default blueprint like
+To switch Bootstrap version or preprocessor, see the documentation.
 
-    ember generate ember-bootstrap --bootstrap-version=4 --preprocessor=sass
-    
-The `--bootstrap-version` can be "3" or "4" and defaults to "3" if the option is omitted. The `--preprocessor`
-can be `none`, `less`, or `sass` and will use the currently installed preprocessor as its cue if omitted.
-We explicitly support `ember-cli-less` and `ember-cli-sass`. You will need to install and configure other
-preprocessors yourself.
-
-The default blueprint does the following:
-
-* Removes any unneeded versions of `bootstrap` and `bootstrap-sass` from `package.json` and `bower.json`
-* Installs the appropriate version of `bootstrap` or `bootstrap-sass` as an npm package
-* Removes unneeded dependencies on `ember-cli-less` and `ember-cli-sass`
-* Installs `ember-cli-less` or `ember-cli-sass` if appropriate
-* Creates `app.less` or `app.scss` if appropriate and it doesn't exist
-* Adds the appropriate `@import` statement to your `app.less` or `app.scss` if it's not there
-* Safely edits your `ember-cli-build.js` to ensure the proper ember-bootstrap settings for your configuration
-    
 ### 1.0 alpha
     
 The 1.0 release is currently in alpha stage. While the API is not guaranteed to remain unchanged until the first stable release, 

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -83,7 +83,7 @@ module.exports = {
       let source = fs.readFileSync(file, 'utf-8');
       let build = new BuildConfigEditor(source);
       let newBuild = build.edit('ember-bootstrap', settings);
-      fs.writeFileSync(newBuild.code());
+      fs.writeFileSync(file, newBuild.code());
     } else {
       this.ui.writeLine(chalk.red(`Could not find ${file} to modify.`));
     }

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -24,8 +24,8 @@ module.exports = {
   description: 'Configure ember-bootstrap',
 
   availableOptions: [
-    { name: 'bootstrap-version', type: Number, default: 3, aliases: ['bv'] },
-    { name: 'target-preprocessor', type: String, aliases: ['tp'] }
+    { name: 'bootstrap-version', type: Number, default: 3, aliases: ['bootstrap', 'bv'] },
+    { name: 'preprocessor', type: String, aliases: ['pp'] }
   ],
 
   works: 'insideProject',
@@ -34,31 +34,31 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let { bootstrapVersion, targetPreprocessor } = option;
+    let { bootstrapVersion, preprocessor } = option;
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
       throw new SilentError('Bootstrap version must be 3 or 4');
     }
 
-    if (targetPreprocessor && !validPreprocessors.includes(targetPreprocessor)) {
+    if (preprocessor && !validPreprocessors.includes(preprocessor)) {
       throw new SilentError(`Valid preprocessors are: ${validPreprocessors.join(', ')}`);
     }
 
-    if (!targetPreprocessor) {
+    if (!preprocessor) {
       let dependencies = this.project.dependencies();
       if ('ember-cli-sass' in dependencies) {
-        targetPreprocessor = option.targetPreprocessor = 'sass';
+        preprocessor = option.preprocessor = 'sass';
       } else if ('ember-cli-less' in dependencies) {
-        targetPreprocessor = option.targetPreprocessor = 'less';
+        preprocessor = option.preprocessor = 'less';
       } else {
-        targetPreprocessor = 'none';
+        preprocessor = 'none';
       }
     }
 
-    if (bootstrapVersion === 4 && targetPreprocessor === 'less') {
+    if (bootstrapVersion === 4 && preprocessor === 'less') {
       throw new SilentError('You cannot use LESS with Bootstrap 4');
     }
 
-    this.ui.writeLine(chalk.green(`Installing for Bootstrap ${bootstrapVersion} using preprocessor ${targetPreprocessor}`));
+    this.ui.writeLine(chalk.green(`Installing for Bootstrap ${bootstrapVersion} using preprocessor ${preprocessor}`));
   },
 
   afterInstall(option) {
@@ -86,7 +86,7 @@ module.exports = {
   },
 
   adjustBootstrapDependencies(option) {
-    let { bootstrapVersion, targetPreprocessor } = option;
+    let { bootstrapVersion, preprocessor } = option;
     let dependencies = this.project.dependencies();
     let bowerDependencies = this.project.bowerDependencies();
     let promises = [];
@@ -102,7 +102,7 @@ module.exports = {
         promises.push(this.removePackageFromBowerJSON('bootstrap-sass'));
       }
       promises.push(this.addPackageToProject('bootstrap', bs4Version));
-    } else if (targetPreprocessor === 'sass') {
+    } else if (preprocessor === 'sass') {
       if ('bootstrap' in dependencies) {
         promises.push(this.removePackageFromProject('bootstrap'));
       }
@@ -121,14 +121,14 @@ module.exports = {
   },
 
   addPreprocessorStyleImport(option) {
-    let { targetPreprocessor } = option;
+    let { preprocessor } = option;
     let importStatement = '\n@import "ember-bootstrap/bootstrap";\n';
 
-    if (targetPreprocessor === 'none') {
+    if (preprocessor === 'none') {
       return;
     }
 
-    let extension = targetPreprocessor === 'sass' ? 'scss' : 'less';
+    let extension = preprocessor === 'sass' ? 'scss' : 'less';
 
     let stylePath = path.join('app', 'styles');
     let file = path.join(stylePath, `app.${extension}`);
@@ -147,7 +147,7 @@ module.exports = {
 
   addBuildConfiguration(option) {
     let file = 'ember-cli-build.js';
-    let { bootstrapVersion, targetPreprocessor } = option;
+    let { bootstrapVersion, preprocessor } = option;
     let settings = {
       bootstrapVersion
     };
@@ -156,7 +156,7 @@ module.exports = {
       settings.importBootstrapFont = false;
     }
 
-    settings.importBootstrapCSS = (targetPreprocessor === 'none');
+    settings.importBootstrapCSS = (preprocessor === 'none');
 
     if (fs.existsSync(file)) {
       this.ui.writeLine(chalk.green(`Added ember-bootstrap configuration to ${file}`));

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -111,13 +111,10 @@ module.exports = {
       }
       promises.push(this.addPackageToProject('bootstrap-sass', bs3Version));
     } else {
-      if ('bootstrap' in dependencies) {
-        promises.push(this.removePackageFromProject('bootstrap'));
-      }
       if ('bootstrap-sass' in dependencies) {
         promises.push(this.removePackageFromProject('bootstrap-sass'));
       }
-      promises.push(this.addBowerPackageToProject('bootstrap', bs3Version));
+      promises.push(this.addPackageToProject('bootstrap', bs3Version));
     }
 
     return rsvp.all(promises);

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let bootstrapVersion = option.bootstrapVersion;
+    let bootstrapVersion = option.bootstrapVersion = parseInt(option.bootstrapVersion);
     let preprocessor = option.preprocessor;
 
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -92,23 +92,21 @@ module.exports = {
     let bowerDependencies = this.project.bowerDependencies();
     let promises = [];
 
+    if ('bootstrap' in bowerDependencies) {
+      promises.push(this.removePackageFromBowerJSON('bootstrap'));
+    }
+    if ('bootstrap-sass' in bowerDependencies) {
+      promises.push(this.removePackageFromBowerJSON('bootstrap-sass'));
+    }
+
     if (bootstrapVersion === 4) {
-      if ('bootstrap' in bowerDependencies) {
-        promises.push(this.removePackageFromBowerJSON('bootstrap'));
-      }
       if ('bootstrap-sass' in dependencies) {
         promises.push(this.removePackageFromProject('bootstrap-sass'));
-      }
-      if ('bootstrap-sass' in bowerDependencies) {
-        promises.push(this.removePackageFromBowerJSON('bootstrap-sass'));
       }
       promises.push(this.addPackageToProject('bootstrap', bs4Version));
     } else if (preprocessor === 'sass') {
       if ('bootstrap' in dependencies) {
         promises.push(this.removePackageFromProject('bootstrap'));
-      }
-      if ('bootstrap' in bowerDependencies) {
-        promises.push(this.removePackageFromBowerJSON('bootstrap'));
       }
       promises.push(this.addPackageToProject('bootstrap-sass', bs3Version));
     } else {

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -7,9 +7,16 @@ const path = require('path');
 const writeFile = rsvp.denodeify(fs.writeFile);
 const chalk = require('chalk');
 const BuildConfigEditor = require('ember-cli-build-config-editor');
+const SilentError = require('silent-error'); // From ember-cli
 
 const bs3Version = '^3.3.7';
 const bs4Version = 'next';
+
+const validPreprocessors = [
+  'none',
+  'less',
+  'sass'
+];
 
 module.exports = {
   name: 'ember-bootstrap',
@@ -17,67 +24,100 @@ module.exports = {
   description: 'Configure ember-bootstrap',
 
   availableOptions: [
-    { name: 'bootstrap-version', type: Number, default: 3 }
+    { name: 'bootstrap-version', type: Number, default: 3, aliases: ['bv'] },
+    { name: 'target-preprocessor', type: String, aliases: ['tp'] }
   ],
+
+  works: 'insideProject',
 
   normalizeEntityName() {
   },
 
+  beforeInstall(option) {
+    let { bootstrapVersion, targetPreprocessor } = option;
+    if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
+      throw new SilentError('Bootstrap version must be 3 or 4');
+    }
+
+    if (targetPreprocessor && !validPreprocessors.includes(targetPreprocessor)) {
+      throw new SilentError(`Valid preprocessors are: ${validPreprocessors.join(', ')}`);
+    }
+
+    if (!targetPreprocessor) {
+      let dependencies = this.project.dependencies();
+      if ('ember-cli-sass' in dependencies) {
+        targetPreprocessor = option.targetPreprocessor = 'sass';
+      } else if ('ember-cli-less' in dependencies) {
+        targetPreprocessor = option.targetPreprocessor = 'less';
+      } else {
+        targetPreprocessor = 'none';
+      }
+    }
+
+    if (bootstrapVersion === 4 && targetPreprocessor === 'less') {
+      throw new SilentError('You cannot use LESS with Bootstrap 4');
+    }
+
+    this.ui.writeLine(chalk.green(`Installing for Bootstrap ${bootstrapVersion} using preprocessor ${targetPreprocessor}`));
+  },
+
   afterInstall(option) {
     return this.addDependencies(option)
-      .then(() => this.addPreprocessorImport())
+      .then(() => this.addPreprocessorImport(option))
       .then(() => this.addBuildConfiguration(option));
   },
 
   addDependencies(option) {
-    let dependencies = this.project.dependencies();
-
     if (option.bootstrapVersion === 4) {
       return this.addPackageToProject('bootstrap', bs4Version);
     }
 
-    if ('ember-cli-sass' in dependencies) {
+    // bootstrapVersion === 3
+    if (option.targetPreprocessor === 'sass') {
       return this.addPackageToProject('bootstrap-sass', bs3Version);
     }
 
     return this.addBowerPackageToProject('bootstrap', bs3Version);
   },
 
-  addPreprocessorImport() {
-    let dependencies = this.project.dependencies();
-    let type;
+  addPreprocessorImport(option) {
+    let { targetPreprocessor } = option;
     let importStatement = '\n@import "ember-bootstrap/bootstrap";\n';
 
-    if ('ember-cli-sass' in dependencies) {
-      type = 'scss';
-    } else if ('ember-cli-less' in dependencies) {
-      type = 'less';
+    if (targetPreprocessor === 'none') {
+      return;
     }
 
-    if (type) {
-      let stylePath = path.join('app', 'styles');
-      let file = path.join(stylePath, `app.${type}`);
+    let extension = targetPreprocessor === 'sass' ? 'scss' : 'less';
 
-      if (!fs.existsSync(stylePath)) {
-        fs.mkdirSync(stylePath);
-      }
-      if (fs.existsSync(file)) {
-        this.ui.writeLine(chalk.green(`Added import statement to ${file}`));
-        return this.insertIntoFile(file, importStatement, {});
-      } else {
-        this.ui.writeLine(chalk.green(`Created ${file}`));
-        return writeFile(file, importStatement);
-      }
+    let stylePath = path.join('app', 'styles');
+    let file = path.join(stylePath, `app.${extension}`);
+
+    if (!fs.existsSync(stylePath)) {
+      fs.mkdirSync(stylePath);
+    }
+    if (fs.existsSync(file)) {
+      this.ui.writeLine(chalk.green(`Added import statement to ${file}`));
+      return this.insertIntoFile(file, importStatement, {});
+    } else {
+      this.ui.writeLine(chalk.green(`Created ${file}`));
+      return writeFile(file, importStatement);
     }
   },
 
   addBuildConfiguration(option) {
     let file = 'ember-cli-build.js';
+    let { bootstrapVersion, targetPreprocessor } = option;
     let settings = {
-      bootstrapVersion: option.bootstrapVersion
+      bootstrapVersion
     };
-    if (option.bootstrapVersion === 4) {
+
+    if (bootstrapVersion === 4) {
       settings.importBootstrapFont = false;
+    }
+
+    if (targetPreprocessor !== 'none') {
+      settings.importBootstrapCSS = false;
     }
 
     if (fs.existsSync(file)) {

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -34,7 +34,9 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let { bootstrapVersion, preprocessor } = option;
+    let bootstrapVersion = option.bootstrapVersion;
+    let preprocessor = option.preprocessor;
+
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
       throw new SilentError('Bootstrap version must be 3 or 4');
     }
@@ -87,7 +89,8 @@ module.exports = {
   },
 
   adjustBootstrapDependencies(option) {
-    let { bootstrapVersion, preprocessor } = option;
+    let bootstrapVersion = option.bootstrapVersion;
+    let preprocessor = option.preprocessor;
     let dependencies = this.project.dependencies();
     let bowerDependencies = this.project.bowerDependencies();
     let promises = [];
@@ -120,7 +123,7 @@ module.exports = {
   },
 
   adjustPreprocessorDependencies(option) {
-    let { preprocessor } = option;
+    let preprocessor = option.preprocessor;
     let dependencies = this.project.dependencies();
     let promises = [];
 
@@ -144,7 +147,7 @@ module.exports = {
   },
 
   addPreprocessorStyleImport(option) {
-    let { preprocessor } = option;
+    let preprocessor = option.preprocessor;
     let importStatement = '\n@import "ember-bootstrap/bootstrap";\n';
 
     if (preprocessor === 'none') {
@@ -170,7 +173,8 @@ module.exports = {
 
   addBuildConfiguration(option) {
     let file = 'ember-cli-build.js';
-    let { bootstrapVersion, preprocessor } = option;
+    let bootstrapVersion = option.bootstrapVersion;
+    let preprocessor = option.preprocessor;
     let settings = {
       bootstrapVersion
     };

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -177,9 +177,7 @@ module.exports = {
       bootstrapVersion
     };
 
-    if (bootstrapVersion === 4) {
-      settings.importBootstrapFont = false;
-    }
+    settings.importBootstrapFont = (bootstrapVersion === 3);
 
     settings.importBootstrapCSS = (preprocessor === 'none');
 

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -21,16 +21,16 @@ module.exports = {
   normalizeEntityName() {
   },
 
-  afterInstall(options) {
-    return this.addDependencies(options)
+  afterInstall(option) {
+    return this.addDependencies(option)
       .then(() => this.addPreprocessorImport())
-      .then(() => this.addBuildConfiguration(options));
+      .then(() => this.addBuildConfiguration(option));
   },
 
-  addDependencies(options) {
+  addDependencies(option) {
     let dependencies = this.project.dependencies();
 
-    if (options.bootstrapVersion === 4) {
+    if (option.bootstrapVersion === 4) {
       return this.addPackageToProject('bootstrap', bs4Version);
     }
 

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -41,7 +41,7 @@ module.exports = {
       throw new SilentError('Bootstrap version must be 3 or 4');
     }
 
-    if (preprocessor && !validPreprocessors.includes(preprocessor)) {
+    if (preprocessor && validPreprocessors.indexOf(preprocessor) === -1) {
       throw new SilentError(`Valid preprocessors are: ${validPreprocessors.join(', ')}`);
     }
 

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -63,6 +63,7 @@ module.exports = {
 
   afterInstall(option) {
     return this.adjustBootstrapDependencies(option)
+      .then(() => this.adjustPreprocessorDependencies(option))
       .then(() => this.addPreprocessorStyleImport(option))
       .then(() => this.addBuildConfiguration(option));
   },
@@ -115,6 +116,30 @@ module.exports = {
         promises.push(this.removePackageFromProject('bootstrap-sass'));
       }
       promises.push(this.addPackageToProject('bootstrap', bs3Version));
+    }
+
+    return rsvp.all(promises);
+  },
+
+  adjustPreprocessorDependencies(option) {
+    let { preprocessor } = option;
+    let dependencies = this.project.dependencies();
+    let promises = [];
+
+    if (preprocessor !== 'less' && 'ember-cli-less' in dependencies) {
+      promises.push(this.removePackageFromProject('ember-cli-less'));
+    }
+
+    if (preprocessor !== 'sass' && 'ember-cli-sass' in dependencies) {
+      promises.push(this.removePackageFromProject('ember-cli-sass'));
+    }
+
+    if (preprocessor === 'less' && !('ember-cli-less' in dependencies)) {
+      promises.push(this.addAddonToProject('ember-cli-less'));
+    }
+
+    if (preprocessor === 'sass' && !('ember-cli-sass' in dependencies)) {
+      promises.push(this.addAddonToProject('ember-cli-sass'));
     }
 
     return rsvp.all(promises);

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -141,9 +141,7 @@ module.exports = {
       settings.importBootstrapFont = false;
     }
 
-    if (targetPreprocessor !== 'none') {
-      settings.importBootstrapCSS = false;
-    }
+    settings.importBootstrapCSS = (targetPreprocessor === 'none');
 
     if (fs.existsSync(file)) {
       this.ui.writeLine(chalk.green(`Added ember-bootstrap configuration to ${file}`));

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -14,6 +14,8 @@ const bs4Version = 'next';
 module.exports = {
   name: 'ember-bootstrap',
 
+  description: 'Configure ember-bootstrap',
+
   availableOptions: [
     { name: 'bootstrap-version', type: Number, default: 3 }
   ],

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -248,7 +248,14 @@ module.exports = {
     },
     {
       name: 'fastboot-addon-tests',
-      command: 'ember fastboot:test',
+      command: 'DEBUG=ember-cli-addon-tests ember fastboot:test',
+      npm: {
+        devDependencies: {}
+      }
+    },
+    {
+      name: 'blueprint-tests',
+      command: 'yarn run nodetest',
       npm: {
         devDependencies: {}
       }

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ module.exports = {
     this.app = app;
 
     let options = extend(extend({}, defaultOptions), app.options['ember-bootstrap']);
-    if (process.env['BOOTSTRAPVERSION']) {
+    if (process.env.BOOTSTRAPVERSION) {
       // override bootstrapVersion config when environment variable is set
-      options.bootstrapVersion = parseInt(process.env['BOOTSTRAPVERSION']);
+      options.bootstrapVersion = parseInt(process.env.BOOTSTRAPVERSION);
     }
     this.bootstrapOptions = options;
 
@@ -71,11 +71,10 @@ module.exports = {
   },
 
   validatePreprocessor(name) {
-    let npmDependencies = this.app.project.dependencies();
-    let bowerDependencies = this.app.project.bowerDependencies();
+    let dependencies = this.app.project.dependencies();
     switch (name) {
       case 'sass':
-        if (!('bootstrap-sass' in npmDependencies) && this.getBootstrapVersion() === 3) {
+        if (!('bootstrap-sass' in dependencies) && this.getBootstrapVersion() === 3) {
           this.ui.writeLine(chalk.red('Npm package "bootstrap-sass" is missing, but required for SASS support. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
           return false;
         }
@@ -85,7 +84,7 @@ module.exports = {
           this.ui.writeLine(chalk.red('There is no Less support for Bootstrap 4! Falling back to importing static CSS. Consider switching to Sass for preprocessor support!'));
           return false;
         }
-        if (!('bootstrap' in bowerDependencies)) {
+        if (!('bootstrap' in dependencies)) {
           this.ui.writeLine(chalk.red('Bower package "bootstrap" is missing, but required for Less support. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
           return false;
         }
@@ -95,21 +94,18 @@ module.exports = {
   },
 
   getBootstrapStylesPath() {
+    let nodeModulesPath = this.app.project.nodeModulesPath;
     switch (this.preprocessor) {
       case 'sass':
         if (this.getBootstrapVersion() === 4) {
-          return path.join(this.app.project.nodeModulesPath, 'bootstrap', 'scss');
+          return path.join(nodeModulesPath, 'bootstrap', 'scss');
         } else {
-          return path.join(this.app.project.nodeModulesPath, 'bootstrap-sass', 'assets', 'stylesheets');
+          return path.join(nodeModulesPath, 'bootstrap-sass', 'assets', 'stylesheets');
         }
       case 'less':
-        return path.join(this.app.bowerDirectory, 'bootstrap', 'less');
+        return path.join(nodeModulesPath, 'bootstrap', 'less');
       default:
-        if (this.getBootstrapVersion() === 4) {
-          return path.join(this.app.project.nodeModulesPath, 'bootstrap', 'dist', 'css');
-        } else {
-          return path.join(this.app.bowerDirectory, 'bootstrap', 'dist', 'css');
-        }
+        return path.join(nodeModulesPath, 'bootstrap', 'dist', 'css');
     }
   },
 
@@ -119,7 +115,7 @@ module.exports = {
         return path.join(this.app.project.nodeModulesPath, 'bootstrap-sass', 'assets', 'fonts');
       case 'less':
       default:
-        return path.join(this.app.bowerDirectory, 'bootstrap', 'fonts');
+        return path.join(this.app.project.nodeModulesPath, 'bootstrap', 'fonts');
     }
   },
 
@@ -179,7 +175,7 @@ module.exports = {
     tree = mv(tree, `${templatePath}common/`, templatePath);
     tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
     tree = rm(tree, `${templatePath}bs${otherBsVersion}/**/*`);
-    return tree; //log(tree, {output: 'tree', label: 'moved'});
+    return tree; // log(tree, {output: 'tree', label: 'moved'});
   },
 
   contentFor(type, config) {

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -22,17 +22,6 @@ const scenarios = [
   },
   {
     installed: {
-      npm: ['ember-cli-less', 'bootstrap-sass']
-    },
-    dependencies: {
-      npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
-      }
-    }
-  },
-  {
-    installed: {
       npm: ['ember-cli-sass']
     },
     dependencies: {

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -5,12 +5,8 @@ const bs4Regex = 'next';
 const scenarios = [
   {
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -19,9 +15,16 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
+      npm: {
+        bootstrap: bs3Regex
+      }
+    }
+  },
+  {
+    installed: {
+      npm: ['ember-cli-less', 'bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs3Regex,
         'bootstrap-sass': null
@@ -33,9 +36,16 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
+      npm: {
+        'bootstrap-sass': bs3Regex
+      }
+    }
+  },
+  {
+    installed: {
+      npm: ['ember-cli-sass', 'bootstrap']
+    },
+    dependencies: {
       npm: {
         bootstrap: null,
         'bootstrap-sass': bs3Regex
@@ -47,9 +57,19 @@ const scenarios = [
       preprocessor: 'none'
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
+      npm: {
+        bootstrap: bs3Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none'
+    },
+    installed: {
+      npm: ['bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs3Regex,
         'bootstrap-sass': null
@@ -61,12 +81,9 @@ const scenarios = [
       preprocessor: 'none'
     },
     installed: {
-      npm: ['ember-cli-sass']
+      npm: ['ember-cli-sass', 'bootstrap-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
         bootstrap: bs3Regex,
         'bootstrap-sass': null
@@ -84,12 +101,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-less': null
@@ -101,12 +114,8 @@ const scenarios = [
       preprocessor: 'less'
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-less': true
@@ -121,15 +130,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
-      },
-      addon: {
-        'ember-cli-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -138,12 +140,9 @@ const scenarios = [
       preprocessor: 'less'
     },
     installed: {
-      npm: ['ember-cli-sass']
+      npm: ['ember-cli-sass', 'bootstrap-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
         bootstrap: bs3Regex,
         'bootstrap-sass': null
@@ -159,9 +158,22 @@ const scenarios = [
       preprocessor: 'sass'
     },
     dependencies: {
-      bower: {
-        bootstrap: null
+      npm: {
+        'bootstrap-sass': bs3Regex
       },
+      addon: {
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass'
+    },
+    installed: {
+      npm: ['bootstrap']
+    },
+    dependencies: {
       npm: {
         bootstrap: null,
         'bootstrap-sass': bs3Regex
@@ -179,11 +191,7 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: null,
         'bootstrap-sass': bs3Regex
       }
     }
@@ -196,9 +204,23 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
+      npm: {
+        'bootstrap-sass': bs3Regex
       },
+      addon: {
+        'ember-cli-less': null,
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass'
+    },
+    installed: {
+      npm: ['ember-cli-less', 'bootstrap']
+    },
+    dependencies: {
       npm: {
         bootstrap: null,
         'bootstrap-sass': bs3Regex
@@ -216,12 +238,8 @@ const scenarios = [
       bootstrapVersion: 3
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -233,12 +251,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -250,11 +264,7 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: null,
         'bootstrap-sass': bs3Regex
       }
     }
@@ -265,12 +275,8 @@ const scenarios = [
       bootstrapVersion: 3
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -283,12 +289,8 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-sass': null
@@ -304,12 +306,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-less': null
@@ -322,12 +320,8 @@ const scenarios = [
       bootstrapVersion: 3
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-less': true
@@ -343,12 +337,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs3Regex,
-        'bootstrap-sass': null
+        bootstrap: bs3Regex
       }
     }
   },
@@ -361,12 +351,8 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
         bootstrap: bs3Regex,
-        'bootstrap-sass': null
       },
       addon: {
         'ember-cli-less': true,
@@ -380,11 +366,7 @@ const scenarios = [
       bootstrapVersion: 3
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: null,
         'bootstrap-sass': bs3Regex
       },
       addon: {
@@ -401,11 +383,7 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: null,
         'bootstrap-sass': bs3Regex
       }
     }
@@ -419,11 +397,7 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: null,
         'bootstrap-sass': bs3Regex
       },
       addon: {
@@ -439,12 +413,8 @@ const scenarios = [
       bootstrapVersion: 4
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs4Regex,
-        'bootstrap-sass': null
+        bootstrap: bs4Regex
       }
     }
   },
@@ -456,9 +426,19 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
+      npm: {
+        bootstrap: bs4Regex
+      }
+    }
+  },
+  {
+    options: {
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass', 'bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs4Regex,
         'bootstrap-sass': null
@@ -471,12 +451,8 @@ const scenarios = [
       bootstrapVersion: 4
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs4Regex,
-        'bootstrap-sass': null
+        bootstrap: bs4Regex
       }
     }
   },
@@ -489,9 +465,23 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
+      npm: {
+        bootstrap: bs4Regex
       },
+      addon: {
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass', 'bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs4Regex,
         'bootstrap-sass': null
@@ -510,12 +500,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
-        bootstrap: bs4Regex,
-        'bootstrap-sass': null
+        bootstrap: bs4Regex
       },
       addon: {
         'ember-cli-less': null
@@ -528,9 +514,23 @@ const scenarios = [
       bootstrapVersion: 4
     },
     dependencies: {
-      bower: {
-        bootstrap: null
+      npm: {
+        bootstrap: bs4Regex
       },
+      addon: {
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs4Regex,
         'bootstrap-sass': null
@@ -549,9 +549,20 @@ const scenarios = [
       npm: ['ember-cli-sass']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
+      npm: {
+        bootstrap: bs4Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass', 'bootstrap-sass']
+    },
+    dependencies: {
       npm: {
         bootstrap: bs4Regex,
         'bootstrap-sass': null
@@ -567,12 +578,8 @@ const scenarios = [
       npm: ['ember-cli-less']
     },
     dependencies: {
-      bower: {
-        bootstrap: null
-      },
       npm: {
         bootstrap: bs4Regex,
-        'bootstrap-sass': null
       },
       addon: {
         'ember-cli-less': null,

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -1,0 +1,586 @@
+'use strict';
+
+const bs3Regex = '\\^3\\.\\d+\\.\\d+';
+const bs4Regex = 'next';
+const scenarios = [
+  {
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none'
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none'
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none'
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less'
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less'
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less'
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': true,
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass'
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      },
+      addon: {
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass'
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass'
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      },
+      addon: {
+        'ember-cli-less': null,
+        'ember-cli-sass': true
+      }
+    }
+  },
+
+  // BS3 option
+  {
+    options: {
+      bootstrapVersion: 3
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 3
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less',
+      bootstrapVersion: 3
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'less',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs3Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': true,
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 3
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      },
+      addon: {
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 3
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: null,
+        'bootstrap-sass': bs3Regex
+      },
+      addon: {
+        'ember-cli-less': null,
+        'ember-cli-sass': true
+      }
+    }
+  },
+
+  // BS4 option
+  {
+    options: {
+      bootstrapVersion: 4
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 4
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'none',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 4
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-sass': true
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-sass']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      }
+    }
+  },
+  {
+    options: {
+      preprocessor: 'sass',
+      bootstrapVersion: 4
+    },
+    installed: {
+      npm: ['ember-cli-less']
+    },
+    dependencies: {
+      bower: {
+        bootstrap: null
+      },
+      npm: {
+        bootstrap: bs4Regex,
+        'bootstrap-sass': null
+      },
+      addon: {
+        'ember-cli-less': null,
+        'ember-cli-sass': true
+      }
+    }
+  }
+
+];
+
+module.exports = scenarios;

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -35,7 +35,6 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
   setupTestHooks(this);
 
   describe('import styles', function() {
-    setupTestHooks(this);
 
     describe('based on existing preprocessor', function() {
 

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -9,10 +9,16 @@ const modifyPackages = blueprintHelpers.modifyPackages;
 
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const file = chai.file;
+const chaiThings = require('chai-things');
 const expect = chai.expect;
+const Promise = require('rsvp');
 
 const fs = require('fs');
 const path = require('path');
+
+const scenarios = require('./dependencyScenarios');
+
+chai.use(chaiThings);
 
 function createStyleFixture(name) {
   let stylePath = path.join('app', 'styles');
@@ -29,6 +35,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
   setupTestHooks(this);
 
   describe('import styles', function() {
+    setupTestHooks(this);
 
     describe('based on existing preprocessor', function() {
 
@@ -172,7 +179,100 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
   describe('install dependencies', function() {
 
+    const Blueprint = require('ember-cli/lib/models/blueprint');
+    const origTaskFor = Blueprint.prototype.taskFor;
+    let installed = {
+      npm: [],
+      bower: [],
+      addon: []
+    };
+
+    before(function() {
+      Blueprint.prototype.taskFor = function(taskName) {
+        let match = taskName.match(/^(npm|bower|addon)-install$/);
+
+        if (match) {
+          let type = match[1];
+          return {
+            run: function(options) {
+              let packages = options.packages || [];
+              installed[type] = installed[type].concat(packages);
+              return Promise.resolve();
+            }
+          };
+        }
+
+        return origTaskFor.apply(this, arguments);
+      };
+    });
+
+    after(function() {
+      Blueprint.prototype.taskFor = origTaskFor;
+    });
+
+    beforeEach(function() {
+      installed = {
+        npm: [],
+        bower: [],
+        addon: []
+      };
+    });
+
+    function checkPackage(type, pkg, version) {
+      let installedPackages = installed[type];
+      if (version === null) {
+        if (type === 'addon') {
+          expect(installedPackages).to.not.include.some.that.equal(pkg);
+        } else {
+          expect(installedPackages).to.not.include.some.that.match(new RegExp(`${pkg}@.*`));
+        }
+      } else {
+        if (type === 'addon') {
+          expect(installedPackages).to.include.some.that.equal(pkg);
+        } else {
+          expect(installedPackages).to.include.some.that.match(new RegExp(`${pkg}@${version}`));
+        }
+      }
+    }
+
+    scenarios.forEach(function(scenario) {
+      let args = [];
+      let options = scenario.options || {};
+      let preprocessor = options.preprocessor;
+      let bootstrapVersion = options.bootstrapVersion;
+      let installed = scenario.installed || {};
+      let npmInstalled = installed.npm || [];
+
+      if (preprocessor) {
+        args.push(`--preprocessor=${preprocessor}`);
+      }
+      if (bootstrapVersion) {
+        args.push(`--bootstrapVersion=${bootstrapVersion}`);
+      }
+
+      let preInstalledText = npmInstalled.length > 0 ? `, preInstalled: ${npmInstalled.join(', ')}` : '';
+
+      it(`installs dependencies for ember g ember-bootstrap ${args.join(' ')}${preInstalledText}`, function() {
+        args = ['ember-bootstrap'].concat(args);
+
+        return emberNew()
+          .then(() => modifyPackages(npmInstalled.map((pkg) => ({ name: pkg, dev: true }))))
+          .then(() => emberGenerate(args))
+          .then(() => {
+            for (let pkg in scenario.dependencies.bower) {
+              checkPackage('bower', pkg, scenario.dependencies.bower[pkg]);
+            }
+
+            for (let pkg in scenario.dependencies.npm) {
+              checkPackage('npm', pkg, scenario.dependencies.npm[pkg]);
+            }
+
+            for (let pkg in scenario.dependencies.addon) {
+              checkPackage('addon', pkg, scenario.dependencies.addon[pkg]);
+            }
+
+          });
+      })
+    });
   });
-
-
 });

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -186,17 +186,30 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
       bower: [],
       addon: []
     };
+    let uninstalled = {
+      npm: [],
+      bower: []
+    };
 
     before(function() {
       Blueprint.prototype.taskFor = function(taskName) {
         let match = taskName.match(/^(npm|bower|addon)-install$/);
-
         if (match) {
           let type = match[1];
           return {
             run: function(options) {
               let packages = options.packages || [];
               installed[type] = installed[type].concat(packages);
+              return Promise.resolve();
+            }
+          };
+        }
+
+        if (taskName === 'npm-uninstall') {
+          return {
+            run: function(options) {
+              let packages = options.packages || [];
+              uninstalled.npm = uninstalled.npm.concat(packages);
               return Promise.resolve();
             }
           };
@@ -216,11 +229,20 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
         bower: [],
         addon: []
       };
+      uninstalled = {
+        npm: [],
+        bower: []
+      };
     });
 
     function checkPackage(type, pkg, version) {
       let installedPackages = installed[type];
+      let uninstalledPackages = uninstalled[type === 'addon' ? 'npm' : type];
       if (version === null) {
+        if (type === 'bower') {
+          return; // not yet implemented
+        }
+        expect(uninstalledPackages).to.include.some.that.equal(pkg);
         if (type === 'addon') {
           expect(installedPackages).to.not.include.some.that.equal(pkg);
         } else {

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -28,74 +28,151 @@ function createStyleFixture(name) {
 describe('Acceptance: ember generate ember-bootstrap', function() {
   setupTestHooks(this);
 
-  it('skips blueprint when no preprocessor present', function() {
-    let args = ['ember-bootstrap'];
+  describe('import styles', function() {
 
-    return emberNew()
-      .then(() => emberGenerate(args, (file) => {
-        expect(file('app/styles/app.scss')).to.not.exist;
-        expect(file('app/styles/app.less')).to.not.exist;
-      }));
-  });
+    describe('based on existing preprocessor', function() {
 
-  it('creates app.scss if not existing', function() {
-    let args = ['ember-bootstrap'];
+      it('skips blueprint when no preprocessor present', function() {
+        let args = ['ember-bootstrap'];
 
-    return emberNew()
-      .then(() => modifyPackages([
-        { name: 'ember-cli-sass' }
-      ]))
-      .then(() => emberGenerate(args))
-      .then(() => {
-        expect(file('app/styles/app.scss'))
-          .to.contain('@import "ember-bootstrap/bootstrap";');
-        expect(file('app/styles/app.less')).to.not.exist;
+        return emberNew()
+          .then(() => emberGenerate(args, (file) => {
+            expect(file('app/styles/app.scss')).to.not.exist;
+            expect(file('app/styles/app.less')).to.not.exist;
+          }));
       });
-  });
 
-  it('adds @import to existing app.scss', function() {
-    let args = ['ember-bootstrap'];
+      it('creates app.scss if not existing and ember-cli-sass is present', function() {
+        let args = ['ember-bootstrap'];
 
-    return emberNew()
-      .then(() => modifyPackages([
-        { name: 'ember-cli-sass' }
-      ]))
-      .then(() => createStyleFixture('app.scss'))
-      .then(() => emberGenerate(args, (file) => {
-        expect(file('app/styles/app.scss')).to.contain('@import "ember-bootstrap/bootstrap";');
-        expect(file('app/styles/app.less')).to.not.exist;
-      }));
-  });
-
-  it('creates app.less if not existing', function() {
-    let args = ['ember-bootstrap'];
-
-    return emberNew()
-      .then(() => modifyPackages([
-        { name: 'ember-cli-less' }
-      ]))
-      .then(() => emberGenerate(args))
-      .then(() => {
-        expect(file('app/styles/app.less'))
-          .to.contain('@import "ember-bootstrap/bootstrap";');
-        expect(file('app/styles/app.scss')).to.not.exist;
+        return emberNew()
+          .then(() => modifyPackages([
+            { name: 'ember-cli-sass' }
+          ]))
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.scss'))
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.less')).to.not.exist;
+          });
       });
-  });
 
-  it('adds @import to existing app.less', function() {
-    let args = ['ember-bootstrap'];
+      it('adds @import to existing app.scss if ember-cli-sass is present', function() {
+        let args = ['ember-bootstrap'];
 
-    return emberNew()
-      .then(() => modifyPackages([
-        { name: 'ember-cli-less' }
-      ]))
-      .then(() => createStyleFixture('app.less'))
-      .then(() => emberGenerate(args))
-      .then(() => {
-        expect(file('app/styles/app.less'))
-          .to.contain('body { color: red; }')
-          .to.contain('@import "ember-bootstrap/bootstrap";');
-        expect(file('app/styles/app.scss')).to.not.exist;
+        return emberNew()
+          .then(() => modifyPackages([
+            { name: 'ember-cli-sass' }
+          ]))
+          .then(() => createStyleFixture('app.scss'))
+          .then(() => emberGenerate(args, (file) => {
+            expect(file('app/styles/app.scss')).to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.less')).to.not.exist;
+          }));
       });
+
+      it('creates app.less if not existing and ember-cli-less is present', function() {
+        let args = ['ember-bootstrap'];
+
+        return emberNew()
+          .then(() => modifyPackages([
+            { name: 'ember-cli-less' }
+          ]))
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.less'))
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.scss')).to.not.exist;
+          });
+      });
+
+      it('adds @import to existing app.less if ember-cli-less is present', function() {
+        let args = ['ember-bootstrap'];
+
+        return emberNew()
+          .then(() => modifyPackages([
+            { name: 'ember-cli-less' }
+          ]))
+          .then(() => createStyleFixture('app.less'))
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.less'))
+              .to.contain('body { color: red; }')
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.scss')).to.not.exist;
+          });
+      });
+
+    });
+
+    describe('based on generator option', function() {
+
+      it('skips blueprint when --preprocessor=none', function() {
+        let args = ['ember-bootstrap', '--preprocessor=none'];
+
+        return emberNew()
+          .then(() => emberGenerate(args, (file) => {
+            expect(file('app/styles/app.scss')).to.not.exist;
+            expect(file('app/styles/app.less')).to.not.exist;
+          }));
+      });
+
+      it('creates app.scss if not existing and --preprocessor=sass', function() {
+        let args = ['ember-bootstrap', '--preprocessor=sass'];
+
+        return emberNew()
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.scss'))
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.less')).to.not.exist;
+          });
+      });
+
+      it('adds @import to existing app.scss if --preprocessor=sass', function() {
+        let args = ['ember-bootstrap', '--preprocessor=sass'];
+
+        return emberNew()
+          .then(() => createStyleFixture('app.scss'))
+          .then(() => emberGenerate(args, (file) => {
+            expect(file('app/styles/app.scss')).to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.less')).to.not.exist;
+          }));
+      });
+
+      it('creates app.less if not existing and --preprocessor=less', function() {
+        let args = ['ember-bootstrap', '--preprocessor=less'];
+
+        return emberNew()
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.less'))
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.scss')).to.not.exist;
+          });
+      });
+
+      it('adds @import to existing app.less if --preprocessor=less', function() {
+        let args = ['ember-bootstrap', '--preprocessor=less'];
+
+        return emberNew()
+          .then(() => createStyleFixture('app.less'))
+          .then(() => emberGenerate(args))
+          .then(() => {
+            expect(file('app/styles/app.less'))
+              .to.contain('body { color: red; }')
+              .to.contain('@import "ember-bootstrap/bootstrap";');
+            expect(file('app/styles/app.scss')).to.not.exist;
+          });
+      });
+
+    });
+
   });
+
+  describe('install dependencies', function() {
+
+  });
+
+
 });

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -39,7 +39,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
     describe('based on existing preprocessor', function() {
 
-      it('skips blueprint when no preprocessor present', function() {
+      it('skips style import when no preprocessor present', function() {
         let args = ['ember-bootstrap'];
 
         return emberNew()
@@ -114,7 +114,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
     describe('based on generator option', function() {
 
-      it('skips blueprint when --preprocessor=none', function() {
+      it('skips style import when --preprocessor=none', function() {
         let args = ['ember-bootstrap', '--preprocessor=none'];
 
         return emberNew()

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bootstrap-sass": "^3.3.7",
     "broccoli-asset-rev": "^2.4.5",
     "chai": "^3.5.0",
+    "chai-things": "^0.2.0",
     "ember-ajax": "^2.4.1",
     "ember-cli": "^2.10.0",
     "ember-cli-app-version": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-ajax": "^2.4.1",
     "ember-cli": "^2.10.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-blueprint-test-helpers": "^0.17.0",
+    "ember-cli-blueprint-test-helpers": "simonihmig/ember-cli-blueprint-test-helpers#cleanup-symlink",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.2",
     "ember-cli-fastboot": "^1.0.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "broccoli-stew": "^1.4.0",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-build-config-editor": "^0.2.0",
+    "ember-cli-build-config-editor": "^0.2.1",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "broccoli-stew": "^1.4.0",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-build-config-editor": "^0.1.1",
+    "ember-cli-build-config-editor": "^0.1.2",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",
+    "fs-extra": "^2.0.0",
     "rsvp": "^3.3.3"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.2",
     "ember-cli-fastboot": "^1.0.0-beta.15",
-    "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.5",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember try:each && DEBUG=ember-cli.addon-tests ember fastboot:test",
+    "test": "ember try:each",
     "nodetest": "mocha node-tests --recursive"
   },
   "repository": {
@@ -28,7 +28,7 @@
     "ember-ajax": "^2.4.1",
     "ember-cli": "^2.10.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-blueprint-test-helpers": "0.14.0",
+    "ember-cli-blueprint-test-helpers": "^0.17.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.2",
     "ember-cli-fastboot": "^1.0.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "broccoli-stew": "^1.4.0",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.7",
+    "ember-cli-build-config-editor": "^0.1.1",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "broccoli-stew": "^1.4.0",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-build-config-editor": "^0.1.2",
+    "ember-cli-build-config-editor": "^0.2.0",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",

--- a/tests/dummy/app/templates/getting-started/assets.hbs
+++ b/tests/dummy/app/templates/getting-started/assets.hbs
@@ -1,5 +1,47 @@
 <h1 id="addon-options">Importing assets</h1>
 
+<h2 id="configuration-with-blueprint">Configuration using the default blueprint</h2>
+
+<p>By default, ember-bootstrap installs Bootstrap 3 and uses the installed preprocessor if there is one. You can use
+    the ember-bootstrap default blueprint to switch Bootstrap version or preprocessor. Simply re-run the default
+    blueprint like</p>
+
+<pre class="highlight">ember generate ember-bootstrap --bootstrap-version=4 --preprocessor=sass
+</pre>
+
+<p>The <code>--bootstrap-version</code> can be "3" or "4" and defaults to "3" if the option is omitted. The
+    <code>--preprocessor</code> can be "none", "less", or "sass". The blueprint will use the currently installed
+    preprocessor as its cue if this option is omitted. We explicitly support ember-cli-less and ember-cli-sass. You will
+    need to install and configure other preprocessors yourself.</p>
+
+<p>The default blueprint does the following:</p>
+
+<ul>
+    <li>
+        Removes any unneeded versions of bootstrap and bootstrap-sass from <code>package.json</code>
+        and <code>bower.json</code>
+    </li>
+    <li>
+        Installs the appropriate version of bootstrap or bootstrap-sass as an npm package
+    </li>
+    <li>
+        Removes unneeded dependencies on ember-cli-less and ember-cli-sass
+    </li>
+    <li>
+        Installs ember-cli-less or ember-cli-sass if appropriate
+    </li>
+    <li>
+        Creates <code>app.less</code> or <code>app.scss</code> if appropriate and it doesn't exist
+    </li>
+    <li>
+        Adds the appropriate "@import" statement to your <code>app.less</code> or <code>app.scss</code> if it&apos;s
+        not there already
+    </li>
+    <li>
+        Safely edits your <code>ember-cli-build.js</code> to ensure the proper ember-bootstrap settings for your configuration
+    </li>
+</ul>
+
 <h2 id="importing-css-assets">Importing static CSS Assets</h2>
 
 <p>When not using a CSS preprocessor (see below) ember-bootstrap will automatically import the static Bootstrap CSS into

--- a/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
+++ b/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
@@ -1,0 +1,64 @@
+<h1>Bootstrap 4</h1>
+
+<p>The 1.0 release of ember-bootstrap also contains experimental support for Bootstrap 4. Several of the API changes
+  in 1.0 were motivated by creating a mutually compatible structure that works with both Bootstrap 3 and Bootstrap 4.
+  The support is experimental because Bootstrap 4 itself is only now approaching beta release as of this writing in
+  February 2017. There have been many changes throughout the series of alpha releases and we expect a couple more in
+  the first beta.</p>
+
+<h2>Moving to Bootstrap 4</h2>
+
+<p>We've made every effort to make moving from Bootstrap 3 to Bootstrap 4 in 1.0 completely transparent. Making the
+  switch from earlier versions of ember-bootstrap will take some additional work. Here are the key steps.</p>
+
+<ol>
+    <li>
+        <strong>Bootstrap 4 uses SASS!</strong> If you were using LESS with Bootstrap 3, you will need to switch to
+        either static CSS or SASS. The details of doing this are beyond the scope of this guide. It could be as simple
+        as changing <code>@</code> to <code>$</code> but is likely more complex. Remove ember-cli-less from your
+        <code>package.json</code> and install ember-cli-sass if appropriate.
+    </li>
+    <li>
+        Run the ember-bootstrap blueprint. (You don't have to do this again if you already did it with the right
+        preprocessor as part of your migraion to 1.0.)
+        <pre class="highlight"><code>ember generate ember-bootstrap</code></pre>
+    </li>
+    <li>
+        Add the <code>bootstrapVersion</code> key to the ember-bootstrap configuration so it looks similar to
+        <div>
+            <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
+
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+    var app = new EmberApp({
+        'ember-bootstrap': {
+            bootstrapVersion: 4
+        }
+    });
+
+    return app.toTree();
+};
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        Make sure your ember-bootstrap code uses all of the new contextual components. Most of the differences between
+        the two versions of Bootstrap are hidden by proper component usage. Some of the more noteworthy ones are
+        <code>bs-form</code>, <code>bs-nav.link-to</code> (which also affects navs in navbars),
+        <code>bs-dropdown.menu.item</code>, and <code>bs-dropdown.menu.divider</code>.
+    </li>
+    <li>
+        Refer to the <a href="https://v4-alpha.getbootstrap.com/getting-started/introduction/" target="_blank">Bootstrap
+        4 documentation</a> and, in particular, the <a href="https://v4-alpha.getbootstrap.com/migration/" target="_blank">
+        Migration Guide</a> for other necessary changes in markup with Bootstrap 4.
+    </li>
+</ol>
+
+Please let us know if you find any issues by either <a href="https://github.com/kaliber5/ember-bootstrap/issues/new">
+filing an issue</a> or, even better, forking the repo and submitting a pull request with a fix.
+
+<h2>Known Issues</h2>
+
+Known issues and pull requests relating to the Bootstrap 4 implementation will be labeled.

--- a/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
+++ b/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
@@ -19,29 +19,7 @@
         <code>package.json</code> and install ember-cli-sass if appropriate.
     </li>
     <li>
-        Run the ember-bootstrap blueprint. (You don't have to do this again if you already did it with the right
-        preprocessor as part of your migraion to 1.0.)
-        <pre class="highlight"><code>ember generate ember-bootstrap</code></pre>
-    </li>
-    <li>
-        Add the <code>bootstrapVersion</code> key to the ember-bootstrap configuration so it looks similar to
-        <div>
-            <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
-
-/* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-
-module.exports = function(defaults) {
-    var app = new EmberApp(defaults, {
-        'ember-bootstrap': {
-            bootstrapVersion: 4
-        }
-    });
-
-    return app.toTree();
-};
-            </code></pre>
-        </div>
+        Run the ember-bootstrap blueprint. For details, see the <a href="assets.hbs">assets guide</a>.
     </li>
     <li>
         Make sure your ember-bootstrap code uses all of the new contextual components. Most of the differences between

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,10 +281,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.2.tgz#2cc19979d15c655108bf565323b8e7ee38751f6b"
-
 ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
@@ -2006,15 +2002,15 @@ ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-blueprint-test-helpers@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.14.0.tgz#0b259a6f5ec4d6ab08bb2243c5a66f97c67cda4e"
+ember-cli-blueprint-test-helpers@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.17.0.tgz#fa984b6b7ba616d959b6a14c3a9ba3e242b51023"
   dependencies:
     chai "^3.3.0"
     chai-as-promised "^6.0.0"
     chai-files "^1.0.0"
     debug "^2.2.0"
-    ember-cli-internal-test-helpers "^0.8.1"
+    ember-cli-internal-test-helpers "^0.9.1"
     exists-sync "0.0.3"
     findup "^0.1.5"
     fs-extra "^0.30.0"
@@ -2110,15 +2106,14 @@ ember-cli-inject-live-reload@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.4.1.tgz#ddadb9a346c5ed694ec0f9e11f49994eacafd277"
 
-ember-cli-internal-test-helpers@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-internal-test-helpers/-/ember-cli-internal-test-helpers-0.8.3.tgz#e9b7db67f3fda4db736d1a319a282c04beada495"
+ember-cli-internal-test-helpers@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-internal-test-helpers/-/ember-cli-internal-test-helpers-0.9.1.tgz#d54a9124bb6408ceba83f049ba8479f4b96cdd19"
   dependencies:
     chai "^3.3.0"
     chai-as-promised "^6.0.0"
     chai-files "^1.1.0"
     chalk "^1.1.1"
-    configstore "^2.0.0"
     debug "^2.2.0"
     exists-sync "0.0.3"
     fs-extra "^0.30.0"
@@ -6171,16 +6166,7 @@ recast@0.10.33, recast@^0.10.10:
     private "~0.1.5"
     source-map "~0.5.0"
 
-recast@^0.11.17, recast@^0.11.3:
-  version "0.11.18"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.18.tgz#07af6257ca769868815209401d4d60eef1b5b947"
-  dependencies:
-    ast-types "0.9.2"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.11.22:
+recast@^0.11.17, recast@^0.11.22, recast@^0.11.3:
   version "0.11.22"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.22.tgz#dedeb18fb001a2bbc6ac34475fda53dfe3d47dfa"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,6 +285,10 @@ ast-types@0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.2.tgz#2cc19979d15c655108bf565323b8e7ee38751f6b"
 
+ast-types@0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
+
 astw@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astw/-/astw-2.0.0.tgz#08121ac8288d35611c0ceec663f6cd545604897d"
@@ -2028,6 +2032,12 @@ ember-cli-broccoli-sane-watcher@^2.0.3:
     rsvp "^3.0.18"
     sane "^1.1.1"
 
+ember-cli-build-config-editor@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-build-config-editor/-/ember-cli-build-config-editor-0.2.1.tgz#715394296bd09275c66385eb46e3b1276ad843ca"
+  dependencies:
+    recast "^0.11.22"
+
 ember-cli-dependency-checker@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-1.3.0.tgz#f0e8cb7f0f43c1e560494eaa9372804e7a088a2a"
@@ -3252,6 +3262,13 @@ fs-extra@^0.26.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.0.0.tgz#337352bded4a0b714f3eb84de8cea765e9d37600"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
 
 fs-promise@^0.3.1:
   version "0.3.1"
@@ -6159,6 +6176,15 @@ recast@^0.11.17, recast@^0.11.3:
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.18.tgz#07af6257ca769868815209401d4d60eef1b5b947"
   dependencies:
     ast-types "0.9.2"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
+
+recast@^0.11.22:
+  version "0.11.22"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.22.tgz#dedeb18fb001a2bbc6ac34475fda53dfe3d47dfa"
+  dependencies:
+    ast-types "0.9.5"
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,9 +2006,9 @@ ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-blueprint-test-helpers@^0.17.0:
+ember-cli-blueprint-test-helpers@simonihmig/ember-cli-blueprint-test-helpers#cleanup-symlink:
   version "0.17.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.17.0.tgz#fa984b6b7ba616d959b6a14c3a9ba3e242b51023"
+  resolved "https://codeload.github.com/simonihmig/ember-cli-blueprint-test-helpers/tar.gz/1da201023ca915a775229cf2da1fd73b378751b9"
   dependencies:
     chai "^3.3.0"
     chai-as-promised "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,6 +1138,10 @@ chai-files@^1.0.0, chai-files@^1.1.0:
   dependencies:
     assertion-error "^1.0.1"
 
+chai-things@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chai-things/-/chai-things-0.2.0.tgz#c55128378f9bb399e994f00052151984ed6ebe70"
+
 chai@^3.3.0, chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"


### PR DESCRIPTION
The default blueprint is run when `ember-bootstrap` is installed and can also be run separately. Currently it installs all of the dependencies necessary for e-b. With the Bootstrap 4 support, there are more dependencies and permutations of Bootstrap versions and preprocessors.

This PR investigates whether it works correctly in those situations and explores where we should go from there. Phase 1 assesses whether the blueprint works correctly for the various upgrade paths needed to support #206 with 2 Bootstrap versions (3, 4) and 3 preprocessor options (none, LESS, SASS). Phase 2 investigates whether we can improve the overhead of the current solution by installing only the packages necessary to support the chosen configuration.

# Phase 1: Install a functional `ember-bootstrap`

The `bs4` branch approach is to install `bootstrap#^3.3.7` in `bower.json` and `bootstrap#^4.0.0-alpha.6` and `bootstrap-sass#^3.3.7` in `package.json` and use build-time tree manipulation based on the `bootstrapVersion` setting in `index.js`. This results in additional overhead to install `ember-bootstrap`, but exactly what is needed in the production distribution.

* `e-b` = ember-bootstrap (None, <bs4, bs4)
* `BS` = Bootstrap (None, 3, 4)
* `Pre` = CSS preprocessor (None, LESS, SASS)
  * `LESS` = Assumes `ember-cli-less`
  * `SASS` = Assumes `ember-cli-sass`

## Installation Scenarios

Normal usage when `ember-bootstrap` has not been installed invokes the blueprint during `ember install ember-bootstrap`.

From/To (e-b/BS/Pre) | bs4/3/None | bs4/3/LESS | bs4/3/SASS | bs4/4/None | bs4/4/SASS |
---- | ---- | ---- | ---- | ---- | ----
None/None/None | Add bootstrap3 in bower.json and bootstrap4 in package.json | No direct path | No direct path | No direct path | No direct path
None/None/LESS | No direct path | Add bootstrap3 in bower.json and bootstrap 4 in package.json; create app.less | No direct path | No direct path | No direct path
None/None/SASS | No direct path | No direct path | Add bootstrap-sass and bootstrap4 in package.json; create app.scss | No direct path | No direct path
None/3/None | Update bootstrap3 in bower.json and add bootstrap4 in package.json | No direct path | No direct path | No direct path | No direct path
None/3/LESS | No direct path | Update bootstrap3 in bower.json and add bootstrap 4 in package.json; append import to app.less | No direct path | No direct path | No direct path
None/3/SASS | No direct path | No direct path | Add bootstrap-sass and bootstrap4 in package.json; append import to app.scss | No direct path | No direct path
None/4/None | Downgrade to bootstrap3 in bower.json and add bootstrap4 in package.json | No direct path | No direct path | No direct path | No direct path
None/4/SASS | No direct path | No direct path | Add bootstrap-sass and update bootstrap4 in package.json; append import to app.scss | No direct path | No direct path

### Notes

* Anything installed in `bower.json` will be untouched except for updating the "bootstrap" version if applicable. Most notably, this includes "bootstrap-sass".
* The blueprint makes no modifications to `ember-cli-build.js`
* The blueprint makes the wrong assumptions if an alternate preprocessor is present.
* There is no direct route to change preprocessors or to use Bootstrap 4 via the blueprint.

## Configuration Change Scenarios

Once `ember-bootstrap` has been installed, the blueprint is invoked with `ember generate ember-bootstrap`.

From/To (e-b/BS/Pre) | bs4/3/None | bs4/3/LESS | bs4/3/SASS | bs4/4/None | bs4/4/SASS |
---- | ---- | ---- | ---- | ---- | ----
<bs4/3/None |  |  |  |  |  
<bs4/3/LESS |  |  |  |  |  
<bs4/3/SASS |  |  |  |  |  
bs4/3/None | No change |  |  |  |  
bs4/3/LESS |  | No change |  |  |  
bs4/3/SASS |  |  | No change |  |  
bs4/4/None |  |  |  | No change |  
bs4/4/SASS |  |  |  |  | No change

## Other configurations

The following and other packages aren't explicitly addressed at this time, although their effects are if they install the packages addressed above.

* `ember-cli-bootstrap-sassy`
* `ember-cli-bootstrap3-sass`
* `ember-cli-postcss`
* `ember-cli-css-preprocess`

# Phase 2: Optimize Installation

Install only the necessary bootstrap and preprocessor packages and automatically manage the `bootstrapVersion` in `index.js`.