### PR TITLE
Blueprint honor existing config

### DIFF
--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -196,7 +196,7 @@ module.exports = {
     if (preprocessor !== 'none') {
       settings.importBootstrapCSS = false;
     } else if (config.hasOwnProperty('importBootstrapCSS')) {
-      settings.importBootstrapCSS = config. importBootstrapCSS;
+      settings.importBootstrapCSS = config.importBootstrapCSS;
     } else {
       settings.importBootstrapCSS = true;
     }

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -33,6 +33,8 @@ module.exports = {
   normalizeEntityName() {
   },
 
+  existingConfiguration: null,
+
   beforeInstall(option) {
     let bootstrapVersion = parseInt(option.bootstrapVersion, 10) || this.retrieveBootstrapVersion() || 3;
     let preprocessor = option.preprocessor;
@@ -178,13 +180,24 @@ module.exports = {
     let file = 'ember-cli-build.js';
     let bootstrapVersion = this.bootstrapVersion;
     let preprocessor = this.preprocessor;
+    let config = this.retrieveExistingConfiguration();
     let settings = {
       bootstrapVersion
     };
 
-    settings.importBootstrapFont = (bootstrapVersion === 3);
+    if (bootstrapVersion === 4) {
+      settings.importBootstrapFont = false;
+    } else if (config.hasOwnProperty('importBootstrapFont')) {
+      settings.importBootstrapFont = config.importBootstrapFont;
+    } else {
+      settings.importBootstrapFont = true;
+    }
 
-    settings.importBootstrapCSS = (preprocessor === 'none');
+    if (config.hasOwnProperty('importBootstrapCSS')) {
+      settings.importBootstrapFont = config.importBootstrapFont;
+    } else {
+      settings.importBootstrapCSS = (preprocessor === 'none');
+    }
 
     if (!fs.existsSync(file)) {
       this.ui.writeLine(chalk.red(`Could not find ${file} to modify.`));
@@ -204,13 +217,23 @@ module.exports = {
     }
   },
 
-  retrieveBootstrapVersion() {
+  retrieveExistingConfiguration() {
+    if (this.existingConfiguration) {
+      return this.existingConfiguration;
+    }
+
     let file = 'ember-cli-build.js';
 
     let source = fs.readFileSync(file);
     let build = new BuildConfigEditor(source);
-    let config = build.retrieve(this.name);
+    this.existingConfiguration = build.retrieve(this.name) || {};
+    return this.existingConfiguration;
+  },
 
-    return config && parseInt(config.bootstrapVersion, 10);
+  retrieveBootstrapVersion() {
+
+    let config = this.retrieveExistingConfiguration();
+
+    return config.bootstrapVersion && parseInt(config.bootstrapVersion, 10);
   }
 };

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -194,7 +194,7 @@ module.exports = {
     }
 
     if (config.hasOwnProperty('importBootstrapCSS')) {
-      settings.importBootstrapFont = config.importBootstrapFont;
+      settings.importBootstrapCSS = config.importBootstrapCSS;
     } else {
       settings.importBootstrapCSS = (preprocessor === 'none');
     }

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -20,6 +20,10 @@ const scenarios = [
       npm: {
         bootstrap: bs4Regex
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapFont: false
     }
   },
   {
@@ -30,6 +34,9 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3
     }
   },
   {

--- a/node-tests/blueprints/dependencyScenarios.js
+++ b/node-tests/blueprints/dependencyScenarios.js
@@ -8,6 +8,29 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
+    }
+  },
+  { // Existing settings are preserved if they don't need to be overridden
+    installed: {
+      config: {
+        importBootstrapCSS: false,
+        importBootstrapFont: false
+      }
+    },
+    dependencies: {
+      npm: {
+        bootstrap: bs3Regex
+      }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -23,6 +46,7 @@ const scenarios = [
     },
     config: {
       bootstrapVersion: 4,
+      importBootstrapCSS: true,
       importBootstrapFont: false
     }
   },
@@ -36,7 +60,9 @@ const scenarios = [
       }
     },
     config: {
-      bootstrapVersion: 3
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -47,6 +73,11 @@ const scenarios = [
       npm: {
         'bootstrap-sass': bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -58,6 +89,11 @@ const scenarios = [
         bootstrap: null,
         'bootstrap-sass': bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -68,6 +104,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -82,6 +123,11 @@ const scenarios = [
         bootstrap: bs3Regex,
         'bootstrap-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -99,6 +145,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -115,6 +166,11 @@ const scenarios = [
       addon: {
         'ember-cli-less': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -128,6 +184,11 @@ const scenarios = [
       addon: {
         'ember-cli-less': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -141,6 +202,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -159,6 +225,11 @@ const scenarios = [
         'ember-cli-less': true,
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -172,6 +243,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -189,6 +265,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -202,6 +283,11 @@ const scenarios = [
       npm: {
         'bootstrap-sass': bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -219,6 +305,11 @@ const scenarios = [
         'ember-cli-less': null,
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -237,6 +328,11 @@ const scenarios = [
         'ember-cli-less': null,
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
 
@@ -249,6 +345,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -262,6 +363,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -275,6 +381,11 @@ const scenarios = [
       npm: {
         'bootstrap-sass': bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -286,6 +397,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -303,6 +419,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -320,6 +441,11 @@ const scenarios = [
       addon: {
         'ember-cli-less': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: true,
+      importBootstrapFont: true
     }
   },
   {
@@ -334,6 +460,11 @@ const scenarios = [
       addon: {
         'ember-cli-less': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -348,6 +479,11 @@ const scenarios = [
       npm: {
         bootstrap: bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -366,6 +502,11 @@ const scenarios = [
         'ember-cli-less': true,
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -380,6 +521,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -394,6 +540,11 @@ const scenarios = [
       npm: {
         'bootstrap-sass': bs3Regex
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
   {
@@ -412,6 +563,11 @@ const scenarios = [
         'ember-cli-less': null,
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 3,
+      importBootstrapCSS: false,
+      importBootstrapFont: true
     }
   },
 
@@ -424,6 +580,11 @@ const scenarios = [
       npm: {
         bootstrap: bs4Regex
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: true,
+      importBootstrapFont: false
     }
   },
   {
@@ -437,6 +598,11 @@ const scenarios = [
       npm: {
         bootstrap: bs4Regex
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -451,6 +617,11 @@ const scenarios = [
         bootstrap: bs4Regex,
         'bootstrap-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -462,6 +633,11 @@ const scenarios = [
       npm: {
         bootstrap: bs4Regex
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: true,
+      importBootstrapFont: false
     }
   },
   {
@@ -479,6 +655,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: true,
+      importBootstrapFont: false
     }
   },
   {
@@ -497,6 +678,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: true,
+      importBootstrapFont: false
     }
   },
   {
@@ -514,6 +700,11 @@ const scenarios = [
       addon: {
         'ember-cli-less': null
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: true,
+      importBootstrapFont: false
     }
   },
   {
@@ -528,6 +719,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -546,6 +742,11 @@ const scenarios = [
       addon: {
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -560,6 +761,11 @@ const scenarios = [
       npm: {
         bootstrap: bs4Regex
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -575,6 +781,11 @@ const scenarios = [
         bootstrap: bs4Regex,
         'bootstrap-sass': null
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   },
   {
@@ -593,6 +804,11 @@ const scenarios = [
         'ember-cli-less': null,
         'ember-cli-sass': true
       }
+    },
+    config: {
+      bootstrapVersion: 4,
+      importBootstrapCSS: false,
+      importBootstrapFont: false
     }
   }
 

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -281,8 +281,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
       expect(config).to.exist;
       Object.keys(expectedConfig).forEach((key) => {
-        expect(config[key], key).to.exist;
-        expect(config[key], key).to.equal(expectedConfig[key]);
+        expect(config, key).to.have.property(key, expectedConfig[key]);
       });
     }
 

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -182,7 +182,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
   });
 
-  describe('install dependencies', function() {
+  describe('install dependencies and configuration', function() {
 
     let Blueprint = require('ember-cli/lib/models/blueprint');
     let origTaskFor = Blueprint.prototype.taskFor;
@@ -195,6 +195,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
       npm: [],
       bower: []
     };
+    let buildFile = 'ember-cli-build.js';
 
     before(function() {
       Blueprint.prototype.taskFor = function(taskName) {
@@ -202,7 +203,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
         if (match) {
           let type = match[1];
           return {
-            run: function(options) {
+            run(options) {
               let packages = options.packages || [];
               installed[type] = installed[type].concat(packages);
               return Promise.resolve();
@@ -212,7 +213,7 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
 
         if (taskName === 'npm-uninstall') {
           return {
-            run: function(options) {
+            run(options) {
               let packages = options.packages || [];
               uninstalled.npm = uninstalled.npm.concat(packages);
               return Promise.resolve();
@@ -263,11 +264,26 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
     }
 
     function editConfiguration(config) {
-      let buildFile = 'ember-cli-build.js';
       let source = fs.readFileSync(buildFile);
       let editor = new BuildConfigEditor(source);
       editor.edit('ember-bootstrap', config);
       fs.writeFileSync(buildFile, editor.code());
+    }
+
+    function checkConfiguration(expectedConfig) {
+      if (!expectedConfig) {
+        return; // No expectation means nothing to check
+      }
+
+      let source = fs.readFileSync(buildFile);
+      let editor = new BuildConfigEditor(source);
+      let config = editor.retrieve('ember-bootstrap');
+
+      expect(config).to.exist;
+      Object.keys(expectedConfig).forEach((key) => {
+        expect(config[key], key).to.exist;
+        expect(config[key], key).to.equal(expectedConfig[key]);
+      });
     }
 
     scenarios.forEach(function(scenario) {
@@ -277,8 +293,9 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
       let bootstrapVersion = options.bootstrapVersion;
       let installed = scenario.installed || {};
       let npmInstalled = installed.npm || [];
-      let config = installed.config;
-      let configuredBootstrapVersion = config && config.bootstrapVersion;
+      let installedConfig = installed.config;
+      let configuredBootstrapVersion = installedConfig && installedConfig.bootstrapVersion;
+      let config = scenario.config;
 
       if (preprocessor) {
         args.push(`--preprocessor=${preprocessor}`);
@@ -290,12 +307,12 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
       let preInstalledText = npmInstalled.length > 0 ? `, preInstalled: ${npmInstalled.join(', ')}` : '';
       let configuredVersionText = configuredBootstrapVersion ? `, configured version: ${configuredBootstrapVersion}` : '';
 
-      it(`installs dependencies for ember g ember-bootstrap ${args.join(' ')}${preInstalledText}${configuredVersionText}`, function() {
+      it(`installs dependencies and config for ember g ember-bootstrap ${args.join(' ')}${preInstalledText}${configuredVersionText}`, function() {
         args = ['ember-bootstrap'].concat(args);
 
         return emberNew()
           .then(() => modifyPackages(npmInstalled.map((pkg) => ({ name: pkg, dev: true }))))
-          .then(() => editConfiguration(config))
+          .then(() => editConfiguration(installedConfig))
           .then(() => emberGenerate(args))
           .then(() => {
             for (let pkg in scenario.dependencies.bower) {
@@ -310,7 +327,8 @@ describe('Acceptance: ember generate ember-bootstrap', function() {
               checkPackage('addon', pkg, scenario.dependencies.addon[pkg]);
             }
 
-          });
+          })
+          .then(() => checkConfiguration(config));
       });
     });
   });


### PR DESCRIPTION
When running the blueprint, preserve existing configuration settings if they don't need to be overridden by the target configuration.

Fixes #282 