### PR TITLE
Fix BS4 navbar positioning.

### DIFF
--- a/addon/components/base/bs-navbar.js
+++ b/addon/components/base/bs-navbar.js
@@ -87,7 +87,8 @@ export default Ember.Component.extend(TypeClass, {
   fluid: true,
 
   /**
-   * Specifies the position classes for the navbar, currently supporting none, "fixed-top", "fixed-bottom", and "static-top".
+   * Specifies the position classes for the navbar, currently supporting none, "fixed-top", "fixed-bottom", and
+   * either "static-top" (BS3) or "sticky-top" (BS4).
    * See the [bootstrap docs](http://getbootstrap.com/components/#navbar-fixed-top) for details.
    *
    * @property position
@@ -99,13 +100,14 @@ export default Ember.Component.extend(TypeClass, {
 
   positionClass: Ember.computed('position', function() {
     let position = this.get('position');
-    let validPositions = ['fixed-top', 'fixed-bottom', 'static-top'];
+    let validPositions = this.get('_validPositions');
+    let positionPrefix = this.get('_positionPrefix');
 
     if (validPositions.indexOf(position) === -1) {
       return null;
     }
 
-    return `navbar-${position}`;
+    return `${positionPrefix}${position}`;
   }),
 
   actions: {

--- a/addon/components/bs3/bs-navbar.js
+++ b/addon/components/bs3/bs-navbar.js
@@ -1,1 +1,7 @@
-export { default } from 'ember-bootstrap/components/base/bs-navbar';
+import Navbar from 'ember-bootstrap/components/base/bs-navbar';
+
+export default Navbar.extend({
+  _validPositions: ['fixed-top', 'fixed-bottom', 'static-top'],
+
+  _positionPrefix: 'navbar-'
+});

--- a/addon/components/bs4/bs-navbar.js
+++ b/addon/components/bs4/bs-navbar.js
@@ -39,5 +39,9 @@ export default Navbar.extend({
     let backgroundColor = this.get('backgroundColor');
 
     return `bg-${backgroundColor}`;
-  })
+  }),
+
+  _validPositions: ['fixed-top', 'fixed-bottom', 'sticky-top'],
+
+  _positionPrefix: ''
 });

--- a/tests/helpers/bootstrap-test.js
+++ b/tests/helpers/bootstrap-test.js
@@ -51,4 +51,12 @@ export function placementClassFor(type, placement) {
   return versionDependent(placement, `${type}-${placement}`);
 }
 
+export function positionClassFor(position) {
+  return versionDependent(`navbar-${position}`, position);
+}
+
+export function positionStickyClass() {
+  return versionDependent('navbar-static-top', 'sticky-top');
+}
+
 export { test };

--- a/tests/integration/components/bs-navbar-test.js
+++ b/tests/integration/components/bs-navbar-test.js
@@ -1,5 +1,5 @@
 import { moduleForComponent } from 'ember-qunit';
-import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
+import { positionClassFor, positionStickyClass, test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('bs-navbar', 'Integration | Component | bs-navbar', {
@@ -133,31 +133,39 @@ testBS4('it exposes all the requisite contextual components', function(assert) {
 test('it nas no positional classes when position is not specified', function(assert) {
   this.render(hbs`{{bs-navbar}}`);
 
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-top'), 'it does not have navbar-fixed-top');
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-bottom'), 'it does not have navbar-fixed-bottom');
-  assert.notOk(this.$('nav').hasClass('navbar-static-top'), 'it does not have navbar-static-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-top')), 'it does not have position fixed-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-bottom')), 'it does not have position fixed-bottom');
+  assert.notOk(this.$('nav').hasClass(positionStickyClass()), `it does not have ${positionStickyClass()}`);
 });
 
 test('it handles fixed-top properly', function(assert) {
   this.render(hbs`{{bs-navbar position="fixed-top"}}`);
 
-  assert.ok(this.$('nav').hasClass('navbar-fixed-top'), 'it has navbar-fixed-top');
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-bottom'), 'it does not have navbar-fixed-bottom');
-  assert.notOk(this.$('nav').hasClass('navbar-static-top'), 'it does not have navbar-static-top');
+  assert.ok(this.$('nav').hasClass(positionClassFor('fixed-top')), 'it has position fixed-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-bottom')), 'it does not have position fixed-bottom');
+  assert.notOk(this.$('nav').hasClass(positionStickyClass()), `it does not have ${positionStickyClass()}`);
 });
 
 test('it handles fixed-bottom properly', function(assert) {
   this.render(hbs`{{bs-navbar position="fixed-bottom"}}`);
 
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-top'), 'it does not have navbar-fixed-top');
-  assert.ok(this.$('nav').hasClass('navbar-fixed-bottom'), 'it has navbar-fixed-bottom');
-  assert.notOk(this.$('nav').hasClass('navbar-static-top'), 'it does not have navbar-static-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-top')), 'it does not have position fixed-top');
+  assert.ok(this.$('nav').hasClass(positionClassFor('fixed-bottom')), 'it has position fixed-bottom');
+  assert.notOk(this.$('nav').hasClass(positionStickyClass()), `it does not have ${positionStickyClass()}`);
 });
 
-test('it handles static-top properly', function(assert) {
+testBS3('it handles static-top properly', function(assert) {
   this.render(hbs`{{bs-navbar position="static-top"}}`);
 
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-top'), 'it does not have navbar-fixed-top');
-  assert.notOk(this.$('nav').hasClass('navbar-fixed-bottom'), 'it does not have navbar-fixed-bottom');
-  assert.ok(this.$('nav').hasClass('navbar-static-top'), 'it has navbar-static-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-top')), 'it does not have position fixed-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-bottom')), 'it does not have position fixed-bottom');
+  assert.ok(this.$('nav').hasClass(positionStickyClass()), `it has ${positionStickyClass()}`);
+});
+
+testBS4('it handles sticky-top properly', function(assert) {
+  this.render(hbs`{{bs-navbar position="sticky-top"}}`);
+
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-top')), 'it does not have position fixed-top');
+  assert.notOk(this.$('nav').hasClass(positionClassFor('fixed-bottom')), 'it does not have position fixed-bottom');
+  assert.ok(this.$('nav').hasClass(positionStickyClass()), `it has ${positionStickyClass()}`);
 });


### PR DESCRIPTION
Use `fixed-top`, `fixed-bottom`, and `sticky-top` for BS4 instead of `navbar-fixed-top`, `navbar-fixed-bottom`, and `navbar-static-top` for navbar `position`.

Fixes #269.