### PR TITLE
Bubble the dropdown button toggle click event

### DIFF
--- a/addon/templates/components/common/bs-dropdown.hbs
+++ b/addon/templates/components/common/bs-dropdown.hbs
@@ -1,6 +1,6 @@
 {{yield
   (hash
-    button=(component "bs-dropdown/button" dropdown=this onClick=(action "toggleDropdown"))
+    button=(component "bs-dropdown/button" dropdown=this onClick=(action "toggleDropdown") bubble=true)
     toggle=(component "bs-dropdown/toggle" dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
     menu=(component "bs-dropdown/menu")
     isOpen=isOpen


### PR DESCRIPTION
Hey!

So, currently if I have multiple `bs-dropdown` dropdowns, when I click on two of the toggle dropdown buttons, both dropdowns remain open. What I would expect is for the first dropdown to be closed when a second toggle is clicked.

This PR fixes that. If this can be done in a better way, I'm open to suggestions.

Thanks!