### PR TITLE
Add carousel-fade to BS4 carousels.

### DIFF
--- a/addon/components/base/bs-carousel.js
+++ b/addon/components/base/bs-carousel.js
@@ -401,22 +401,33 @@ export default Component.extend(ComponentParent, {
   transitionDuration: 600,
 
   /**
+   * The type slide transition to perform.
+   * Options are 'fade' or 'slide'. Note: BS4 only
+   *
+   * @default 'slide'
+   * @property transition
+   * @public
+   * @type string
+   */
+  transition: 'slide',
+
+  /**
    * Do a presentation and calls itself to perform a cycle.
    *
    * @method cycle
    * @private
    */
   cycle: task(function* () {
-    yield this.get('transition').perform();
+    yield this.get('transitioner').perform();
     yield timeout(this.get('interval'));
     this.toAppropriateSlide();
   }).restartable(),
 
   /**
-   * @method transition
+   * @method transitioner
    * @private
    */
-  transition: task(function* () {
+  transitioner: task(function* () {
     this.set('presentationState', 'willTransit');
     yield timeout(this.get('transitionDuration'));
     this.set('presentationState', 'didTransition');
@@ -452,7 +463,7 @@ export default Component.extend(ComponentParent, {
       this.assignClassNameControls(toIndex);
       this.setFollowingIndex(toIndex);
       if (this.get('shouldRunAutomatically') === false || this.get('isMouseHovering')) {
-        this.get('transition').perform();
+        this.get('transitioner').perform();
       } else {
         this.get('cycle').perform();
       }
@@ -516,7 +527,7 @@ export default Component.extend(ComponentParent, {
       if (
         self.get('pauseOnMouseEnter')
         && (
-          self.get('transition.last') !== null
+          self.get('transitioner.last') !== null
           || self.get('waitIntervalToInitCycle.last') !== null
         )
       ) {

--- a/addon/components/bs4/bs-carousel.js
+++ b/addon/components/bs4/bs-carousel.js
@@ -1,8 +1,12 @@
 import Carousel from 'ember-bootstrap/components/base/bs-carousel';
+import { equal } from '@ember/object/computed';
+
 
 export default Carousel.extend({
   nextControlClassName: 'carousel-control-next',
   nextControlIcon: 'carousel-control-next-icon',
   prevControlClassName: 'carousel-control-prev',
-  prevControlIcon: 'carousel-control-prev-icon'
+  prevControlIcon: 'carousel-control-prev-icon',
+  classNameBindings: ['carouselFade'],
+  carouselFade: equal('transition', 'fade').readOnly()
 });

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -104,6 +104,11 @@ module('Integration | Component | bs-carousel', function(hooks) {
 
   // Parameters
 
+  testBS4('carousel transition="fade" has correct markup', async function(assert) {
+    await render(hbs`{{bs-carousel interval=0 transition='fade'}}`);
+    assert.dom('.carousel').hasClass('carousel-fade', 'has carousel-fade class');
+  });
+
   test('carousel autoPlay=false must not start sliding', async function(assert) {
     await render(hbs`{{#bs-carousel autoPlay=false interval=300 transitionDuration=transitionDuration as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
     await waitTransitionTime();


### PR DESCRIPTION
Took a stab at adding the carousel fade functionality to a BS4 only carousel.

When a `transition` param is set to `fade`, it will add the 'carousel-fade' class to the carousel so all slide transitions are fade transitions.

Is there a way to signify that some params are for BS4 only?

Addresses https://github.com/kaliber5/ember-bootstrap/issues/582