### PR TITLE
Removed the `align` property of the `nav-toggler` component

### DIFF
--- a/addon/components/base/bs-navbar.js
+++ b/addon/components/base/bs-navbar.js
@@ -30,6 +30,9 @@ import listenTo from 'ember-bootstrap/utils/listen-to-cp';
  {{/bs-navbar}}
  ```
 
+ **Note:** the `<div class="navbar-header">` is required for BS3 to hold the elements visible on a mobile breakpoint,
+ when the actual content is collapsed. It should *not* be used for BS4!
+
  The component yields references to the following contextual components:
 
  * [Components.NavbarContent](Components.NavbarContent.html)

--- a/addon/components/base/bs-navbar/toggle.js
+++ b/addon/components/base/bs-navbar/toggle.js
@@ -23,16 +23,6 @@ export default Component.extend({
   collapsed: true,
 
   /**
-   * Bootstrap 4 Only: Defines the alignment of the toggler. Valid values are 'left' and 'right'
-   * to set the `navbar-toggler-*` class.
-   *
-   * @property align
-   * @type String
-   * @default null
-   * @public
-   */
-
-  /**
    * @event onClick
    * @public
    */

--- a/addon/components/bs4/bs-navbar/toggle.js
+++ b/addon/components/bs4/bs-navbar/toggle.js
@@ -1,26 +1,5 @@
-import { computed } from '@ember/object';
 import NavbarToggle from 'ember-bootstrap/components/base/bs-navbar/toggle';
 
 export default NavbarToggle.extend({
-  classNames: ['navbar-toggler'],
-  classNameBindings: ['alignmentClass'],
-
-  /**
-   * Defines the alignment of the toggler. Valid values are 'left' and 'right'
-   * to set the `navbar-toggler-*` class.
-   *
-   * @property align
-   * @type String
-   * @default null
-   * @public
-   */
-  align: null,
-
-  alignmentClass: computed('align', function() {
-    let align = this.get('align');
-
-    if (align) {
-      return `navbar-toggler-${align}`;
-    }
-  }).readOnly()
+  classNames: ['navbar-toggler']
 });


### PR DESCRIPTION
It has been removed, as it has not been used anymore in the stable BS4
Fixes 549