### PR TITLE
fixes #441, providing fallback for undefined formLayout prop

### DIFF
--- a/addon/components/bs4/bs-form.js
+++ b/addon/components/bs4/bs-form.js
@@ -1,9 +1,10 @@
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
+
 import Form from 'ember-bootstrap/components/base/bs-form';
 
 export default Form.extend({
   layoutClass: computed('formLayout', function() {
-    let layout = this.get('formLayout');
-    return layout === 'inline' ? 'form-inline' : null;
+    let layout = get(this, 'formLayout');
+    return layout === 'inline' ? 'form-inline' : false;
   }).readOnly()
 });


### PR DESCRIPTION
Fixes #441 

Since BS4 has only two options, I didn't use assert, and just used false as fallback.

My previous PR used the local branch. 
