### PR TITLE
fix sporadic errors with bs-modal in tests

### DIFF
--- a/addon/components/base/bs-modal.js
+++ b/addon/components/base/bs-modal.js
@@ -418,7 +418,9 @@ export default Component.extend(TransitionSupport, {
       this.set('inDom', true);
       schedule('afterRender', () => {
         let modalEl = this.get('modalElement');
-        modalEl.scrollTop = 0;
+        if (!modalEl) {
+          return;
+        }
 
         this.handleUpdate();
         this.set('showModal', true);
@@ -512,6 +514,9 @@ export default Component.extend(TransitionSupport, {
       assert('Backdrop element should be in DOM', backdrop);
 
       let callbackRemove = function() {
+        if (this.get('isDestroyed')) {
+          return;
+        }
         this.set('showBackdrop', false);
         if (callback) {
           callback.call(this);

--- a/addon/components/base/bs-modal.js
+++ b/addon/components/base/bs-modal.js
@@ -422,6 +422,7 @@ export default Component.extend(TransitionSupport, {
           return;
         }
 
+        modalEl.scrollTop = 0;
         this.handleUpdate();
         this.set('showModal', true);
         this.get('onShow')();


### PR DESCRIPTION
If I create and close a modal in a test I get two sporadic errors. Investigated this because our app's CI has been failing sporadically with the `scrollTop` error.

Here is the test I used to reproduce the issues:

```javascript
let i;
for (i = 0; i < 5000; i++) {
  test(`bs-modal remove markup ${i}`, function(assert) {
    assert.expect(0);
    this.set('showModal', true);
    this.render(hbs`{{#bs-modal open=showModal onHide=(action (mut showModal) false) as |modal|}}
        {{#modal.body}}Hello world!{{/modal.body}}
      {{/bs-modal}}`);
    this.set('showModal', false);
  });
}
```

error w/ "scrollTop"
<img width="866" alt="screen shot 2017-11-11 at 1 40 20 pm" src="https://user-images.githubusercontent.com/11699/32693622-ae180ca2-c6f3-11e7-9c3b-cf9a0b2d94ae.png">

error w/ "set on destroyed object"
<img width="1252" alt="screen shot 2017-11-11 at 3 05 05 pm" src="https://user-images.githubusercontent.com/11699/32693632-cbc5bdda-c6f3-11e7-965f-8dd67b5b23ce.png">
