### PR TITLE
Make BS4 support official

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Browser Status](https://badges.herokuapp.com/sauce/ember-bootstrap)](https://saucelabs.com/u/ember-bootstrap)
 
 
-An [ember-cli](http://www.ember-cli.com) addon for using [Bootstrap](http://getbootstrap.com/) 3 or 4 (experimental) in Ember applications.
+An [ember-cli](http://www.ember-cli.com) addon for using [Bootstrap](http://getbootstrap.com/) 3 or 4 in Ember applications.
 
 The addon includes the Bootstrap assets (CSS, Icons) in your project (can be disabled). On top of that, it provides a set of native Ember components (no use of Bootstrap JavaScript!).</p>
 
@@ -30,10 +30,11 @@ To switch Bootstrap version or preprocessor, see the [setup documentation](http:
 ember-bootstrap works and is fully [tested](https://travis-ci.org/kaliber5/ember-bootstrap) with
 
 * Ember.js 2.3+
-* Bootstrap 3 and 4. *Support for Bootstrap 4 is currently considered experimental and not covered by SemVer, as Bootstrap 4 itself is not yet stable.*
+* Bootstrap 3 and 4.
 * all modern evergreen browsers (Chrome, Firefox, Safari, Edge) and IE 11. 
 * FastBoot 1.0+ 
-* jQuery-less builds using [ember-native-dom-event-dispatcher](https://github.com/rwjblue/ember-native-dom-event-dispatcher)
+* jQuery-less builds (using [ember-native-dom-event-dispatcher](https://github.com/rwjblue/ember-native-dom-event-dispatcher)
+or Ember 3.x)
 
 This project follows [Semantic Versioning](http://semver.org/).
 
@@ -51,4 +52,4 @@ If you want to keep up to date with ember-bootstrap, you may want to [follow me 
 
 ## Copyright and license
 
-Code and documentation copyright 2017 [kaliber5](http://www.kaliber5.de) and contributors. Code released under [the MIT license](LICENSE.md).
+Code and documentation copyright 2018 [kaliber5](http://www.kaliber5.de) and contributors. Code released under [the MIT license](LICENSE.md).

--- a/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
+++ b/tests/dummy/app/templates/getting-started/bootstrap-4.hbs
@@ -2,10 +2,7 @@
 <h1>Bootstrap 4</h1>
 
 <p>
-  The 1.0 release of ember-bootstrap also contains experimental support for Bootstrap 4. Several of the API changes
-  in 1.0 were motivated by creating a mutually compatible structure that works with both Bootstrap 3 and Bootstrap 4.
-  The support is experimental because Bootstrap 4 itself is still in a beta phase. There have been many changes
-  throughout the series of alpha releases and we expect a couple more in the first beta.
+  Starting with the 1.2.0 release of ember-bootstrap it comes with support for Bootstrap 4 that can be considered stable.
 </p>
 
 <h2>Moving to Bootstrap 4</h2>
@@ -39,10 +36,10 @@
   </li>
   <li>
     Refer to the
-    <a href="https://v4-alpha.getbootstrap.com/getting-started/introduction/" target="_blank" rel="noopener">
+    <a href="http://getbootstrap.com/docs/4.0/getting-started/introduction/" target="_blank" rel="noopener">
       Bootstrap 4 documentation
     </a> and, in particular, the
-    <a href="https://v4-alpha.getbootstrap.com/migration/" target="_blank" rel="noopener">
+    <a href="http://getbootstrap.com/docs/4.0/migration/" target="_blank" rel="noopener">
       Migration Guide
     </a> for other necessary changes in markup with Bootstrap 4.
   </li>

--- a/tests/dummy/app/templates/getting-started/index.hbs
+++ b/tests/dummy/app/templates/getting-started/index.hbs
@@ -40,7 +40,7 @@
   <div class="col-sm-3">
     <h2>Bootstrap 4</h2>
     <p>
-      ember-bootstrap comes with (experimental) support for Bootstrap 4 (beta). Learn how to switch your project to use
+      ember-bootstrap comes with support for Bootstrap 4. Learn how to switch your project to use
       Bootstrap 4.
     </p>
     <p>{{#link-to "getting-started.bootstrap-4" class="btn btn-primary"}}Tell me more{{/link-to}}</p>

--- a/tests/dummy/app/templates/getting-started/setup.hbs
+++ b/tests/dummy/app/templates/getting-started/setup.hbs
@@ -25,7 +25,7 @@
 
 <h4>Switch to Bootstrap 4</h4>
 
-<p>Bootstrap 4 is still in an beta stage, so support for it in ember-bootstrap remains experimental. But you can easily make the switch by running this command:</p>
+<p>You can switch to Bootstrap 4 by running this command:</p>
 
 <pre class="highlight">ember generate ember-bootstrap --bootstrap-version=4</pre>
 


### PR DESCRIPTION
As BS 4 hit stable (with no breaking changes from `beta.3`), and there are no known unresolved bugs, I think we can remove the *experimental*  support warnings and declare our support to be stable as well. 

@srvance agree?