### PR TITLE
toggle button does not inherit from `bs-button` anymore,…

### DIFF
--- a/addon/components/base/bs-navbar/toggle.js
+++ b/addon/components/base/bs-navbar/toggle.js
@@ -1,4 +1,4 @@
-import BsButtonComponent from 'ember-bootstrap/components/bs-button';
+import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-navbar/toggle';
 
 /**
@@ -15,11 +15,12 @@ import layout from 'ember-bootstrap/templates/components/bs-navbar/toggle';
  * @extends Components.Button
  * @public
  */
-export default BsButtonComponent.extend({
+export default Component.extend({
   layout,
+  tagName: 'button',
 
   classNameBindings: ['collapsed'],
-  collapsed: true
+  collapsed: true,
 
   /**
    * Bootstrap 4 Only: Defines the alignment of the toggler. Valid values are 'left' and 'right'
@@ -30,5 +31,16 @@ export default BsButtonComponent.extend({
    * @default null
    * @public
    */
+
+  /**
+   * @event onClick
+   * @public
+   */
+  onClick() {
+  },
+
+  click() {
+    this.onClick();
+  }
 
 });

--- a/tests/integration/components/bs-navbar/toggle-test.js
+++ b/tests/integration/components/bs-navbar/toggle-test.js
@@ -1,7 +1,7 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import { test, testBS3, testBS4 } from '../../../helpers/bootstrap-test';
+import { test, testBS3, testBS4, versionDependent } from '../../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | bs-navbar/toggle', function(hooks) {
@@ -29,21 +29,12 @@ module('Integration | Component | bs-navbar/toggle', function(hooks) {
     assert.dom('*').hasText('template block text');
   });
 
-  testBS3('it has correct markup', async function(assert) {
+  test('it has correct markup', async function(assert) {
     await render(hbs`{{bs-navbar/toggle}}`);
 
     assert.dom('button').exists({ count: 1 }, 'there is exactly one button element');
-    assert.dom('button').hasClass('navbar-toggle', 'the toggle has the navbar-toggle class');
+    assert.dom('button').hasClass(versionDependent('navbar-toggle','navbar-toggler'), 'the toggle has the appropriate toggle class');
     assert.dom('button').hasClass('collapsed', 'the toggle has the collapsed class');
-    assert.dom('button').hasClass('btn', 'the toggle has the btn class indicating it derives from bs-button');
-  });
-
-  testBS4('it has correct markup', async function(assert) {
-    await render(hbs`{{bs-navbar/toggle}}`);
-
-    assert.dom('button').exists({ count: 1 }, 'there is exactly one button element');
-    assert.dom('button').hasClass('navbar-toggler', 'the toggle has the navbar-toggler class');
-    assert.dom('button').hasClass('collapsed', 'the toggle has the collapsed class');
-    assert.dom('button').hasClass('btn', 'the toggle has the btn class indicating it derives from bs-button');
+    assert.dom('button').doesNotHaveClass('btn', 'the toggle is a simple button without .btn');
   });
 });


### PR DESCRIPTION
… removing the extraneous `.btn`, `.btn-*` classes

Fixed #531