### PR TITLE
Injecting custom CSS classes to the bs-tab component

### DIFF
--- a/addon/components/base/bs-nav.js
+++ b/addon/components/base/bs-nav.js
@@ -75,9 +75,18 @@ export default Component.extend({
   layout,
 
   tagName: 'ul',
-  classNames: ['nav'],
 
-  classNameBindings: ['typeClass', 'justified:nav-justified'],
+  classNameBindings: 'classes',
+
+  classes: computed('customClass', 'typeClass', function() {
+    let customClasses = this.get('customClass');
+    if (isPresent(customClasses)) {
+      return customClasses;
+    }
+    let classes = ['nav'];
+    classes.push(this.get('typeClass'), 'justified:nav-justified');
+    return classes.join(' ');
+  }),
 
   typeClass: computed('type', function() {
     let type = this.get('type');

--- a/addon/components/base/bs-tab.js
+++ b/addon/components/base/bs-tab.js
@@ -121,7 +121,7 @@ export default Component.extend(ComponentParent, {
    */
   type: 'tabs',
 
-  tagName: "",
+  tagName: '',
 
   /**
    * By default the tabs will be automatically generated using the available [TabPane](Components.TabPane.html)

--- a/addon/components/base/bs-tab.js
+++ b/addon/components/base/bs-tab.js
@@ -121,6 +121,8 @@ export default Component.extend(ComponentParent, {
    */
   type: 'tabs',
 
+  tagName: "",
+
   /**
    * By default the tabs will be automatically generated using the available [TabPane](Components.TabPane.html)
    * components. If set to true, you can deactivate this and setup the tabs manually. See the example above.

--- a/addon/templates/components/common/bs-tab.hbs
+++ b/addon/templates/components/common/bs-tab.hbs
@@ -7,7 +7,7 @@
     )
   }}
 {{else}}
-  {{#bs-nav type=type as |nav|}}
+  {{#bs-nav customClass=class type=type as |nav|}}
     {{#each navItems as |item|}}
       {{#if item.isGroup}}
         {{#nav.dropdown tagName="li" class=(if (bs-contains item.childIds isActiveId) "active") as |dd|}}


### PR DESCRIPTION
Hey,
in order to use a template I purchased (built on top of Bootstrap), I needed to change a little bit the bs-tab/bs-nav components.

Basically I wanted to push a custom class to the bs-nav component.. something like:

`{{#bs-tab class="tab-nav" as |tab|}} ...`
-->
`<ul class="tab-nav ember-view">`

I don't know if what I did is a desirable implementation (maybe you just want to keep your "ember-bootstrap" 100% standard bootstrap). 

Just let me know