### PR TITLE
Expose Navbar collapse property and actions

### DIFF
--- a/addon/templates/components/bs3/bs-navbar.hbs
+++ b/addon/templates/components/bs3/bs-navbar.hbs
@@ -1,9 +1,11 @@
 <div class={{if fluid "container-fluid" "container"}}>
   {{yield
     (hash
-      toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=collapsed)
-      content=(component 'bs-navbar/content' collapsed=collapsed)
+      toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=_collapsed)
+      content=(component 'bs-navbar/content' collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
       nav=(component 'bs-navbar/nav')
+      collapse=(action "collapse")
+      expand=(action "expand")
     )
   }}
 </div>

--- a/addon/templates/components/bs4/bs-navbar.hbs
+++ b/addon/templates/components/bs4/bs-navbar.hbs
@@ -1,18 +1,22 @@
 {{#if fluid}}
   {{yield
     (hash
-      toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=collapsed)
-      content=(component 'bs-navbar/content' collapsed=collapsed)
+      toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=_collapsed)
+      content=(component 'bs-navbar/content' collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
       nav=(component 'bs-navbar/nav')
+      collapse=(action "collapse")
+      expand=(action "expand")
     )
   }}
 {{else}}
   <div class="container">
     {{yield
       (hash
-        toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=collapsed)
-        content=(component 'bs-navbar/content' collapsed=collapsed)
+        toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=_collapsed)
+        content=(component 'bs-navbar/content' collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
         nav=(component 'bs-navbar/nav')
+        collapse=(action "collapse")
+        expand=(action "expand")
       )
     }}
   </div>

--- a/tests/integration/components/bs-navbar/toggle-test.js
+++ b/tests/integration/components/bs-navbar/toggle-test.js
@@ -11,30 +11,12 @@ testBS3('it renders inline usage', function(assert) {
   this.render(hbs`{{bs-navbar/toggle}}`);
 
   assert.equal(find('*').textContent.trim(), 'Toggle navigation');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#bs-navbar/toggle}}
-      template block text
-    {{/bs-navbar/toggle}}
-  `);
-
-  assert.equal(find('*').textContent.trim(), 'template block text');
 });
 
 testBS4('it renders inline usage', function(assert) {
   this.render(hbs`{{bs-navbar/toggle}}`);
 
   assert.ok(find('.navbar-toggler > span').classList.contains('navbar-toggler-icon'));
-
-  // Template block usage:
-  this.render(hbs`
-    {{#bs-navbar/toggle}}
-      template block text
-    {{/bs-navbar/toggle}}
-  `);
-
-  assert.equal(find('*').textContent.trim(), 'template block text');
 });
 
 test('it renders block usage', function(assert) {


### PR DESCRIPTION
Makes `collapsed` property public, call `onCollapse`/`onCollapsed` and `onExpand`/`onExpanded` actions. Allows for more flexible customization, while the existing default behavior stays in place. Provides some primitives and a first step for a solution for #317 