### PR TITLE
Make dropdowns BS4 compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ testem.log
 .idea
 *.iml
 .publish
+
+# ember-try
+/package.json.ember-try
+/.node_modules.ember-try/

--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -18,14 +18,19 @@ const {
  * [Components.DropdownMenu](Components.DropdownMenu.html)
    * [Components.DropdownMenuItem](Components.DropdownMenuItem.html)
    * [Components.DropdownMenuDivider](Components.DropdownMenuDivider.html)
+   * [Components.DropdownMenuLinkTo](Components.DropdownMenuLinkTo.html)
 
  ```hbs
  {{#bs-dropdown as |dd|}}
    {{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}
    {{#dd.menu as |ddm|}}
-     {{#ddm.item}}{{#link-to "index"}}Something{{/link-to}}{{/ddm.item}}
+     {{#ddm.item}}
+       {{#ddm.link-to "index"}}Something{{/ddm.link-to}}
+     {{/ddm.item}}
      {{ddm.divider}}
-     {{#ddm.item}}{{#link-to "index"}}Something different{{/link-to}}{{/ddm.item}}
+     {{#ddm.item}}
+       {{#ddm.link-to "index"}}Something different{{/ddm.link-to}}
+     {{/ddm.item}}
    {{/dd.menu}}
  {{/bs-dropdown}}
  ```
@@ -43,8 +48,8 @@ const {
  {{#bs-dropdown as |dd|}}
    {{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}
    {{#dd.menu as |ddm|}}
-       {{#ddm.item}}{{#link-to "index"}}Something{{/link-to}}{{/ddm.item}}
-       {{#ddm.item}}{{#link-to "index"}}Something different{{/link-to}}{{/ddm.item}}
+       {{#ddm.item}}{{#ddm.link-to "index"}}Something{{/ddm.link-to}}{{/ddm.item}}
+       {{#ddm.item}}{{#ddm.link-to "index"}}Something different{{/ddm.link-to}}{{/ddm.item}}
      {{/dd.menu}}
  {{/bs-dropdown}}
  ```
@@ -61,8 +66,8 @@ const {
    {{#bs-button}}Dropdown{{/bs-button}}
    {{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}
    {{#dd.menu as |ddm|}}
-     {{#ddm.item}}{{#link-to "index"}}Something{{/link-to}}{{/ddm.item}}
-     {{#ddm.item}}{{#link-to "index"}}Something different{{/link-to}}{{/ddm.item}}
+     {{#ddm.item}}{{#ddm.link-to "index"}}Something{{/ddm.link-to}}{{/ddm.item}}
+     {{#ddm.item}}{{#ddm.link-to "index"}}Something different{{/ddm.link-to}}{{/ddm.item}}
    {{/dd.menu}}
    {{/bs-dropdown}}
  ```
@@ -85,6 +90,12 @@ const {
 
  If you use the [dropdown divider](Component.DropdownMenuDivider), you don't have to worry
  about differences in the markup between versions.
+
+ Be sure to use the [dropdown menu link-to](Component.DropdownMenuLinkTo), for in-application
+ links as dropdown menu items. This is essential for proper styling regardless of Bootstrap
+ version and will also provide automatic `active` highlighting on dropdown menu items. If you
+ wish to have a dropdown menu item refer to an external link, be sure to apply the `dropdown-item`
+ class to the `<a>` tag for Bootstrap 4 compatibility.
 
  @class Dropdown
  @namespace Components

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -17,14 +17,14 @@ export default Ember.Component.extend({
   layout,
 
   /**
-   * Defaults to a `<ul>` tag. Change for other types of dropdown menus.
+   * Defaults to a `<ul>` tag in BS3 and a '<div>' tag in BS4. Change for other types of dropdown menus.
    *
    * @property tagName
    * @type string
    * @default ul
    * @public
    */
-  tagName: 'ul',
+
   classNames: ['dropdown-menu'],
   classNameBindings: ['alignClass'],
 

--- a/addon/components/base/bs-dropdown/menu/item.js
+++ b/addon/components/base/bs-dropdown/menu/item.js
@@ -11,5 +11,4 @@ import Ember from 'ember';
  @public
  */
 export default Ember.Component.extend({
-  tagName: 'li'
 });

--- a/addon/components/base/bs-dropdown/menu/link-to.js
+++ b/addon/components/base/bs-dropdown/menu/link-to.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+/**
+
+ Extended `{{link-to}}` component for use within Dropdowns.
+
+ @class DropdownMenuLinkTo
+ @namespace Components
+ @extends Ember.LinkComponent
+ @public
+ */
+export default Ember.LinkComponent.extend({
+});

--- a/addon/components/bs3/bs-dropdown/menu.js
+++ b/addon/components/bs3/bs-dropdown/menu.js
@@ -1,2 +1,5 @@
-export { default } from 'ember-bootstrap/components/base/bs-dropdown/menu';
+import DropdownMenu from 'ember-bootstrap/components/base/bs-dropdown/menu';
 
+export default DropdownMenu.extend({
+  tagName: 'ul'
+});

--- a/addon/components/bs3/bs-dropdown/menu/item.js
+++ b/addon/components/bs3/bs-dropdown/menu/item.js
@@ -1,1 +1,5 @@
-export { default } from 'ember-bootstrap/components/base/bs-dropdown/menu/item';
+import DropdownMenuItem from 'ember-bootstrap/components/base/bs-dropdown/menu/item';
+
+export default DropdownMenuItem.extend({
+  tagName: 'li'
+});

--- a/addon/components/bs3/bs-dropdown/menu/link-to.js
+++ b/addon/components/bs3/bs-dropdown/menu/link-to.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/components/base/bs-dropdown/menu/link-to';

--- a/addon/components/bs4/bs-dropdown/menu.js
+++ b/addon/components/bs4/bs-dropdown/menu.js
@@ -1,2 +1,5 @@
-export { default } from 'ember-bootstrap/components/base/bs-dropdown/menu';
+import DropdownMenu from 'ember-bootstrap/components/base/bs-dropdown/menu';
 
+export default DropdownMenu.extend({
+  tagName: 'div'
+});

--- a/addon/components/bs4/bs-dropdown/menu/item.js
+++ b/addon/components/bs4/bs-dropdown/menu/item.js
@@ -1,5 +1,6 @@
 import DropDownMenuItem from 'ember-bootstrap/components/base/bs-dropdown/menu/item';
 
 export default DropDownMenuItem.extend({
+  tagName: 'div',
   classNames: ['dropdown-item']
 });

--- a/addon/components/bs4/bs-dropdown/menu/item.js
+++ b/addon/components/bs4/bs-dropdown/menu/item.js
@@ -1,6 +1,5 @@
 import DropDownMenuItem from 'ember-bootstrap/components/base/bs-dropdown/menu/item';
 
 export default DropDownMenuItem.extend({
-  tagName: 'div',
-  classNames: ['dropdown-item']
+  tagName: ''
 });

--- a/addon/components/bs4/bs-dropdown/menu/link-to.js
+++ b/addon/components/bs4/bs-dropdown/menu/link-to.js
@@ -1,0 +1,5 @@
+import DropdownMenuLinkTo from 'ember-bootstrap/components/base/bs-dropdown/menu/link-to';
+
+export default DropdownMenuLinkTo.extend({
+  classNames: ['dropdown-item']
+});

--- a/addon/templates/components/common/bs-dropdown/menu.hbs
+++ b/addon/templates/components/common/bs-dropdown/menu.hbs
@@ -1,6 +1,7 @@
 {{yield
   (hash
     item=(component "bs-dropdown/menu/item")
+    link-to=(component "bs-dropdown/menu/link-to")
     divider=(component "bs-dropdown/menu/divider")
   )
 }}

--- a/app/components/bs-dropdown/menu/link-to.js
+++ b/app/components/bs-dropdown/menu/link-to.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/components/bs-dropdown/menu/link-to';

--- a/fastboot-tests/fixtures/fastboot/app/templates/dropdown.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/dropdown.hbs
@@ -3,7 +3,7 @@
 {{#bs-dropdown id="dropdown" as |dd|}}
     {{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}
     {{#dd.menu as |ddm|}}
-        {{#ddm.item}}{{#link-to "index"}}Home{{/link-to}}{{/ddm.item}}
-        {{#ddm.item}}{{#link-to "dropdown"}}Dropdowns{{/link-to}}{{/ddm.item}}
+        {{#ddm.item}}{{#ddm.link-to "index"}}Home{{/ddm.link-to}}{{/ddm.item}}
+        {{#ddm.item}}{{#ddm.link-to "dropdown"}}Dropdowns{{/ddm.link-to}}{{/ddm.item}}
     {{/dd.menu}}
 {{/bs-dropdown}}

--- a/tests/dummy/app/templates/demo/dropdown.hbs
+++ b/tests/dummy/app/templates/demo/dropdown.hbs
@@ -4,11 +4,15 @@
     {{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}
     {{#dd.menu as |menu|}}
       {{#menu.item}}
-        {{#link-to "index"}}Home{{/link-to}}
+        {{#menu.link-to "index"}}Home{{/menu.link-to}}
       {{/menu.item}}
       {{menu.divider}}
       {{#menu.item}}
-        {{#link-to "demo.dropdown"}}Dropdowns{{/link-to}}
+        {{#menu.link-to "demo.dropdown"}}Dropdowns{{/menu.link-to}}
+      {{/menu.item}}
+      {{menu.divider}}
+      {{#menu.item}}
+        <a href="https://example.com" class="dropdown-item">External</a>
       {{/menu.item}}
     {{/dd.menu}}
   {{/bs-dropdown}}
@@ -16,11 +20,11 @@
     {{#dd.toggle}}Dropup <span class="caret"></span>{{/dd.toggle}}
     {{#dd.menu align="right" as |menu|}}
       {{#menu.item}}
-        {{#link-to "index"}}Home{{/link-to}}
+        {{#menu.link-to "index"}}Home{{/menu.link-to}}
       {{/menu.item}}
       {{menu.divider}}
       {{#menu.item}}
-        {{#link-to "demo.dropdown"}}Dropdowns{{/link-to}}
+        {{#menu.link-to "demo.dropdown"}}Dropdowns{{/menu.link-to}}
       {{/menu.item}}
     {{/dd.menu}}
   {{/bs-dropdown}}
@@ -39,10 +43,10 @@
     {{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}
     {{#dd.menu as |menu|}}
       {{#menu.item}}
-        {{#link-to "index"}}Home{{/link-to}}
+        {{#menu.link-to "index"}}Home{{/menu.link-to}}
       {{/menu.item}}
       {{#menu.item}}
-        {{#link-to "demo.dropdown"}}Dropdowns{{/link-to}}
+        {{#menu.link-to "demo.dropdown"}}Dropdowns{{/menu.link-to}}
       {{/menu.item}}
     {{/dd.menu}}
   {{/bs-dropdown}}
@@ -52,10 +56,10 @@
     {{#dd.button}}<span class="caret"></span>{{/dd.button}}
     {{#dd.menu as |menu|}}
       {{#menu.item}}
-        {{#link-to "index"}}Home{{/link-to}}
+        {{#menu.link-to "index"}}Home{{/menu.link-to}}
       {{/menu.item}}
       {{#menu.item}}
-        {{#link-to "demo.dropdown"}}Dropdowns{{/link-to}}
+        {{#menu.link-to "demo.dropdown"}}Dropdowns{{/menu.link-to}}
       {{/menu.item}}
     {{/dd.menu}}
   {{/bs-dropdown}}

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -75,7 +75,7 @@ test('clicking dropdown menu will close it', async function(assert) {
   await click('a.dropdown-toggle');
   assert.equal(find(':first-child').classList.contains(openClass()), true, 'Dropdown is open');
 
-  await click('ul.dropdown-menu a');
+  await click('.dropdown-menu a');
   assert.equal(find(':first-child').classList.contains(openClass()), false, 'Dropdown is closed');
 });
 
@@ -84,7 +84,7 @@ test('clicking dropdown menu when closeOnMenuClick is false will not close it', 
   await click('a.dropdown-toggle');
   assert.equal(find(':first-child').classList.contains(openClass()), true, 'Dropdown is open');
 
-  await click('ul.dropdown-menu a');
+  await click('.dropdown-menu a');
   assert.equal(find(':first-child').classList.contains(openClass()), true, 'Dropdown is open');
 });
 
@@ -113,6 +113,6 @@ test('closing dropdown calls onHide action', async function(assert) {
   this.render(hbs`{{#bs-dropdown onHide=(action "hide") as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`);
 
   await click('a.dropdown-toggle');
-  await click('ul.dropdown-menu a');
+  await click('.dropdown-menu a');
   assert.ok(action.calledOnce);
 });

--- a/tests/integration/components/bs-dropdown/menu-test.js
+++ b/tests/integration/components/bs-dropdown/menu-test.js
@@ -34,5 +34,5 @@ testBS3('dropdown menu yields item component', function(assert) {
 testBS4('dropdown menu yields item component', function(assert) {
   this.render(hbs`{{#bs-dropdown/menu as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`);
 
-  assert.equal(findAll('.dropdown-item').length, 1, 'has item component');
+  assert.equal(findAll('.dropdown-item').length, 0, 'has item component with no markup');
 });

--- a/tests/integration/components/bs-dropdown/menu-test.js
+++ b/tests/integration/components/bs-dropdown/menu-test.js
@@ -1,12 +1,13 @@
 import { findAll, find } from 'ember-native-dom-helpers';
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent } from 'ember-qunit';
+import { testBS3, testBS4 } from '../../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('bs-dropdown-menu', 'Integration | Component | bs-dropdown/menu', {
   integration: true
 });
 
-test('dropdown menu has correct markup', function(assert) {
+testBS3('dropdown menu has correct markup', function(assert) {
   this.render(hbs`{{#bs-dropdown/menu align="right"}}Something{{/bs-dropdown/menu}}`);
 
   assert.equal(find(':first-child').tagName, 'UL', 'menu is an unordered list (<ul>) by default');
@@ -15,8 +16,23 @@ test('dropdown menu has correct markup', function(assert) {
   assert.equal(find('ul').innerHTML.trim(), 'Something', 'menu contains block contents');
 });
 
-test('dropdown menu yields item component', function(assert) {
+testBS4('dropdown menu has correct markup', function(assert) {
+  this.render(hbs`{{#bs-dropdown/menu align="right"}}Something{{/bs-dropdown/menu}}`);
+
+  assert.equal(find(':first-child').tagName, 'DIV', 'menu is a div (<div>) by default');
+  assert.equal(find('div').classList.contains('dropdown-menu'), true, 'menu has dropdown-menu class');
+  assert.equal(find('div').classList.contains('dropdown-menu-right'), true, 'menu has dropdown-menu-right class');
+  assert.equal(find('div').innerHTML.trim(), 'Something', 'menu contains block contents');
+});
+
+testBS3('dropdown menu yields item component', function(assert) {
   this.render(hbs`{{#bs-dropdown/menu as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`);
 
   assert.equal(findAll('li').length, 1, 'has item component');
+});
+
+testBS4('dropdown menu yields item component', function(assert) {
+  this.render(hbs`{{#bs-dropdown/menu as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`);
+
+  assert.equal(findAll('.dropdown-item').length, 1, 'has item component');
 });

--- a/tests/integration/components/bs-dropdown/menu/item-test.js
+++ b/tests/integration/components/bs-dropdown/menu/item-test.js
@@ -1,12 +1,13 @@
 import { find, findAll } from 'ember-native-dom-helpers';
-import { moduleForComponent, test } from 'ember-qunit';
+import { moduleForComponent } from 'ember-qunit';
+import { testBS3, testBS4 } from '../../../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('bs-dropdown/menu/item', 'Integration | Component | bs dropdown/menu/item', {
   integration: true
 });
 
-test('it has correct markup', function(assert) {
+testBS3('it has correct markup', function(assert) {
   // Template block usage:
   this.render(hbs`
     {{#bs-dropdown/menu/item}}
@@ -15,5 +16,17 @@ test('it has correct markup', function(assert) {
   `);
 
   assert.equal(findAll('li').length, 1, 'renders as <li> element');
+  assert.equal(find('*').textContent.trim(), 'template block text');
+});
+
+testBS4('it has correct markup', function(assert) {
+  // Template block usage:
+  this.render(hbs`
+    {{#bs-dropdown/menu/item}}
+      template block text
+    {{/bs-dropdown/menu/item}}
+  `);
+
+  assert.equal(findAll('div').length, 1, 'renders as <div> element');
   assert.equal(find('*').textContent.trim(), 'template block text');
 });

--- a/tests/integration/components/bs-dropdown/menu/link-to-test.js
+++ b/tests/integration/components/bs-dropdown/menu/link-to-test.js
@@ -3,32 +3,30 @@ import { moduleForComponent } from 'ember-qunit';
 import { testBS3, testBS4 } from '../../../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('bs-dropdown/menu/item', 'Integration | Component | bs-dropdown/menu/item', {
+moduleForComponent('bs-dropdown/menu/link-to', 'Integration | Component | bs dropdown/menu/link to', {
   integration: true
 });
 
 testBS3('it has correct markup', function(assert) {
   // Template block usage:
   this.render(hbs`
-    {{#bs-dropdown/menu/item}}
+    {{#bs-dropdown/menu/link-to}}
       template block text
-    {{/bs-dropdown/menu/item}}
+    {{/bs-dropdown/menu/link-to}}
   `);
 
-  assert.equal(findAll('li').length, 1, 'renders as <li> element');
   assert.equal(find('*').textContent.trim(), 'template block text');
+  assert.equal(findAll('a.dropdown-item').length, 0, 'renders as plain element with no dropdown item class');
 });
 
 testBS4('it has correct markup', function(assert) {
   // Template block usage:
   this.render(hbs`
-    <span>
-    {{#bs-dropdown/menu/item}}
+    {{#bs-dropdown/menu/link-to}}
       template block text
-    {{/bs-dropdown/menu/item}}
-    </span>
+    {{/bs-dropdown/menu/link-to}}
   `);
 
-  assert.equal(findAll('div').length, 0, 'renders as no element');
   assert.equal(find('*').textContent.trim(), 'template block text');
+  assert.equal(findAll('a.dropdown-item').length, 1, 'renders as plain element with dropdown item class');
 });

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -142,12 +142,12 @@ test('tab navigation is groupable', function(assert) {
   assert.equal(find('ul.nav.nav-tabs > li:nth-child(2) > a').textContent.trim(), 'Tab 2', 'navigation item shows pane title');
   assert.equal(find('ul.nav.nav-tabs > li:nth-child(3)').classList.contains('dropdown'), true, 'adds dropdown for grouped items');
   assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > a').textContent.trim(), 'Dropdown', 'drop down item shows pane groupTitle');
-  assert.equal(findAll('ul.nav.nav-tabs > li:nth-child(3) > ul.dropdown-menu > li').length, 2, 'puts items with groupTitle under dropdown menu');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu').children.length, 2, 'puts items with groupTitle under dropdown menu');
   assert.equal(find(
-    'ul.nav.nav-tabs > li:nth-child(3) > ul.dropdown-menu > li:nth-child(1) > a'
+    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(1) > a'
   ).textContent.trim(), 'Tab 3', 'dropdown menu item shows pane title');
   assert.equal(find(
-    'ul.nav.nav-tabs > li:nth-child(3) > ul.dropdown-menu > li:nth-child(2) > a'
+    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(2) > a'
   ).textContent.trim(), 'Tab 4', 'dropdown menu item shows pane title');
 });
 

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -1,7 +1,7 @@
 import { find, findAll, click } from 'ember-native-dom-helpers';
 import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
+import test from 'ember-sinon-qunit/test-support/test';
 
 moduleForComponent('bs-tab', 'Integration | Component | bs-tab', {
   integration: true
@@ -118,40 +118,7 @@ test('activeId activates tabs', function(assert) {
   assertActiveTab.call(this, assert, 1, true);
 });
 
-testBS3('tab navigation is groupable', function(assert) {
-  this.render(hbs`
-    {{#bs-tab as |tab|}}
-      {{#tab.pane title="Tab 1"}}
-          tabcontent 1
-      {{/tab.pane}}
-      {{#tab.pane title="Tab 2"}}
-          tabcontent 2
-      {{/tab.pane}}
-      {{#tab.pane title="Tab 3" groupTitle="Dropdown"}}
-          tabcontent 3
-      {{/tab.pane}}
-      {{#tab.pane title="Tab 4" groupTitle="Dropdown"}}
-          tabcontent 4
-      {{/tab.pane}}
-    {{/bs-tab}}
-  `);
-
-  assert.equal(findAll('ul.nav.nav-tabs').length, 1, 'has tabs navigation');
-  assert.equal(findAll('ul.nav.nav-tabs > li').length, 3, 'has tabs navigation items');
-  assert.equal(find('ul.nav.nav-tabs > li:nth-child(1) > a').textContent.trim(), 'Tab 1', 'navigation item shows pane title');
-  assert.equal(find('ul.nav.nav-tabs > li:nth-child(2) > a').textContent.trim(), 'Tab 2', 'navigation item shows pane title');
-  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3)').classList.contains('dropdown'), true, 'adds dropdown for grouped items');
-  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > a').textContent.trim(), 'Dropdown', 'drop down item shows pane groupTitle');
-  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu').children.length, 2, 'puts items with groupTitle under dropdown menu');
-  assert.equal(find(
-    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(1) > a'
-  ).textContent.trim(), 'Tab 3', 'dropdown menu item shows pane title');
-  assert.equal(find(
-    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(2) > a'
-  ).textContent.trim(), 'Tab 4', 'dropdown menu item shows pane title');
-});
-
-testBS4('tab navigation is groupable', function(assert) {
+test('tab navigation is groupable', function(assert) {
   this.render(hbs`
     {{#bs-tab as |tab|}}
       {{#tab.pane title="Tab 1"}}

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -1,7 +1,7 @@
 import { find, findAll, click } from 'ember-native-dom-helpers';
 import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import test from 'ember-sinon-qunit/test-support/test';
+import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
 
 moduleForComponent('bs-tab', 'Integration | Component | bs-tab', {
   integration: true
@@ -118,7 +118,7 @@ test('activeId activates tabs', function(assert) {
   assertActiveTab.call(this, assert, 1, true);
 });
 
-test('tab navigation is groupable', function(assert) {
+testBS3('tab navigation is groupable', function(assert) {
   this.render(hbs`
     {{#bs-tab as |tab|}}
       {{#tab.pane title="Tab 1"}}
@@ -148,6 +148,39 @@ test('tab navigation is groupable', function(assert) {
   ).textContent.trim(), 'Tab 3', 'dropdown menu item shows pane title');
   assert.equal(find(
     'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(2) > a'
+  ).textContent.trim(), 'Tab 4', 'dropdown menu item shows pane title');
+});
+
+testBS4('tab navigation is groupable', function(assert) {
+  this.render(hbs`
+    {{#bs-tab as |tab|}}
+      {{#tab.pane title="Tab 1"}}
+          tabcontent 1
+      {{/tab.pane}}
+      {{#tab.pane title="Tab 2"}}
+          tabcontent 2
+      {{/tab.pane}}
+      {{#tab.pane title="Tab 3" groupTitle="Dropdown"}}
+          tabcontent 3
+      {{/tab.pane}}
+      {{#tab.pane title="Tab 4" groupTitle="Dropdown"}}
+          tabcontent 4
+      {{/tab.pane}}
+    {{/bs-tab}}
+  `);
+
+  assert.equal(findAll('ul.nav.nav-tabs').length, 1, 'has tabs navigation');
+  assert.equal(findAll('ul.nav.nav-tabs > li').length, 3, 'has tabs navigation items');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(1) > a').textContent.trim(), 'Tab 1', 'navigation item shows pane title');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(2) > a').textContent.trim(), 'Tab 2', 'navigation item shows pane title');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3)').classList.contains('dropdown'), true, 'adds dropdown for grouped items');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > a').textContent.trim(), 'Dropdown', 'drop down item shows pane groupTitle');
+  assert.equal(find('ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu').children.length, 2, 'puts items with groupTitle under dropdown menu');
+  assert.equal(find(
+    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(1)'
+  ).textContent.trim(), 'Tab 3', 'dropdown menu item shows pane title');
+  assert.equal(find(
+    'ul.nav.nav-tabs > li:nth-child(3) > .dropdown-menu > :nth-child(2)'
   ).textContent.trim(), 'Tab 4', 'dropdown menu item shows pane title');
 });
 


### PR DESCRIPTION
Fixes #337. Continuing the conversation here.

I don't see a way to do this without a breaking change. That's not ideal since we've gone to beta, but I think it's necessary.

On rereading the docs, the `<a>` or `<button>` decision is about the dropdown button, not the item. For items, they only mention links or dividers. We have dividers covered, leaving us with two types of links, internal and external. I'm not worried separately about dropdown items that are plain text as that can be covered with a disabled item.

I'm going to create `bs-dropdown.menu.link-to` for the internal links.

External links need more thought as their tag structure between the two versions is significantly different.