### PR TITLE
feat(Button): bs-button yields state and shorthands

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -334,9 +334,7 @@ export default Component.extend(TypeClass, SizeClass, {
 
   resetObserver: observer('reset', function() {
     if (this.get('reset')) {
-      scheduleOnce('actions', this, function() {
-        this.set('state', 'default');
-      });
+      scheduleOnce('actions', this, 'resetState');
     }
   }),
 

--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -285,7 +285,11 @@ export default Component.extend(TypeClass, SizeClass, {
   isSettled: or('isFulfilled', 'isRejected'),
 
   /**
-   * Set this to true to reset the state. A typical use case is to bind this attribute with ember-data isDirty flag.
+   * Set this to `true` to reset the `state`. A typical use case is to bind this attribute with ember-data isDirty flag.
+   *
+   * The old value is not taken into consideration. Setting a `true` value to `true` again will also reset `state`.
+   * In that case it's even to notify the observer system that the property has changed by calling
+   * [`notifyPropertyChange()`](https://www.emberjs.com/api/ember/3.2/classes/EmberObject/methods/notifyPropertyChange?anchor=notifyPropertyChange).
    *
    * @property reset
    * @type boolean

--- a/addon/templates/components/common/bs-button.hbs
+++ b/addon/templates/components/common/bs-button.hbs
@@ -1,1 +1,8 @@
-{{#if icon}}<i class="{{icon}}"></i> {{/if}}{{text}}{{yield}}
+{{#if icon}}<i class="{{icon}}"></i> {{/if}}{{text}}{{yield
+  (hash
+    isFulfilled=isFulfilled
+    isPending=isPending
+    isRejected=isRejected
+    isSettled=isSettled
+  )
+}}


### PR DESCRIPTION
Example usage to show a slider if button triggered by `onClick` event
is pending:

```
{{#bs-button onClick=(action 'download') |button|}}
  Download
  {{#if button.isPending}}
    {{fa-icon "slider"}}
  {{/if}}
{{/bs-button}}
```