### PR TITLE
Yield actions in dropdown & navbar

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -17,6 +17,12 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown';
    * [Components.DropdownMenuDivider](Components.DropdownMenuDivider.html)
    * [Components.DropdownMenuLinkTo](Components.DropdownMenuLinkTo.html)
 
+ Furthermore references to the following actions are yielded:
+
+ * `toggleDropdown`
+ * `openDropdown`
+ * `closeDropdown`
+
  ```hbs
  {{#bs-dropdown as |dd|}}
    {{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}
@@ -78,6 +84,44 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown';
  ...
  {{/bs-dropdown}}
  ```
+
+ ### Open, close or toggle the dropdown programmatically
+
+ If you wanted to control when the dropdown opens and closes programmatically, the `bs-dropdown` component yields the
+ `openDropdown`, `closeDropdown` and `toggleDropdown` actions which you can then pass to your own handlers. For example:
+
+ ```hbs
+ {{#bs-dropdown closeOnMenuClick=false as |dd|}}
+   {{#bs-button}}Dropdown{{/bs-button}}
+   {{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}
+   {{#dd.menu as |ddm|}}
+     {{#each items as |item|}}
+       {{#ddm.item}}
+         <a href onclick={{action "changeItems" item dd.closeDropdown}}>
+           {{item.text}}
+         </a>
+       {{/ddm.item}}
+     {{/each}}
+   {{/dd.menu}}
+   {{/bs-dropdown}}
+ ```
+
+ Then in your controller or component, optionally close the dropdown:
+
+ ```js
+ ...
+ actions: {
+   handleDropdownClicked(item, closeDropdown) {
+     if(item.isTheRightOne) {
+       this.chosenItems.pushObject(item);
+       closeDropdown();
+     } else {
+       this.set('item', this.getRandomItems());
+     }
+   },
+ }
+ ```
+
 
  ### Bootstrap 3/4 Notes
 

--- a/addon/components/base/bs-navbar.js
+++ b/addon/components/base/bs-navbar.js
@@ -43,6 +43,7 @@ import listenTo from 'ember-bootstrap/utils/listen-to-cp';
 
  * `collapse`: triggers the `onCollapse` action and collapses the navbar (mobile)
  * `expand`: triggers the `onExpand` action and expands the navbar (mobile)
+ * `toggleNavbar`: triggers the `toggleNavbar` action and toggles the navbar (mobile)
 
  ### Responsive Design
 

--- a/addon/templates/components/bs3/bs-navbar.hbs
+++ b/addon/templates/components/bs3/bs-navbar.hbs
@@ -6,6 +6,7 @@
       nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
+      toggleNavbar=(action 'toggleNavbar')
     )
   }}
 </div>

--- a/addon/templates/components/bs4/bs-navbar.hbs
+++ b/addon/templates/components/bs4/bs-navbar.hbs
@@ -6,6 +6,7 @@
       nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
+      toggleNavbar=(action 'toggleNavbar')
     )
   }}
 {{else}}
@@ -17,6 +18,7 @@
         nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
         collapse=(action "collapse")
         expand=(action "expand")
+        toggleNavbar=(action 'toggleNavbar')
       )
     }}
   </div>

--- a/addon/templates/components/common/bs-dropdown.hbs
+++ b/addon/templates/components/common/bs-dropdown.hbs
@@ -3,6 +3,9 @@
     button=(component "bs-dropdown/button" dropdown=this onClick=(action "toggleDropdown"))
     toggle=(component "bs-dropdown/toggle" dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
     menu=(component "bs-dropdown/menu" isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement)
+    toggleDropdown=(action "toggleDropdown")
+    openDropdown=(action "openDropdown")
+    closeDropdown=(action "closeDropdown")
     isOpen=isOpen
   )
 }}


### PR DESCRIPTION
Navbar already yielded open & close actions but forcing developers to double-bookkeep the open/closed status is unnecessary when we can just yield the toggle action as well.
Dropdown is impossible to control programmatically without yielding the actions.

Fixes #559