### PR TITLE
Filter trees before calling _super.

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,25 +157,27 @@ module.exports = {
     return this.getBootstrapVersion() === 3 ? 4 : 3;
   },
 
-  treeForAddon() {
-    let tree = this._super.treeForAddon.apply(this, arguments);
+  treeForAddon(tree) {
     let bsVersion = this.getBootstrapVersion();
     let otherBsVersion = this.getOtherBootstrapVersion();
-    let componentsPath = 'modules/ember-bootstrap/components/';
+    let componentsPath = 'components/';
+
     tree = mv(tree, `${componentsPath}bs${bsVersion}/`, componentsPath);
     tree = rm(tree, `${componentsPath}bs${otherBsVersion}/**/*`);
-    return tree; // log(tree, {output: 'tree', label: 'moved'});
+
+    return this._super.treeForAddon.call(this, tree);
   },
 
-  treeForAddonTemplates() {
-    let tree = this._super.treeForAddonTemplates.apply(this, arguments);
+  treeForAddonTemplates(tree) {
     let bsVersion = this.getBootstrapVersion();
     let otherBsVersion = this.getOtherBootstrapVersion();
     let templatePath = 'components/';
+
     tree = mv(tree, `${templatePath}common/`, templatePath);
     tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
     tree = rm(tree, `${templatePath}bs${otherBsVersion}/**/*`);
-    return tree; // log(tree, {output: 'tree', label: 'moved'});
+
+    return this._super.treeForAddonTemplates.call(this, tree);
   },
 
   contentFor(type, config) {


### PR DESCRIPTION
This fixes issues with ember-cli@2.12, and works on prior versions of ember-cli. Simply put, the concept that we are trying to do here is to filter down the set of things in the tree before we process them.

This will also have the positive result of not transpiling all of the compoents and templates for both bootstrap versions, just before removing one of them.