### PR TITLE
form element yields control component for easier customization

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -16,13 +16,9 @@ const {
 
   assert,
   typeOf,
-  A
+  A,
+  getOwner
 } = Ember;
-
-const nonTextFieldControlTypes = A([
-  'checkbox',
-  'textarea'
-]);
 
 const nonDefaultLayouts = A([
   'checkbox'
@@ -122,13 +118,14 @@ const nonDefaultLayouts = A([
 
  ```hbs
  {{#bs-form formLayout="horizontal" model=this action="submit" as |form|}}
- {{#form.element label="Select-2" property="gender" useIcons=false as |el|}}
- {{select-2 id=el.id content=genderChoices optionLabelPath="label" value=el.value searchEnabled=false}}
- {{/form.element}}
+   {{#form.element label="Select-2" property="gender" useIcons=false as |el|}}
+     {{select-2 id=el.id content=genderChoices optionLabelPath="label" value=el.value searchEnabled=false}}
+   {{/form.element}}
  {{/bs-form}}
  ```
 
  The component yields a hash with the following properties:
+ * `control`: the component that would be used for rendering the form control based on the given `controlType`
  * `id`: id to be used for the form control, so it matches the labels `for` attribute
  * `value`: the value of the form element
  * `validation`: the validation state of the element, `null` if no validation is to be shown, otherwise 'success', 'error' or 'warning'
@@ -609,9 +606,7 @@ export default FormGroup.extend({
    * @readonly
    * @public
    */
-  useIcons: computed('controlType', function() {
-    return !nonTextFieldControlTypes.includes(this.get('controlType'));
-  }),
+  useIcons: computed.equal('controlComponent', 'bs-form/element/control/input'),
 
   /**
    * The form layout used for the markup generation (see http://getbootstrap.com/css/#forms):
@@ -674,11 +669,13 @@ export default FormGroup.extend({
    */
   controlComponent: computed('controlType', function() {
     let controlType = this.get('controlType');
-    if (!nonTextFieldControlTypes.includes(controlType)) {
-      controlType = 'input';
+    let componentName = `bs-form/element/control/${controlType}`;
+
+    if (getOwner(this).hasRegistration(`component:${componentName}`)) {
+      return componentName;
     }
 
-    return `bs-form/element/control/${controlType}`;
+    return 'bs-form/element/control/input';
   }),
 
   /**
@@ -754,7 +751,7 @@ export default FormGroup.extend({
    * @param {String} property The value of `property`
    * @public
    */
-  onChange(value, model, property) {}, // eslint-disable-line no-unused-vars
+  onChange() {},
 
   init() {
     this._super(...arguments);

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -117,7 +117,7 @@ const nonDefaultLayouts = A([
  (from the [ember-select-2 addon](https://istefo.github.io/ember-select-2)):
 
  ```hbs
- {{#bs-form formLayout="horizontal" model=this action="submit" as |form|}}
+ {{#bs-form model=this onSubmit=(action "submit") as |form|}}
    {{#form.element label="Select-2" property="gender" useIcons=false as |el|}}
      {{select-2 id=el.id content=genderChoices optionLabelPath="label" value=el.value searchEnabled=false}}
    {{/form.element}}
@@ -132,6 +132,17 @@ const nonDefaultLayouts = A([
 
  If your custom control does not render an input element, you should set `useIcons` to `false` since bootstrap only supports
  feedback icons with textual `<input class="form-control">` elements.
+
+ If you just want to customize the existing control component, you can use the aforementioned yielded `control` component
+ to customize that existing component:
+
+ ```hbs
+ {{#bs-form model=this onSubmit=(action "submit") as |form|}}
+   {{#form.element label="Email" placeholder="Email" property="email" as |el|}}
+     {{el.control class="input-lg"}}
+   {{/form.element}}
+ {{/bs-form}}
+ ```
 
  ### HTML attributes
 

--- a/addon/templates/components/common/bs-form/element.hbs
+++ b/addon/templates/components/common/bs-form/element.hbs
@@ -16,20 +16,13 @@
     formElementId=formElementId
   )
 }}
-  {{#if hasBlock}}
-    {{yield
-      (hash
-        value=value
-        id=formElementId
-        validation=validation
-      )
-    }}
-  {{else}}
-    {{component controlComponent
+  {{#with
+    (component controlComponent
       value=value
       id=formElementId
       name=name
       type=controlType
+      label=label
       placeholder=placeholder
       autofocus=autofocus
       disabled=disabled
@@ -56,6 +49,18 @@
       title=title
       onChange=(action "change")
       validationType=_validationType
-    }}
-  {{/if}}
+  ) as |control|}}
+    {{#if hasBlock}}
+      {{yield
+        (hash
+          value=value
+          id=formElementId
+          validation=validation
+          control=control
+        )
+      }}
+    {{else}}
+      {{component control}}
+    {{/if}}
+  {{/with}}
 {{/component}}

--- a/tests/dummy/app/templates/demo/forms.hbs
+++ b/tests/dummy/app/templates/demo/forms.hbs
@@ -86,14 +86,14 @@ the original one in tests. -bs-form contains the (copy pasted) validation suppor
 
 <h2>Custom Controls</h2>
 
-<p>Use the form element in block form to add your custom controls.</p>
+<p>Use the form element in block form to add your custom controls:</p>
 
 <div class="bs-example">
   <!-- BEGIN-SNIPPET form-custom -->
   {{#bs-form model=this onSubmit=(action "submit") as |form|}}
-    {{#form.element label="Email" placeholder="Email" property="username" as |el|}}
+    {{#form.element label="Email" placeholder="Email" property="email" as |el|}}
       <div class="input-group">
-        <input value={{el.value}} class="form-control" oninput={{action (mut el.value) value="target.value"}} onchange={{action (mut el.value) value="target.value"}} id={{el.id}} type="text">
+        <input value={{el.value}} class="form-control" placeholder="Email" oninput={{action (mut el.value) value="target.value"}} onchange={{action (mut el.value) value="target.value"}} id={{el.id}} type="text">
         <span class="input-group-addon">@example.com</span>
       </div>
     {{/form.element}}
@@ -103,4 +103,20 @@ the original one in tests. -bs-form contains the (copy pasted) validation suppor
 </div>
 <div class="highlight">
   {{code-snippet name="form-custom.hbs"}}
+</div>
+
+<p>You can also just customize the existing control component:</p>
+
+<div class="bs-example">
+  <!-- BEGIN-SNIPPET form-customized -->
+  {{#bs-form model=this onSubmit=(action "submit") as |form|}}
+    {{#form.element label="Email" placeholder="Email" property="email" as |el|}}
+      {{el.control class="input-lg"}}
+    {{/form.element}}
+    {{bs-button defaultText="Submit" type="primary" buttonType="submit"}}
+  {{/bs-form}}
+  <!-- END-SNIPPET -->
+</div>
+<div class="highlight">
+  {{code-snippet name="form-customized.hbs"}}
 </div>

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -213,6 +213,7 @@ test('Custom controls are supported', function(assert) {
         <div id="value">{{el.value}}</div>
         <div id="id">{{el.id}}</div>
         <div id="validation">{{el.validation}}</div>
+        <div id="control">{{el.control}}</div>
       {{/form.element}}
     {{/bs-form}}
   `);
@@ -221,6 +222,7 @@ test('Custom controls are supported', function(assert) {
   assert.equal(this.$('#value').text().trim(), 'male', 'value is yielded to block template');
   assert.equal(this.$('#id').text().trim(), `${this.$('.form-group').attr('id')}-field`, 'id is yielded to block template');
   assert.equal(this.$('#validation').text().trim(), 'success');
+  assert.equal(this.$('#control input[type=text]').length, 1, 'control component is yielded');
 });
 
 test('supported input attributes propagate', function(assert) {
@@ -572,4 +574,14 @@ test('events enabling validation rendering are configurable per `showValidationO
     this.$('.form-group').hasClass(validationErrorClass()),
     'events present in `showValidationOn` trigger validation'
   );
+});
+
+test('it uses custom control component when registered in DI container', function(assert) {
+  this.register('component:bs-form/element/control/foo', Ember.Component.extend({
+    layout: hbs`<div id="foo"></div>`
+  }));
+  this.render(hbs`
+      {{bs-form/element controlType="foo"}}
+  `);
+  assert.equal(this.$('#foo').length, 1, 'Custom control is used');
 });


### PR DESCRIPTION
Relates partly to #249, and should allow an easy solution to #243.

Also removes the hardcoding of the checkbox and textarea controls. Instead it uses a more dynamic and extensible approach, looking up the control component on the DI container, and uses that if available (otherwise plain `<input>`). So if a `bs-form/element/control/foo` component exists, it would be used for a `{{form.element controlType="foo"}}` element.

Still needs some better documentation.