### PR TITLE
Use configured `bootstrapVersion` if present

### DIFF
--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -24,7 +24,7 @@ module.exports = {
   description: 'Configure ember-bootstrap',
 
   availableOptions: [
-    { name: 'bootstrap-version', type: Number, default: 3, aliases: ['bootstrap', 'bv'] },
+    { name: 'bootstrap-version', type: Number, aliases: ['bootstrap', 'bv'] },
     { name: 'preprocessor', type: String, aliases: ['pp'] }
   ],
 
@@ -34,7 +34,8 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let bootstrapVersion = parseInt(option.bootstrapVersion) || 3;
+    let configuredBootstrapVersion = this.retrieveBootstrapVersion();
+    let bootstrapVersion = parseInt(option.bootstrapVersion) || configuredBootstrapVersion || 3;
     let preprocessor = option.preprocessor;
 
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
@@ -202,5 +203,15 @@ module.exports = {
       let settingsString = JSON.stringify(settings);
       this.ui.writeLine(chalk.red(`Configuration file could not be edited. Manually update your ember-cli-build.js to include '${this.name}': ${settingsString}`));
     }
+  },
+
+  retrieveBootstrapVersion() {
+    let file = 'ember-cli-build.js';
+
+    let source = fs.readFileSync(file);
+    let build = new BuildConfigEditor(source);
+    let config = build.retrieve(this.name);
+
+    return config && config.bootstrapVersion;
   }
 };

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -34,8 +34,7 @@ module.exports = {
   },
 
   beforeInstall(option) {
-    let configuredBootstrapVersion = this.retrieveBootstrapVersion();
-    let bootstrapVersion = parseInt(option.bootstrapVersion) || configuredBootstrapVersion || 3;
+    let bootstrapVersion = parseInt(option.bootstrapVersion, 10) || this.retrieveBootstrapVersion() || 3;
     let preprocessor = option.preprocessor;
 
     if (bootstrapVersion !== 3 && bootstrapVersion !== 4) {
@@ -212,6 +211,6 @@ module.exports = {
     let build = new BuildConfigEditor(source);
     let config = build.retrieve(this.name);
 
-    return config && config.bootstrapVersion;
+    return config && parseInt(config.bootstrapVersion, 10);
   }
 };

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -12,6 +12,18 @@ const scenarios = [
   },
   {
     installed: {
+      config: {
+        bootstrapVersion: 4
+      }
+    },
+    dependencies: {
+      npm: {
+        bootstrap: bs4Regex
+      }
+    }
+  },
+  {
+    installed: {
       npm: ['ember-cli-less']
     },
     dependencies: {
@@ -341,7 +353,7 @@ const scenarios = [
     },
     dependencies: {
       npm: {
-        bootstrap: bs3Regex,
+        bootstrap: bs3Regex
       },
       addon: {
         'ember-cli-less': true,
@@ -568,7 +580,7 @@ const scenarios = [
     },
     dependencies: {
       npm: {
-        bootstrap: bs4Regex,
+        bootstrap: bs4Regex
       },
       addon: {
         'ember-cli-less': null,

--- a/tests/dummy/app/templates/getting-started/assets.hbs
+++ b/tests/dummy/app/templates/getting-started/assets.hbs
@@ -10,10 +10,10 @@
 <pre class="highlight">ember generate ember-bootstrap --bootstrap-version=4 --preprocessor=sass
 </pre>
 
-<p>The <code>--bootstrap-version</code> can be "3" or "4" and defaults to "3" if the option is omitted. The
-    <code>--preprocessor</code> can be "none", "less", or "sass". The blueprint will use the currently installed
-    preprocessor as its cue if this option is omitted. We explicitly support ember-cli-less and ember-cli-sass. You will
-    need to install and configure other preprocessors yourself.</p>
+<p>The <code>--bootstrap-version</code> can be "3" or "4" and if omitted, defaults to the currently configured version,
+    if present, or "3". The <code>--preprocessor</code> can be "none", "less", or "sass". The blueprint will use the
+    currently installed preprocessor as its cue if this option is omitted. We explicitly support ember-cli-less and
+    ember-cli-sass. You will need to install and configure other preprocessors yourself.</p>
 
 <p>The default blueprint does the following:</p>
 


### PR DESCRIPTION
Remove the `--bootstrap-version` option default because there is no way to distinguish between an omitted and defaulted value. Use the configured `bootstrapVersion` as the first fallback if the `--bootstrap-version` option is not supplied and fall back to "3" as a last resort.

Fixes #276