### PR TITLE
Fix accordion items wrongly registering as childs on …

### DIFF
--- a/addon/components/base/bs-accordion/item.js
+++ b/addon/components/base/bs-accordion/item.js
@@ -2,7 +2,6 @@ import { oneWay, not } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import TypeClass from 'ember-bootstrap/mixins/type-class';
-import ComponentChild from 'ember-bootstrap/mixins/component-child';
 import layout from 'ember-bootstrap/templates/components/bs-accordion/item';
 
 /**
@@ -13,11 +12,10 @@ import layout from 'ember-bootstrap/templates/components/bs-accordion/item';
  @class AccordionItem
  @namespace Components
  @extends Ember.Component
- @uses Mixins.ComponentChild
  @uses Mixins.TypeClass
  @public
  */
-export default Component.extend(ComponentChild, TypeClass, {
+export default Component.extend(TypeClass, {
   layout,
 
   /**


### PR DESCRIPTION
…the (wrong) parent, e.g. on tab component.

Fixes the weird tab/accordion issue demonstrated in https://github.com/mqje/ember-bootstrap-accordion-example: accordion items were being registered as child to the tab containing them, that's why the tab nav got rerendered whenever a new accordion item was added... 🙄

@mqje this should fix it! Thanks for the awesome reproduction!