### PR TITLE
WIP: Yield validate and submit actions as part of the form hash

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -44,6 +44,7 @@ import layout from 'ember-bootstrap/templates/components/bs-form';
     {{form.element controlType="email" label="Email" placeholder="Email" property="email"}}
     {{form.element controlType="password" label="Password" placeholder="Password" property="password"}}
     {{form.element controlType="checkbox" label="Remember me" property="rememberMe"}}
+    {{bs-button defaultText="Validate" type="info" onClick=(action form.validate)}}
     {{bs-button defaultText="Submit" type="primary" buttonType="submit"}}
   {{/bs-form}}
   ```
@@ -242,6 +243,24 @@ export default Component.extend({
     }
   },
 
+  _validate() {
+    let model = this.get('model');
+
+    let validationPromise = this.validate(model);
+    if (validationPromise && validationPromise instanceof RSVP.Promise) {
+      let validatedPromise = new RSVP.Promise((resolve, reject) => {
+        validationPromise
+          .then(() => { resolve() })
+          .catch(() => {
+            this.set('showAllValidations', true);
+            return reject();
+          });
+      });
+
+      return validatedPromise;
+    }
+  },
+
   keyPress(e) {
     let code = e.keyCode || e.which;
     if (code === 13 && this.get('submitOnEnter')) {
@@ -261,6 +280,38 @@ export default Component.extend({
         isPresent(model) && isPresent(property)
       );
       set(model, property, value);
+    },
+
+    /**
+     * Submit action yielded in the bs-form template and accessible as `form.submit`
+     *
+     * @method actions.submit
+     * @param {Object} [model] Optional, falls back to model passed to bs-form
+     * @return {Promise} (not yet implemented)
+     * @public
+     */
+    submit(model=null) {
+      if(model) {
+        this.set('model', model);
+      }
+      return this.submit();
+    },
+
+    /**
+     * Validate action yielded in the bs-form template and accessible as `form.validate`
+     * This action returns a promise that will either resolve if the model is valid
+     * or reject if it's not.
+     *
+     * @method actions.validate
+     * @param {Object} [model] Optional, falls back to model passed to bs-form
+     * @return {Promise}
+     * @public
+     */
+    validate(model=null) {
+      if(model) {
+        this.set('model', model);
+      }
+      return this._validate();
     }
   }
 });

--- a/addon/templates/components/common/bs-form.hbs
+++ b/addon/templates/components/common/bs-form.hbs
@@ -8,5 +8,7 @@
       onChange=(action "change")
     )
     group=(component "bs-form/group" formLayout=formLayout)
+    validate=(action 'validate')
+    submit=(action 'submit')
   )
 }}

--- a/tests/unit/components/common/bs-form-test.js
+++ b/tests/unit/components/common/bs-form-test.js
@@ -1,0 +1,59 @@
+import { setupTest, test } from 'ember-qunit';
+import { reject, resolve } from 'rsvp';
+import { module } from 'qunit';
+
+module('Unit | Component | bs-form', function(hooks) {
+  setupTest(hooks);
+
+  test('calling form.validate returns success if validations pass', function(assert) {
+    assert.expect(1);
+
+    let Factory = this.owner.factoryFor('component:bs-form');
+    let subject = Factory.create({ hasValidator: true, model: {}, validate: function() { return resolve(); } });
+
+    let validatedResult = subject.actions.validate.apply(subject);
+    validatedResult.then(() => {
+      assert.ok(true, 'validations passed');
+    });
+  });
+
+  test('calling form.validate returns false if validations fail', function(assert) {
+    assert.expect(1);
+
+    let Factory = this.owner.factoryFor('component:bs-form');
+    let subject = Factory.create({ hasValidator: true, model: {}, validate: function() { return reject(); } });
+
+    let validatedResult = subject.actions.validate.apply(subject);
+    validatedResult.catch(() => {
+      assert.ok(true, 'validations failed');
+    });
+  });
+
+  test('calling form.validate with a model validates that specific model', function(assert) {
+    assert.expect(2);
+
+    let testModel = {
+      validated: false,
+    };
+
+    let Factory = this.owner.factoryFor('component:bs-form');
+    let subject = Factory.create({
+      hasValidator: true,
+      validate: function(model) {
+        return model.validated ? resolve() : reject();
+      }
+    });
+
+    let failingResult = subject.actions.validate.apply(subject, [ testModel ]);
+    failingResult.catch(() => {
+      assert.ok(true, 'validations failed');
+    });
+
+    testModel.validated = true;
+
+    let passingResult = subject.actions.validate.apply(subject, [ testModel ]);
+    passingResult.then(() => {
+      assert.ok(true, 'validations passed');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #476 

@simonihmig Here's the promised PR. This is still a WIP but thought I'd put it up to get your input on a few things (and make sure I'm taking this the direction you want). This has been tested against the client app I'm working on (and it greatly simplifies the use case I'm dealing with).