### PR TITLE
Fix form sizing classes for Bootstrap 4

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -504,6 +504,15 @@ export default FormGroup.extend({
   hasCustomWarning: notEmpty('customWarning'),
 
   /**
+   * Property for size styling, set to 'lg', 'sm' or 'xs' (the latter only for BS3)
+   *
+   * @property size
+   * @type String
+   * @public
+   */
+  size: null,
+
+  /**
    * The array of validation messages (either errors or warnings) from either custom error/warnings or , if we are showing model validation messages, the model's validation
    *
    * @property validationMessages

--- a/addon/components/base/bs-form/element/control/input.js
+++ b/addon/components/base/bs-form/element/control/input.js
@@ -13,7 +13,7 @@ export default Control.extend(ControlAttributes, {
     'value',
     'type',
     'placeholder',
-    'size',
+    'controlSize:size',
     'minlength',
     'maxlength',
     'min',

--- a/addon/components/base/bs-form/group.js
+++ b/addon/components/base/bs-form/group.js
@@ -1,7 +1,6 @@
 import { notEmpty } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/group';
-import SizeClass from 'ember-bootstrap/mixins/size-class';
 
 /**
  This component renders a `<div class="form-group">` element, with support for validation states and feedback icons (only for BS3).
@@ -25,7 +24,7 @@ import SizeClass from 'ember-bootstrap/mixins/size-class';
  @extends Ember.Component
  @public
  */
-export default Component.extend(SizeClass, {
+export default Component.extend({
   layout,
 
   /**

--- a/addon/components/bs3/bs-form/group.js
+++ b/addon/components/bs3/bs-form/group.js
@@ -3,8 +3,9 @@ import FormGroup from 'ember-bootstrap/components/base/bs-form/group';
 import Config from 'ember-bootstrap/config';
 import { isBlank } from '@ember/utils';
 import { computed } from '@ember/object';
+import SizeClass from 'ember-bootstrap/mixins/size-class';
 
-export default FormGroup.extend({
+export default FormGroup.extend(SizeClass, {
   classNames: ['form-group'],
   classNameBindings: ['validationClass', 'hasFeedback'],
 

--- a/addon/components/bs4/bs-form/element/control/input.js
+++ b/addon/components/bs4/bs-form/element/control/input.js
@@ -1,4 +1,7 @@
 import FormElementControlInput from 'ember-bootstrap/components/base/bs-form/element/control/input';
 import ControlValidationMixin from 'ember-bootstrap/mixins/control-validation';
+import SizeClass from 'ember-bootstrap/mixins/size-class';
 
-export default FormElementControlInput.extend(ControlValidationMixin);
+export default FormElementControlInput.extend(ControlValidationMixin, SizeClass, {
+  classTypePrefix: 'form-control'
+});

--- a/addon/components/bs4/bs-form/element/label.js
+++ b/addon/components/bs4/bs-form/element/label.js
@@ -1,9 +1,28 @@
 import FormElementLabel from 'ember-bootstrap/components/base/bs-form/element/label';
+import { isBlank } from '@ember/utils';
+import { computed } from '@ember/object';
 
 export default FormElementLabel.extend({
   tagName: 'label',
 
   classNames: [],
-  classNameBindings: ['invisibleLabel:sr-only', 'isHorizontal:col-form-label', 'isCheckbox:form-check-label', 'labelClass'],
-  attributeBindings: ['formElementId:for']
+  classNameBindings: ['invisibleLabel:sr-only', 'isHorizontal:col-form-label', 'isCheckbox:form-check-label', 'labelClass', 'sizeClass'],
+  attributeBindings: ['formElementId:for'],
+
+  sizeClass: computed('size', 'isHorizontal', function() {
+    if (!this.get('isHorizontal')) {
+      return;
+    }
+    let size = this.get('size');
+    return isBlank(size) ? null : `col-form-label-${size}`;
+  }),
+
+  /**
+   * Property for size styling, set to 'lg', 'sm'
+   *
+   * @property size
+   * @type String
+   * @public
+   */
+  size: null
 });

--- a/addon/components/bs4/bs-form/group.js
+++ b/addon/components/bs4/bs-form/group.js
@@ -3,7 +3,6 @@ import FormGroup from 'ember-bootstrap/components/base/bs-form/group';
 
 export default FormGroup.extend({
   classNameBindings: ['isHorizontal:row', 'isCheckbox:form-check:form-group', 'isInlineCheckbox:form-check-inline'],
-  classTypePrefix: 'form-control',
 
   /**
    * Indicates whether the type of the control widget equals `checkbox`

--- a/addon/templates/components/common/bs-form/element.hbs
+++ b/addon/templates/components/common/bs-form/element.hbs
@@ -16,6 +16,7 @@
     formElementId=formElementId
     controlType=controlType
     formLayout=formLayout
+    size=size
   )
   helpTextComponent=(if hasHelpText
     (component helpTextComponent
@@ -36,7 +37,7 @@
       disabled=disabled
       readonly=readonly
       required=required
-      size=controlSize
+      controlSize=controlSize
       tabindex=tabindex
       minlength=minlength
       maxlength=maxlength
@@ -60,6 +61,7 @@
       ariaDescribedBy=(if hasHelpText ariaDescribedBy)
       onChange=(action "change")
       validationType=validation
+      size=size
   ) as |control|}}
     {{#if hasBlock}}
       {{yield

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -704,10 +704,15 @@ module('Integration | Component | bs-form/element', function(hooks) {
   });
 
   testBS4('support size classes', async function(assert) {
-    await render(hbs`{{bs-form/element size="lg"}}`);
-    assert.equal(find('.form-group').classList.contains('form-control-lg'), true, 'form-group has large class');
+    await render(hbs`{{bs-form/element size="lg" label="foo" formLayout="horizontal"}}`);
+    assert.equal(find('.form-group').classList.contains('form-group-lg'), false, 'form-group has not large class');
+    assert.equal(find('input').classList.contains('form-control-lg'), true, 'input has large class');
+    assert.equal(find('label').classList.contains('col-form-label-lg'), true, 'label has large class');
 
-    await render(hbs`{{bs-form/element size="sm"}}`);
-    assert.equal(find('.form-group').classList.contains('form-control-sm'), true, 'form-group has small class');
+    await render(hbs`{{bs-form/element size="sm" label="foo" formLayout="horizontal"}}`);
+    assert.equal(find('.form-group').classList.contains('form-group-sm'), false, 'form-group has not small class');
+    assert.equal(find('input').classList.contains('form-control-sm'), true, 'input has small class');
+    assert.equal(find('label').classList.contains('col-form-label-sm'), true, 'label has large class');
   });
+
 });

--- a/tests/integration/components/bs-form/element/control/input-test.js
+++ b/tests/integration/components/bs-form/element/control/input-test.js
@@ -1,5 +1,6 @@
-import { findAll } from 'ember-native-dom-helpers';
+import { findAll, find } from 'ember-native-dom-helpers';
 import { module, test } from 'qunit';
+import { testBS4 } from "../../../../../helpers/bootstrap-test";
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -12,5 +13,13 @@ module('Integration | Component | bs form/element/control/input', function(hooks
     await render(hbs`{{bs-form/element/control/input}}`);
 
     assert.equal(findAll('input[type=text]').length, 1);
+  });
+
+  testBS4('support size classes', async function(assert) {
+    await render(hbs`{{bs-form/element/control/input size="lg"}}`);
+    assert.equal(find('input').classList.contains('form-control-lg'), true, 'input has large class');
+
+    await render(hbs`{{bs-form/element/control/input size="sm"}}`);
+    assert.equal(find('input').classList.contains('form-control-sm'), true, 'input has small class');
   });
 });

--- a/tests/integration/components/bs-form/element/label-test.js
+++ b/tests/integration/components/bs-form/element/label-test.js
@@ -41,4 +41,18 @@ module('Integration | Component | bs form/element/label', function(hooks) {
     await render(hbs`{{bs-form/element/label controlType="checkbox"}}`);
     assert.equal(find('label').classList.contains('form-check-label'), true, 'component has form-check-label class');
   });
+
+  testBS4('support size classes when using horizontal forms', async function(assert) {
+    await render(hbs`{{bs-form/element/label size="lg" formLayout="horizontal"}}`);
+    assert.equal(find('label').classList.contains('col-form-label-lg'), true, 'label has large class');
+
+    await render(hbs`{{bs-form/element/label size="sm" formLayout="horizontal"}}`);
+    assert.equal(find('label').classList.contains('col-form-label-sm'), true, 'label has small class');
+
+    await render(hbs`{{bs-form/element/label size="lg"}}`);
+    assert.equal(find('label').classList.contains('col-form-label-lg'), false, 'label does not have large class');
+
+    await render(hbs`{{bs-form/element/label size="sm"}}`);
+    assert.equal(find('label').classList.contains('col-form-label-sm'), false, 'label does not have small class');
+  });
 });

--- a/tests/integration/components/bs-form/group-test.js
+++ b/tests/integration/components/bs-form/group-test.js
@@ -52,12 +52,12 @@ module('Integration | Component | bs-form/group', function(hooks) {
     assert.equal(find('.form-group').classList.contains('form-group-sm'), true, 'form-group has small class');
   });
 
-  testBS4('support size classes', async function(assert) {
+  testBS4('does not set size class for BS4', async function(assert) {
     await render(hbs`{{bs-form/group size="lg"}}`);
-    assert.equal(find('.form-group').classList.contains('form-control-lg'), true, 'form-group has large class');
+    assert.equal(find('.form-group').classList.contains('form-group-lg'), false, 'form-group has not large class');
 
     await render(hbs`{{bs-form/group size="sm"}}`);
-    assert.equal(find('.form-group').classList.contains('form-control-sm'), true, 'form-group has small class');
+    assert.equal(find('.form-group').classList.contains('form-group-sm'), false, 'form-group has not small class');
   });
 
   async function testValidationState(assert, state) {


### PR DESCRIPTION
For BS4, this removes the size class of the `.form-group`, and applies the appropriate sizes to the form control (`input`) and `label` (the latter only for horizontal layouts).

Fixes #494 

cc @basz 