### PR TITLE
Fix BS4 form label class and update tests.

### DIFF
--- a/addon/components/bs4/bs-form/element/label.js
+++ b/addon/components/bs4/bs-form/element/label.js
@@ -3,7 +3,7 @@ import FormElementLabel from 'ember-bootstrap/components/base/bs-form/element/la
 export default FormElementLabel.extend({
   tagName: 'label',
 
-  classNames: ['form-control-label'],
+  classNames: ['col-form-label'],
   classNameBindings: ['invisibleLabel:sr-only', 'labelClass'],
   attributeBindings: ['formElementId:for']
 });

--- a/tests/integration/components/bs-form/element/label-test.js
+++ b/tests/integration/components/bs-form/element/label-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { testBS3, testBS4 } from '../../../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('bs-form/element/label', 'Integration | Component | bs form/element/label', {
@@ -22,4 +23,14 @@ test('it renders', function(assert) {
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');
+});
+
+testBS3('bs3 class', function(assert) {
+  this.render(hbs`{{bs-form/element/label}}`);
+  assert.equal(this.$('label').hasClass('control-label'), true);
+});
+
+testBS4('bs4 class', function(assert) {
+  this.render(hbs`{{bs-form/element/label}}`);
+  assert.equal(this.$('label').hasClass('col-form-label'), true);
 });


### PR DESCRIPTION
BS4 uses `col-form-label` class for form labels.