### PR TITLE
showValidations public property to control visibility of validations errors in bs-form

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import RSVP from 'rsvp';
-import { set, computed } from '@ember/object';
+import { set, computed, observer } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
 import layout from 'ember-bootstrap/templates/components/bs-form';
@@ -207,6 +207,22 @@ export default Component.extend({
    * @public
    */
   onInvalid(model, error) {}, // eslint-disable-line no-unused-vars
+  
+  /**
+   * showValidations controls visibility of validation errors.
+   * null (default): Show validation errors after user interactions like form submission, focus out event of input
+   *        fields etc. So just the same behaviour as currently implemented.
+   * true:  Show all validation errors immediately independently of user interactions.
+   * false: Do not show validation errors.
+   */
+  showValidations: null,
+  updateShowAllValidations: observer('showValidations', function () {
+    if (this.get('showValidations')) {
+      this.set('showAllValidations', true)
+    } else if (this.get('showValidations') === false) {
+      this.set('showAllValidations', false)
+    }
+  }),
 
   /**
    * Submit handler that will send the default action ("action") to the controller when submitting the form.


### PR DESCRIPTION
Add showValidations public property to control the visibility of validations on errors in bs-form



