### PR TITLE
Fix `calling set on destroyed element` issue for bs-tooltip

### DIFF
--- a/addon/components/base/bs-contextual-help.js
+++ b/addon/components/base/bs-contextual-help.js
@@ -451,7 +451,7 @@ export default Component.extend(TransitionSupport, {
    * @private
    */
   show() {
-    if (this.get('isDestroyed')) {
+    if (this.get('isDestroyed') || this.get('isDestroying')) {
       return;
     }
 


### PR DESCRIPTION
It's possible if you very quickly try and open a tooltip while changing 
routes, to get a console error because the tooltip tries to call `set` 
during the transition.

This can happen if the user quickly moves the cursor across a tooltip trigger on their way to click a link. Hard to reproduce reliably, but I can make it happen every so often in my app.