### PR TITLE
Fix wrong config being added to `ember-cli-build.js` 

### DIFF
--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let bootstrapVersion = option.bootstrapVersion = parseInt(option.bootstrapVersion) || 3;
+    let bootstrapVersion = parseInt(option.bootstrapVersion) || 3;
     let preprocessor = option.preprocessor;
 
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
@@ -48,9 +48,9 @@ module.exports = {
     if (!preprocessor) {
       let dependencies = this.project.dependencies();
       if ('ember-cli-sass' in dependencies) {
-        preprocessor = option.preprocessor = 'sass';
+        preprocessor = 'sass';
       } else if ('ember-cli-less' in dependencies) {
-        preprocessor = option.preprocessor = 'less';
+        preprocessor = 'less';
       } else {
         preprocessor = 'none';
       }
@@ -61,13 +61,16 @@ module.exports = {
     }
 
     this.ui.writeLine(chalk.green(`Installing for Bootstrap ${bootstrapVersion} using preprocessor ${preprocessor}`));
+
+    this.bootstrapVersion = bootstrapVersion;
+    this.preprocessor = preprocessor;
   },
 
-  afterInstall(option) {
-    return this.adjustBootstrapDependencies(option)
-      .then(() => this.adjustPreprocessorDependencies(option))
-      .then(() => this.addPreprocessorStyleImport(option))
-      .then(() => this.addBuildConfiguration(option));
+  afterInstall() {
+    return this.adjustBootstrapDependencies()
+      .then(() => this.adjustPreprocessorDependencies())
+      .then(() => this.addPreprocessorStyleImport())
+      .then(() => this.addBuildConfiguration());
   },
 
   removePackageFromBowerJSON(dependency) {
@@ -88,9 +91,9 @@ module.exports = {
     });
   },
 
-  adjustBootstrapDependencies(option) {
-    let bootstrapVersion = option.bootstrapVersion;
-    let preprocessor = option.preprocessor;
+  adjustBootstrapDependencies() {
+    let bootstrapVersion = this.bootstrapVersion;
+    let preprocessor = this.preprocessor;
     let dependencies = this.project.dependencies();
     let bowerDependencies = this.project.bowerDependencies();
     let promises = [];
@@ -122,8 +125,8 @@ module.exports = {
     return rsvp.all(promises);
   },
 
-  adjustPreprocessorDependencies(option) {
-    let preprocessor = option.preprocessor;
+  adjustPreprocessorDependencies() {
+    let preprocessor = this.preprocessor;
     let dependencies = this.project.dependencies();
     let promises = [];
 
@@ -146,8 +149,8 @@ module.exports = {
     return rsvp.all(promises);
   },
 
-  addPreprocessorStyleImport(option) {
-    let preprocessor = option.preprocessor;
+  addPreprocessorStyleImport() {
+    let preprocessor = this.preprocessor;
     let importStatement = '\n@import "ember-bootstrap/bootstrap";\n';
 
     if (preprocessor === 'none') {
@@ -171,10 +174,10 @@ module.exports = {
     }
   },
 
-  addBuildConfiguration(option) {
+  addBuildConfiguration() {
     let file = 'ember-cli-build.js';
-    let bootstrapVersion = option.bootstrapVersion;
-    let preprocessor = option.preprocessor;
+    let bootstrapVersion = this.bootstrapVersion;
+    let preprocessor = this.preprocessor;
     let settings = {
       bootstrapVersion
     };

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -42,10 +42,11 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
         let args = ['ember-bootstrap'];
 
         return emberNew()
-          .then(() => emberGenerate(args, (file) => {
+          .then(() => emberGenerate(args))
+          .then(() => {
             expect(file('app/styles/app.scss')).to.not.exist;
             expect(file('app/styles/app.less')).to.not.exist;
-          }));
+          });
       });
 
       it('creates app.scss if not existing and ember-cli-sass is present', function() {
@@ -71,10 +72,11 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
             { name: 'ember-cli-sass' }
           ]))
           .then(() => createStyleFixture('app.scss'))
-          .then(() => emberGenerate(args, (file) => {
+          .then(() => emberGenerate(args))
+          .then(() => {
             expect(file('app/styles/app.scss')).to.contain('@import "ember-bootstrap/bootstrap";');
             expect(file('app/styles/app.less')).to.not.exist;
-          }));
+          });
       });
 
       it('creates app.less if not existing and ember-cli-less is present', function() {
@@ -117,10 +119,11 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
         let args = ['ember-bootstrap', '--preprocessor=none'];
 
         return emberNew()
-          .then(() => emberGenerate(args, (file) => {
+          .then(() => emberGenerate(args))
+          .then(() => {
             expect(file('app/styles/app.scss')).to.not.exist;
             expect(file('app/styles/app.less')).to.not.exist;
-          }));
+          });
       });
 
       it('creates app.scss if not existing and --preprocessor=sass', function() {
@@ -140,10 +143,11 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
         return emberNew()
           .then(() => createStyleFixture('app.scss'))
-          .then(() => emberGenerate(args, (file) => {
+          .then(() => emberGenerate(args))
+          .then(() => {
             expect(file('app/styles/app.scss')).to.contain('@import "ember-bootstrap/bootstrap";');
             expect(file('app/styles/app.less')).to.not.exist;
-          }));
+          });
       });
 
       it('creates app.less if not existing and --preprocessor=less', function() {


### PR DESCRIPTION
…when no preprocessor was used

@srvance `option.preprocessor` was checked for being `'none'` at some places, while it was just `undefined`. This lead to `importBootstrapCSS` being written as `false` when no preprocessor was used. Unfortunately I broke some blueprint tests when refactoring things, so they did not catch this.

Fixed this, and will merge and release once tests have passed, so hopefully not too many users are affected by this...