### PR TITLE
Add info command & issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+Thank you for taking the time to open an issue!
+
+For bug reports please include the following section in your issue details.
+If you include instructions on how to reproduce the bug or a failing test case
+it will make it easier for us to track down the issue you're having.
+
+---
+
+Output from `ember bootstrap:info`:
+```
+[Replace this line with the output.]
+```

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release-bs4
   - EMBER_TRY_SCENARIO=ember-beta-bs4
   - EMBER_TRY_SCENARIO=fastboot-addon-tests
-  - EMBER_TRY_SCENARIO=blueprint-tests
+  - EMBER_TRY_SCENARIO=node-tests
 
 matrix:
   fast_finish: true

--- a/blueprints/.eslintrc.js
+++ b/blueprints/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:ember-suave/recommended'
+  ],
+  env: {
+    node: true
+  },
+  rules: {
+    'ember-suave/no-direct-property-access': 'off',
+    'ember-suave/prefer-destructuring': 'off'
+  }
+};

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -254,7 +254,7 @@ module.exports = {
       }
     },
     {
-      name: 'blueprint-tests',
+      name: 'node-tests',
       command: 'yarn run nodetest',
       npm: {
         devDependencies: {}

--- a/index.js
+++ b/index.js
@@ -29,6 +29,12 @@ const supportedPreprocessors = [
 module.exports = {
   name: 'ember-bootstrap',
 
+  includedCommands() {
+    return {
+      'bootstrap:info': require('./lib/commands/info')
+    };
+  },
+
   included(app) {
     // workaround for https://github.com/ember-cli/ember-cli/issues/3718
     if (typeof app.import !== 'function' && app.app) {

--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:ember-suave/recommended'
+  ],
+  env: {
+    node: true
+  },
+  rules: {
+    'ember-suave/no-direct-property-access': 'off',
+    'ember-suave/prefer-destructuring': 'off'
+  }
+};

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  name: 'bootstrap:info',
+  description: 'Print information on your Bootstrap environment',
+
+  availableOptions: [],
+  works: 'insideProject',
+
+  run(options) {
+    let InfoTask = require('../tasks/info');
+
+    let testTask = new InfoTask({
+      ui: this.ui
+    });
+
+    return testTask.run(options);
+  }
+};

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 'use strict';
 
 module.exports = {
@@ -7,13 +8,13 @@ module.exports = {
   availableOptions: [],
   works: 'insideProject',
 
-  run(options) {
+  run() {
     let InfoTask = require('../tasks/info');
 
     let testTask = new InfoTask({
       ui: this.ui
     });
 
-    return testTask.run(options);
+    return testTask.run(this.project.root);
   }
 };

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -9,6 +9,7 @@ const bowerVersion = require('../utils/bower-version');
 const buildConfiguration = require('../utils/build-configuration');
 
 const npmPackages = [
+  'ember-bootstrap',
   'ember-cli',
   'bootstrap',
   'bootstrap-sass',
@@ -25,17 +26,17 @@ module.exports = CoreObject.extend({
 
   run(projectRoot) {
 
-    this.ui.writeLine(chalk.bold('Bower packages:'));
-    bowerPackages.forEach((pkg) => {
-      let version = bowerVersion(projectRoot, pkg);
-      this.printVersion(pkg, version);
-    });
-
     this.ui.writeLine(chalk.bold('Npm packages:'));
     npmPackages.forEach((pkg) => {
       let version = npmVersion(projectRoot, pkg);
       let installedVersion = version ? npmInstalledVersion(pkg) : undefined;
       this.printVersion(pkg, version, installedVersion);
+    });
+
+    this.ui.writeLine(chalk.bold('Bower packages:'));
+    bowerPackages.forEach((pkg) => {
+      let version = bowerVersion(projectRoot, pkg);
+      this.printVersion(pkg, version);
     });
 
     this.ui.writeLine(chalk.bold('ember-bootstrap configuration:'));

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -45,7 +45,7 @@ module.exports = CoreObject.extend({
 
   printVersion(module, version, installedVersion) {
     if (version && installedVersion) {
-      this.ui.writeLine(`${module}: ${version} -> ${installedVersion || 'n/a'}`);
+      this.ui.writeLine(`${module}: ${version} -> ${installedVersion}`);
     } else if (version) {
       this.ui.writeLine(`${module}: ${version}`);
     } else {

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -1,11 +1,12 @@
+/* eslint-env node */
 'use strict';
 
 const CoreObject = require('core-object');
-const path = require('path');
 const chalk = require('chalk');
 const npmVersion = require('../utils/npm-version');
 const npmInstalledVersion = require('../utils/npm-installed-version');
 const bowerVersion = require('../utils/bower-version');
+const buildConfiguration = require('../utils/build-configuration');
 
 const npmPackages = [
   'ember-cli',
@@ -21,7 +22,7 @@ const bowerPackages = [
 
 module.exports = CoreObject.extend({
 
-  run(options) {
+  run(/* options */) {
 
     this.ui.writeLine(chalk.bold('Bower packages:'));
     bowerPackages.forEach((pkg) => {
@@ -35,6 +36,10 @@ module.exports = CoreObject.extend({
       let installedVersion = version ? npmInstalledVersion(pkg) : undefined;
       this.printVersion(pkg, version, installedVersion);
     });
+
+    this.ui.writeLine(chalk.bold('ember-bootstrap configuration:'));
+    let configuration = buildConfiguration();
+    this.printConfiguration(configuration);
   },
 
   printVersion(module, version, installedVersion) {
@@ -47,4 +52,11 @@ module.exports = CoreObject.extend({
     }
   },
 
+  printConfiguration(configuration) {
+    if (configuration && Object.keys(configuration).length > 0) {
+      Object.keys(configuration).forEach((key) => this.ui.writeLine(`${key}: ${configuration[key]}`));
+    } else {
+      this.ui.writeLine('n/a');
+    }
+  }
 });

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -17,7 +17,8 @@ const npmPackages = [
 ];
 
 const bowerPackages = [
-  'bootstrap'
+  'bootstrap',
+  'bootstrap-sass'
 ];
 
 module.exports = CoreObject.extend({

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const CoreObject = require('core-object');
+const path = require('path');
+const chalk = require('chalk');
+const npmVersion = require('../utils/npm-version');
+const npmInstalledVersion = require('../utils/npm-installed-version');
+const bowerVersion = require('../utils/bower-version');
+
+const npmPackages = [
+  'ember-cli',
+  'bootstrap',
+  'bootstrap-sass',
+  'ember-cli-sass',
+  'ember-cli-less'
+];
+
+const bowerPackages = [
+  'bootstrap'
+];
+
+module.exports = CoreObject.extend({
+
+  run(options) {
+
+    this.ui.writeLine(chalk.bold('Bower packages:'));
+    bowerPackages.forEach((pkg) => {
+      let version = bowerVersion(pkg);
+      this.printVersion(pkg, version);
+    });
+
+    this.ui.writeLine(chalk.bold('Npm packages:'));
+    npmPackages.forEach((pkg) => {
+      let version = npmVersion(pkg);
+      let installedVersion = version ? npmInstalledVersion(pkg) : undefined;
+      this.printVersion(pkg, version, installedVersion);
+    });
+  },
+
+  printVersion(module, version, installedVersion) {
+    if (version && installedVersion) {
+      this.ui.writeLine(`${module}: ${version} -> ${installedVersion || 'n/a'}`);
+    } else if (version) {
+      this.ui.writeLine(`${module}: ${version}`);
+    } else {
+      this.ui.writeLine(`${module}: n/a`);
+    }
+  },
+
+});

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -23,23 +23,23 @@ const bowerPackages = [
 
 module.exports = CoreObject.extend({
 
-  run(/* options */) {
+  run(projectRoot) {
 
     this.ui.writeLine(chalk.bold('Bower packages:'));
     bowerPackages.forEach((pkg) => {
-      let version = bowerVersion(pkg);
+      let version = bowerVersion(projectRoot, pkg);
       this.printVersion(pkg, version);
     });
 
     this.ui.writeLine(chalk.bold('Npm packages:'));
     npmPackages.forEach((pkg) => {
-      let version = npmVersion(pkg);
+      let version = npmVersion(projectRoot, pkg);
       let installedVersion = version ? npmInstalledVersion(pkg) : undefined;
       this.printVersion(pkg, version, installedVersion);
     });
 
     this.ui.writeLine(chalk.bold('ember-bootstrap configuration:'));
-    let configuration = buildConfiguration();
+    let configuration = buildConfiguration(projectRoot);
     this.printConfiguration(configuration);
   },
 

--- a/lib/tasks/info.js
+++ b/lib/tasks/info.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const CoreObject = require('core-object');

--- a/lib/utils/bower-version.js
+++ b/lib/utils/bower-version.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const path = require('path');

--- a/lib/utils/bower-version.js
+++ b/lib/utils/bower-version.js
@@ -1,10 +1,11 @@
+/* eslint-env node */
 'use strict';
 
 const path = require('path');
 const fs = require('fs');
 
-module.exports = function bowerVersion(packageName) {
-  let bowerJsonPath = path.join(process.cwd(), 'bower.json');
+module.exports = function bowerVersion(projectRoot, packageName) {
+  let bowerJsonPath = path.join(projectRoot, 'bower.json');
   if (!fs.existsSync(bowerJsonPath)) {
     return;
   }

--- a/lib/utils/bower-version.js
+++ b/lib/utils/bower-version.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function bowerVersion(packageName) {
+  let bowerJsonPath = path.join(process.cwd(), 'bower.json');
+  if (!fs.existsSync(bowerJsonPath)) {
+    return;
+  }
+
+  let bowerJson = require(bowerJsonPath);
+  return bowerJson.dependencies[packageName];
+};

--- a/lib/utils/build-configuration.js
+++ b/lib/utils/build-configuration.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const path = require('path');

--- a/lib/utils/build-configuration.js
+++ b/lib/utils/build-configuration.js
@@ -5,8 +5,8 @@ const path = require('path');
 const fs = require('fs');
 const EmberBuildConfigEditor = require('ember-cli-build-config-editor');
 
-module.exports = function buildConfiguration() {
-  let emberCLIBuildPath = path.join(process.cwd(), 'ember-cli-build.js');
+module.exports = function buildConfiguration(projectRoot) {
+  let emberCLIBuildPath = path.join(projectRoot, 'ember-cli-build.js');
   if (!fs.existsSync(emberCLIBuildPath)) {
     return;
   }

--- a/lib/utils/build-configuration.js
+++ b/lib/utils/build-configuration.js
@@ -1,0 +1,19 @@
+/* eslint-env node */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const EmberBuildConfigEditor = require('ember-cli-build-config-editor');
+
+module.exports = function buildConfiguration() {
+  let emberCLIBuildPath = path.join(process.cwd(), 'ember-cli-build.js');
+  if (!fs.existsSync(emberCLIBuildPath)) {
+    return;
+  }
+
+  let source = fs.readFileSync(emberCLIBuildPath, 'utf-8');
+
+  let build = new EmberBuildConfigEditor(source);
+
+  return build.retrieve('ember-bootstrap');
+};

--- a/lib/utils/npm-installed-version.js
+++ b/lib/utils/npm-installed-version.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const findup = require('findup-sync');
+
+module.exports = function npmInstalledVersion(packageName) {
+  let requirePath = require.resolve(packageName);
+  if (!requirePath) {
+    return;
+  }
+  let pkgPath = findup('package.json', { cwd: requirePath });
+  if (!pkgPath) {
+    return;
+  }
+  let pkgJson = require(pkgPath);
+  return pkgJson.version;
+};

--- a/lib/utils/npm-installed-version.js
+++ b/lib/utils/npm-installed-version.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 'use strict';
 
 const findup = require('findup-sync');

--- a/lib/utils/npm-installed-version.js
+++ b/lib/utils/npm-installed-version.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const findup = require('findup-sync');

--- a/lib/utils/npm-version.js
+++ b/lib/utils/npm-version.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const path = require('path');

--- a/lib/utils/npm-version.js
+++ b/lib/utils/npm-version.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function npmVersion(packageName) {
+  let pkgJson = require(path.join(process.cwd(), 'package.json'));
+
+  if (pkgJson.devDependencies && pkgJson.devDependencies[packageName]) {
+    return pkgJson.devDependencies[packageName];
+  }
+
+  if (pkgJson.dependencies && pkgJson.dependencies[packageName]) {
+    return pkgJson.dependencies[packageName];
+  }
+};

--- a/lib/utils/npm-version.js
+++ b/lib/utils/npm-version.js
@@ -1,9 +1,10 @@
+/* eslint-env node */
 'use strict';
 
 const path = require('path');
 
-module.exports = function npmVersion(packageName) {
-  let pkgJson = require(path.join(process.cwd(), 'package.json'));
+module.exports = function npmVersion(projectRoot, packageName) {
+  let pkgJson = require(path.join(projectRoot, 'package.json'));
 
   if (pkgJson.devDependencies && pkgJson.devDependencies[packageName]) {
     return pkgJson.devDependencies[packageName];

--- a/node-tests/lint-tests.js
+++ b/node-tests/lint-tests.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const glob = require('glob').sync;
+const lint = require('mocha-eslint');
+
+let paths = glob('fastboot-tests/*')
+  .filter((path) => !(/fixtures/).test(path))
+  .concat([
+    'lib',
+    'node-tests',
+    'blueprints'
+  ]);
+
+lint(paths);

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ember-cli-htmlbars": "^1.0.10",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-wormhole": "^0.4.1",
+    "findup-sync": "^0.4.3",
     "fs-extra": "^2.0.0",
     "rsvp": "^3.3.3",
     "silent-error": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-source": "~2.12.0",
     "emberx-select": "^3.0.0",
     "eslint-plugin-ember-suave": "^1.0.0",
-    "glob": "^5.0.14",
+    "glob": "^7.1.1",
     "gulp": "^3.9.0",
     "gulp-conventional-changelog": "^1.1.0",
     "gulp-gh-pages": "^0.5.4",
@@ -66,6 +66,7 @@
     "loader.js": "^4.2.3",
     "merge-stream": "^1.0.1",
     "mocha": "2.5.3",
+    "mocha-eslint": "^3.0.1",
     "striptags": "^2.1.1"
   },
   "description": "Twitter Bootstrap components for Ember.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3739,6 +3739,13 @@ glimmer-engine@^0.21.2:
     simple-dom "^0.3.0"
     simple-html-tokenizer "^0.3.0"
 
+glob-all@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.1.0.tgz#8913ddfb5ee1ac7812656241b03d5217c64b02ab"
+  dependencies:
+    glob "^7.0.5"
+    yargs "~1.2.6"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -3813,7 +3820,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@~7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3833,7 +3840,7 @@ glob@^4.0.4, glob@^4.0.5, glob@^4.3.1:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^5.0.10, glob@^5.0.14, glob@^5.0.15, glob@^5.0.3:
+glob@^5.0.10, glob@^5.0.15, glob@^5.0.3:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -5392,6 +5399,10 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
@@ -5417,6 +5428,15 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+mocha-eslint@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mocha-eslint/-/mocha-eslint-3.0.1.tgz#ae72abc561cb289d2e6c143788ee182aca1a04db"
+  dependencies:
+    chalk "^1.1.0"
+    eslint "^3.0.0"
+    glob-all "^3.0.1"
+    replaceall "^0.1.6"
 
 mocha@2.5.3:
   version "2.5.3"
@@ -6335,6 +6355,10 @@ repeating@^2.0.0:
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replaceall@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/replaceall/-/replaceall-0.1.6.tgz#81d81ac7aeb72d7f5c4942adf2697a3220688d8e"
 
 request@2, request@^2.74.0, request@^2.79.0:
   version "2.81.0"
@@ -7767,6 +7791,12 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
+
+yargs@~1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.2.6.tgz#9c7b4a82fd5d595b2bf17ab6dcc43135432fe34b"
+  dependencies:
+    minimist "^0.1.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
The `ember bootstrap:info` command prints something like this, useful for github issues:

```
Bower packages:
bootstrap: n/a
Npm packages:
ember-cli: ^2.10.0 -> 2.10.0
bootstrap: ^4.0.0-alpha.6 -> 4.0.0-alpha.6
bootstrap-sass: ^3.3.7 -> 3.3.7
ember-cli-sass: ^6.1.1 -> 6.1.1
ember-cli-less: n/a
```

@srvance Would be cool if we could also print the e-b config from `ember-cli-build.js`. As this is not just JSON, it is not so easily parseable. Would `ember-cli-build-config-editor` be able to extract that information?