### PR TITLE
Ensure component is not destroyed before setting textState

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -259,7 +259,7 @@ export default Ember.Component.extend(TypeClass, SizeClass, {
     let action = this.get('onClick');
     if (action !== null) {
       let promise = (action)(this.get('value'));
-      if (promise && typeof promise.then === 'function') {
+      if (promise && typeof promise.then === 'function' && !this.get('isDestroyed')) {
         this.set('textState', 'pending');
         promise.then(() => {
           if (!this.get('isDestroyed')) {


### PR DESCRIPTION
I have been getting this error when removing a button immediately after it is clicked

`Assertion Failed: calling set on destroyed object: <lineup-ninja@component:bs-button::ember2411>.textState = pending`

This PR adds an additional check that the component is not destroyed before setting textState