### PR TITLE
Fix tooltip/popover positioning

### DIFF
--- a/addon/components/base/bs-contextual-help.js
+++ b/addon/components/base/bs-contextual-help.js
@@ -544,8 +544,8 @@ export default Component.extend(TransitionSupport, {
     let height = tip.offsetHeight;
 
     // manually read margins because getBoundingClientRect includes difference
-    let marginTop = parseInt(tip.style.marginTop, 10);
-    let marginLeft = parseInt(tip.style.marginLeft, 10);
+    let marginTop = parseInt(window.getComputedStyle(tip).marginTop, 10);
+    let marginLeft = parseInt(window.getComputedStyle(tip).marginLeft, 10);
 
     // we must check for NaN for ie 8/9
     if (isNaN(marginTop)) {
@@ -562,28 +562,30 @@ export default Component.extend(TransitionSupport, {
 
     this.set('showHelp', true);
 
-    // check to see if placing tip in new offset caused the tip to resize itself
-    let actualWidth = tip.offsetWidth;
-    let actualHeight = tip.offsetHeight;
+    schedule('afterRender', () => {
+      // check to see if placing tip in new offset caused the tip to resize itself
+      let actualWidth = tip.offsetWidth;
+      let actualHeight = tip.offsetHeight;
 
-    if (placement === 'top' && actualHeight !== height) {
-      offset.top = offset.top + height - actualHeight;
-    }
+      if (placement === 'top' && actualHeight !== height) {
+        offset.top = offset.top + height - actualHeight;
+      }
 
-    let delta = this.getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight);
+      let delta = this.getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight);
 
-    if (delta.left) {
-      offset.left += delta.left;
-    } else {
-      offset.top += delta.top;
-    }
+      if (delta.left) {
+        offset.left += delta.left;
+      } else {
+        offset.top += delta.top;
+      }
 
-    let isVertical = /top|bottom/.test(placement);
-    let arrowDelta = isVertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight;
-    let arrowOffsetPosition = isVertical ? 'offsetWidth' : 'offsetHeight';
+      let isVertical = /top|bottom/.test(placement);
+      let arrowDelta = isVertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight;
+      let arrowOffsetPosition = isVertical ? 'offsetWidth' : 'offsetHeight';
 
-    setOffset(tip, offset);
-    this.replaceArrow(arrowDelta, tip[arrowOffsetPosition], isVertical);
+      setOffset(tip, offset);
+      this.replaceArrow(arrowDelta, tip[arrowOffsetPosition], isVertical);
+    });
   },
 
   /**

--- a/addon/components/base/bs-popover.js
+++ b/addon/components/base/bs-popover.js
@@ -95,5 +95,5 @@ export default ContextualHelp.extend({
    */
   arrowElement: computed('overlayElement', function() {
     return this.get('overlayElement').querySelector('.arrow');
-  })
+  }).volatile()
 });

--- a/addon/components/base/bs-tooltip.js
+++ b/addon/components/base/bs-tooltip.js
@@ -87,5 +87,5 @@ export default ContextualHelp.extend({
    */
   arrowElement: computed('overlayElement', function() {
     return this.get('overlayElement').querySelector('.tooltip-arrow');
-  })
+  }).volatile()
 });

--- a/tests/helpers/bootstrap-test.js
+++ b/tests/helpers/bootstrap-test.js
@@ -19,7 +19,7 @@ export function testBS4() {
   return testForBootstrap(4, ...arguments);
 }
 
-function versionDependent(v3, v4) {
+export function versionDependent(v3, v4) {
   if (currentBootstrapVersion === 3) {
     return v3;
   }

--- a/tests/helpers/contextual-help.js
+++ b/tests/helpers/contextual-help.js
@@ -1,0 +1,38 @@
+import { find, findAll } from 'ember-native-dom-helpers';
+
+export function setupForPositioning() {
+  Object.assign(find('#wrapper').style, {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    textAlign: 'right',
+    width: '300px',
+    height: '300px'
+  });
+
+  Object.assign(document.getElementById('ember-testing').style, {
+    transform: 'none'
+  });
+
+  find('a').style.marginTop = 200;
+}
+
+function offset(el) {
+  let rect = el.getBoundingClientRect();
+
+  return {
+    top: rect.top + document.body.scrollTop,
+    left: rect.left + document.body.scrollLeft
+  };
+}
+
+export function assertPositioning(assert, selector = '.tooltip') {
+  assert.equal(findAll(selector).length, 1, 'Element exists.');
+
+  let tooltip = find(selector);
+  let trigger = find('#target');
+  let marginTop = parseInt(window.getComputedStyle(tooltip).marginTop, 10);
+  let tooltipPos = Math.round(offset(tooltip).top + tooltip.offsetHeight - marginTop);
+  let triggerPos = Math.round(offset(trigger).top);
+  assert.equal(tooltipPos, triggerPos);
+}

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -1,7 +1,7 @@
-import { click } from 'ember-native-dom-helpers';
+import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { test } from '../../helpers/bootstrap-test';
+import { test, versionDependent } from '../../helpers/bootstrap-test';
 import { setupForPositioning, assertPositioning } from '../../helpers/contextual-help';
 
 moduleForComponent('bs-popover', 'Integration | Component | bs-popover', {
@@ -15,4 +15,21 @@ test('should place popover on top of element', async function(assert) {
 
   await click('#target');
   assertPositioning(assert, '.popover');
+});
+
+test('should adjust popover arrow', async function(assert) {
+  let expectedArrowPosition = versionDependent(83, 81);
+  this.render(hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Click me{{#bs-popover placement="top" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}</a></p></div>`);
+
+  setupForPositioning();
+
+  await click('#target');
+  let arrowPosition = parseInt(find('.arrow').style.left, 10);
+  assert.equal(arrowPosition, expectedArrowPosition);
+
+  // check again to prevent regression of https://github.com/kaliber5/ember-bootstrap/issues/361
+  await click('#target');
+  await click('#target');
+  arrowPosition = parseInt(find('.arrow').style.left, 10);
+  assert.equal(arrowPosition, expectedArrowPosition);
 });

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -1,0 +1,18 @@
+import { click } from 'ember-native-dom-helpers';
+import { moduleForComponent } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { test } from '../../helpers/bootstrap-test';
+import { setupForPositioning, assertPositioning } from '../../helpers/contextual-help';
+
+moduleForComponent('bs-popover', 'Integration | Component | bs-popover', {
+  integration: true
+});
+
+test('should place popover on top of element', async function(assert) {
+  this.render(hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Click me{{#bs-popover placement="top" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}</a></p></div>`);
+
+  setupForPositioning();
+
+  await click('#target');
+  assertPositioning(assert, '.popover');
+});

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -3,40 +3,11 @@ import Ember from 'ember';
 import { moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { test, visibilityClass } from '../../helpers/bootstrap-test';
+import { setupForPositioning, assertPositioning } from '../../helpers/contextual-help';
 
 moduleForComponent('bs-tooltip', 'Integration | Component | bs-tooltip', {
   integration: true
 });
-
-function setupForPositioning() {
-  Object.assign(find('#wrapper').style, {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    textAlign: 'right',
-    width: 300,
-    height: 300
-  });
-
-  find('a').style.marginTop = 200;
-}
-
-function offset(el) {
-  let rect = el.getBoundingClientRect();
-
-  return {
-    top: rect.top + document.body.scrollTop,
-    left: rect.left + document.body.scrollLeft
-  };
-}
-
-function assertPositioning(assert) {
-  assert.equal(findAll('.tooltip').length, 1, 'Tooltip exists.');
-
-  let tooltip = find('.tooltip');
-  let trigger = find('#target');
-  assert.ok(Math.round(offset(tooltip).top + tooltip.offsetHeight) <= Math.round(offset(trigger).top));
-}
 
 function isVisible(tt) {
   return tt && tt.classList.contains('fade') && tt.classList.contains(visibilityClass());
@@ -202,10 +173,10 @@ test('Renders in place (no wormhole) if renderInPlace is set', function(assert) 
 test('should place tooltip on top of element', async function(assert) {
   this.render(hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false}}</a></p></div>`);
 
-  setupForPositioning.call(this);
+  setupForPositioning();
 
   await triggerEvent('#target', 'mouseenter');
-  assertPositioning.call(this, assert);
+  assertPositioning(assert);
 });
 
 test('should place tooltip on top of element if already visible', function(assert) {
@@ -213,9 +184,9 @@ test('should place tooltip on top of element if already visible', function(asser
   let done = assert.async();
   this.render(hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=true}}</a></p></div>`);
 
-  setupForPositioning.call(this);
+  setupForPositioning();
   setTimeout(function() {
-    assertPositioning.call(this, assert);
+    assertPositioning(assert);
     done();
   }, 0);
 });
@@ -224,10 +195,10 @@ test('should place tooltip on top of element if visible is set to true', functio
   this.set('visible', false);
   this.render(hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=visible}}</a></p></div>`);
 
-  setupForPositioning.call(this);
+  setupForPositioning();
 
   this.set('visible', true);
-  assertPositioning.call(this, assert);
+  assertPositioning(assert);
 });
 
 test('should show tooltip if leave event hasn\'t occurred before delay expires', function(assert) {


### PR DESCRIPTION
Two issues fixed here:
* migration to native DOM instead of jQuery introduced a regression, positioning was slightly off (not correctly accounting for margins of tooltip/popover)
* #361