### PR TITLE
Check for outdated dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "ember": "~2.10.0",
     "ember-cli-shims": "0.1.3",
-    "bootstrap": "^3.3.7",
     "markdown-it": "^8.2.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const stew = require('broccoli-stew');
 const mv = stew.mv;
 // const log = stew.log;
 const rm = stew.rm;
-const chalk = require('chalk');
+const SilentError = require('silent-error'); // From ember-cli
 
 const defaultOptions = {
   importBootstrapTheme: false,
@@ -42,6 +42,7 @@ module.exports = {
     }
     this.bootstrapOptions = options;
 
+    this.validateDependencies();
     this.preprocessor = this.findPreprocessor();
 
     if (!this.hasPreprocessor()) {
@@ -66,6 +67,12 @@ module.exports = {
     }
   },
 
+  validateDependencies() {
+    if ('bootstrap' in this.app.project.bowerDependencies()) {
+      throw new SilentError('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
+    }
+  },
+
   findPreprocessor() {
     return supportedPreprocessors.find((name) => !!this.app.project.findAddonByName(`ember-cli-${name}`) && this.validatePreprocessor(name));
   },
@@ -75,18 +82,15 @@ module.exports = {
     switch (name) {
       case 'sass':
         if (!('bootstrap-sass' in dependencies) && this.getBootstrapVersion() === 3) {
-          this.ui.writeLine(chalk.red('Npm package "bootstrap-sass" is missing, but required for SASS support. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
-          return false;
+          throw new SilentError('Npm package "bootstrap-sass" is missing, but required for SASS support. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
         }
         break;
       case 'less':
         if (this.getBootstrapVersion() === 4) {
-          this.ui.writeLine(chalk.red('There is no Less support for Bootstrap 4! Falling back to importing static CSS. Consider switching to Sass for preprocessor support!'));
-          return false;
+          throw new SilentError('There is no Less support for Bootstrap 4! Falling back to importing static CSS. Consider switching to Sass for preprocessor support!');
         }
         if (!('bootstrap' in dependencies)) {
-          this.ui.writeLine(chalk.red('Bower package "bootstrap" is missing, but required for Less support. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
-          return false;
+          throw new SilentError('Npm package "bootstrap" is missing, but required for Less support. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
         }
         break;
     }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const stew = require('broccoli-stew');
 const mv = stew.mv;
 // const log = stew.log;
 const rm = stew.rm;
+const chalk = require('chalk');
 const SilentError = require('silent-error'); // From ember-cli
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
@@ -70,7 +71,7 @@ module.exports = {
 
   validateDependencies() {
     if (EmberApp.env() !== 'test' && 'bootstrap' in this.app.project.bowerDependencies()) {
-      throw new SilentError('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
+      this.ui.writeLine(chalk.red('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const mv = stew.mv;
 const rm = stew.rm;
 const chalk = require('chalk');
 const SilentError = require('silent-error'); // From ember-cli
-const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 const defaultOptions = {
   importBootstrapTheme: false,
@@ -70,8 +69,8 @@ module.exports = {
   },
 
   validateDependencies() {
-    if (EmberApp.env() !== 'test' && 'bootstrap' in this.app.project.bowerDependencies()) {
-      this.ui.writeLine(chalk.red('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!'));
+    if ('bootstrap' in this.app.project.bowerDependencies()) {
+      throw new SilentError('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ module.exports = {
   },
 
   validateDependencies() {
-    if ('bootstrap' in this.app.project.bowerDependencies()) {
+    let bowerDependencies = this.app.project.bowerDependencies()
+    if ('bootstrap' in bowerDependencies
+      || 'bootstrap-sass' in bowerDependencies) {
       throw new SilentError('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
     }
   },

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const mv = stew.mv;
 // const log = stew.log;
 const rm = stew.rm;
 const SilentError = require('silent-error'); // From ember-cli
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 const defaultOptions = {
   importBootstrapTheme: false,
@@ -68,7 +69,7 @@ module.exports = {
   },
 
   validateDependencies() {
-    if ('bootstrap' in this.app.project.bowerDependencies()) {
+    if (EmberApp.env() !== 'test' && 'bootstrap' in this.app.project.bowerDependencies()) {
       throw new SilentError('The dependencies for ember-bootstrap are outdated. Please run `ember generate ember-bootstrap` to install the missing dependencies!');
     }
   },


### PR DESCRIPTION
This throws an error when running the build when bootstrap is still a bower dependency. #233 switched the BS3
dependency from bower to npm. The build will fail, if a project just updated ember-bootstrap without rerunning the
blueprint. This will detected this situation and issue an error message.

@srvance I noticed this issue when testing the latest ember-cli fix. After just updating ember-bootstrap, the build failed because it was trying to import the Bootstrap font from `node_modules/bootstrap` which was not present (still in `bower_components`)