### PR TITLE
Render dropdown menu in a wormhole

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -94,6 +94,10 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown';
  wish to have a dropdown menu item refer to an external link, be sure to apply the `dropdown-item`
  class to the `<a>` tag for Bootstrap 4 compatibility.
 
+ In Bootstrap 4 the dropdown menu will be positioned using the `popper.js` library, just as the original Bootstrap
+ version does. This also allows you to set `renderInPlace=false` on the menu component to render it in a wormhole,
+ which you might want to do if you experience clipping issues by an outer `overflow: hidden` element.
+
  @class Dropdown
  @namespace Components
  @extends Ember.Component

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -57,6 +57,17 @@ export default Component.extend({
    */
   inNav: false,
 
+  /**
+   * Applies only to BS4: by default the menu is rendered in the same place the dropdown. If you experience clipping
+   * issues, you can set this to false to render the menu in a wormhole at the top of the DOM.
+   *
+   * @property renderInPlace
+   * @type boolean
+   * @default true
+   * @public
+   */
+  renderInPlace: true,
+
   alignClass: computed('align', function() {
     if (this.get('align') !== 'left') {
       return `dropdown-menu-${this.get('align')}`;

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -3,8 +3,9 @@
   ariaRole=ariaRole
   placement=popperPlacement
   popperTarget=toggleElement
-  renderInPlace=true
   modifiers=popperModifiers
+  renderInPlace=renderInPlace
+  popperContainer="#ember-bootstrap-wormhole"
   registerAPI=(action "registerPopperApi")
 }}
   {{yield

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -183,4 +183,17 @@ module('Integration | Component | bs-dropdown', function(hooks) {
     assert.ok(isVisible(this.element.querySelector('.dropdown-menu a')));
     assert.ok(this.element.querySelector('.dropdown-menu').offsetParent !== null);
   });
+
+  testBS4('dropdown menu can be rendered in a wormhole', async function(assert) {
+    await render(
+      hbs`
+        <div id="ember-bootstrap-wormhole"></div>
+        {{#bs-dropdown as |dd|}}
+          {{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}
+          {{#dd.menu renderInPlace=false}}<li><a href="#">Something</a></li>{{/dd.menu}}
+        {{/bs-dropdown}}`
+    );
+
+    assert.dom('#ember-bootstrap-wormhole .dropdown-menu').exists({ count: 1 }, 'Menu is rendered in wormhole');
+  });
 });


### PR DESCRIPTION
By setting `renderInPlace=false` to prevent clipping issues

Closes #561