### PR TITLE
Fix for issue with destroyed form elements

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -872,8 +872,8 @@ export default FormGroup.extend({
       let el = this.get('element');
       let feedbackIcon;
       // validation state icons are only shown if form element has feedback
-      if (this.get('hasFeedback')
-        && !this.get('isDestroying')
+      if (!this.get('isDestroying')
+        && this.get('hasFeedback')
         // and form group element has
         // an input-group
         && el.querySelector('.input-group')


### PR DESCRIPTION
In some situations I get the following error:
`Assertion Failed: Cannot modify dependent keys for 'validation' on '<???@component:bs-form/element::ember1765>' after it has been destroyed.`

This problem is caused by getting 'hasFeedback' on an object that 'isDestroying'. Changed the order of both checks to fix it.