### PR TITLE
warn if Bootstrap 4 version is not at least 4.0.0-beta

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const rename = stew.rename;
 const BroccoliDebug = require('broccoli-debug');
 const chalk = require('chalk');
 const SilentError = require('silent-error'); // From ember-cli
+const VersionChecker = require('ember-cli-version-checker');
 
 const defaultOptions = {
   importBootstrapTheme: false,
@@ -39,6 +40,8 @@ const componentDependencies = {
   'bs-tab': ['bs-nav'],
   'bs-tooltip': ['bs-contextual-help']
 };
+
+const minimumBS4Version = '4.0.0-beta';
 
 // For ember-cli < 2.7 findHost doesnt exist so we backport from that version
 // for earlier version of ember-cli.
@@ -109,6 +112,15 @@ module.exports = {
 
   validateDependencies() {
     let bowerDependencies = this.app.project.bowerDependencies();
+
+    if (this.getBootstrapVersion() === 4) {
+      let checker = new VersionChecker(this);
+      let dep = checker.for('bootstrap');
+
+      if (!dep.gte(minimumBS4Version)) {
+        this.warn(`For Bootstrap 4 support this version of ember-bootstrap requires at least Bootstrap ${minimumBS4Version}, but you have ${dep.version}. Please run \`ember generate ember-bootstrap\` to update your dependencies!`);
+      }
+    }
 
     if ('bootstrap' in bowerDependencies || 'bootstrap-sass' in bowerDependencies) {
       this.warn('The dependencies for ember-bootstrap may be outdated. Please run `ember generate ember-bootstrap` to install appropriate dependencies!');

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "ember-cli-babel": "^6.8.2",
     "ember-cli-build-config-editor": "0.5.0",
     "ember-cli-htmlbars": "^2.0.2",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-popper": "^0.7.3",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
     "ember-wormhole": "^0.5.2",


### PR DESCRIPTION
When using any version of ember-bootstrap that includes #410 users have to use at least 4.0.0-beta of the bootstrap npm package, otherwise the CSS will not match the markup our components generate.

cc @srvance 