### PR TITLE
insertAdjacentElement doesn't exist in Firefox <= 47

### DIFF
--- a/addon/components/base/bs-modal.js
+++ b/addon/components/base/bs-modal.js
@@ -589,7 +589,8 @@ export default Ember.Component.extend(TransitionSupport, {
   scrollbarWidth: computed(function() {
     let scrollDiv = document.createElement('div');
     scrollDiv.className = 'modal-scrollbar-measure';
-    this.get('modalElement').insertAdjacentElement('afterend', scrollDiv);
+    let modalEl = this.get('modalElement');
+    modalEl.parentNode.insertBefore(scrollDiv, modalEl.nextSibling);
     let scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
     scrollDiv.parentNode.removeChild(scrollDiv);
     return scrollbarWidth;


### PR DESCRIPTION
This was added when the jQuery dependency was removed. It breaks in any Firefox version before 48, which is when support for insertAdjacentElement was added.

Not sure if you care about supporting a year-old version with negligible market share, but it's two lines, so I  figured I'd fix first and ask later.