### PR TITLE
Clarify docs re `bootstrap.js` for newcomers

### DIFF
--- a/tests/dummy/app/templates/getting-started/assets.hbs
+++ b/tests/dummy/app/templates/getting-started/assets.hbs
@@ -3,13 +3,13 @@
 
 <p>ember-bootstrap uses the Bootstrap CSS classes while replacing the behaviors from the components Bootstrap implements
     in <code>bootstrap.js</code>, such as toggle, navbar, modal, etc., with equivalent, CSS class-compatible
-    equivalents.</p>
+    native Ember components.</p>
 
 <p>If you are not using a preprocessor, ember-bootstrap will import the static CSS files. If you are using a preprocessor
     like LESS or SASS, ember-bootstrap imports the preprocessor-ready versions of the styles.</p>
 
 <p>ember-bootstrap specifically excludes `bootstrap.js`. The jQuery and Ember ways of control flow and animation sometimes
-    don't play well together, causing unpredictable results. This is the entire motivation behind ember-bootstrap.</p>
+    don't play well together, causing unpredictable results. This is the main motivation behind ember-bootstrap.</p>
 
 <h1 id="addon-options">Importing assets</h1>
 

--- a/tests/dummy/app/templates/getting-started/assets.hbs
+++ b/tests/dummy/app/templates/getting-started/assets.hbs
@@ -1,4 +1,16 @@
 {{! template-lint-disable block-indentation }}
+<h1 id="included-assets">Included Assets</h1>
+
+<p>ember-bootstrap uses the Bootstrap CSS classes while replacing the behaviors from the components Bootstrap implements
+    in <code>bootstrap.js</code>, such as toggle, navbar, modal, etc., with equivalent, CSS class-compatible
+    equivalents.</p>
+
+<p>If you are not using a preprocessor, ember-bootstrap will import the static CSS files. If you are using a preprocessor
+    like LESS or SASS, ember-bootstrap imports the preprocessor-ready versions of the styles.</p>
+
+<p>ember-bootstrap specifically excludes `bootstrap.js`. The jQuery and Ember ways of control flow and animation sometimes
+    don't play well together, causing unpredictable results. This is the entire motivation behind ember-bootstrap.</p>
+
 <h1 id="addon-options">Importing assets</h1>
 
 <h2 id="configuration-with-blueprint">Configuration using the default blueprint</h2>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -10,8 +10,8 @@
       </p>
 
       <p>
-          Provides a collection of native Ember {{#link-to "demo"}}components{{/link-to}} that mimic the original
-          Bootstrap plugins and components in an ember friendly way, replacing the need for <code>bootstrap.js</code>.
+        Provides a collection of native Ember {{#link-to "demo"}}components{{/link-to}} that mimic the original
+        Bootstrap plugins and components in an ember friendly way, replacing the need for <code>bootstrap.js</code>.
       </p>
     </div>
   </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -9,7 +9,10 @@
         <a href="http://www.emberjs.com"></a>Ember.js applications.
       </p>
 
-      <p>Provides a collection of native Ember {{#link-to "demo"}}components{{/link-to}} that mimic the original Bootstrap plugins and components in an ember friendly way.</p>
+      <p>
+          Provides a collection of native Ember {{#link-to "demo"}}components{{/link-to}} that mimic the original
+          Bootstrap plugins and components in an ember friendly way, replacing the need for <code>bootstrap.js</code>.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
Fixes #330.

Improve the documentation to make it clearer to newcomers that `bootstrap.js` is unnecessary, is not included, and can be harmful.