### PR TITLE
Remove transitionEnd eventlistener

### DIFF
--- a/addon/utils/transition-end.js
+++ b/addon/utils/transition-end.js
@@ -25,7 +25,7 @@ export default function onTransitionEnd(node, handler, context, duration = 0) {
     if (backup) {
       cancel(backup);
     }
-    event.target.removeEventListener(transitionEnd, done);
+    node.removeEventListener(transitionEnd, done);
     join(context, handler, event);
   }
 }


### PR DESCRIPTION
Because the transitionEnd event isn't always triggered on the root component node (if modal contains some other transitions), it wasn't always removed.