### PR TITLE
Yield toggleNavBar action

### DIFF
--- a/addon/components/base/bs-navbar.js
+++ b/addon/components/base/bs-navbar.js
@@ -43,6 +43,7 @@ import listenTo from 'ember-bootstrap/utils/listen-to-cp';
 
  * `collapse`: triggers the `onCollapse` action and collapses the navbar (mobile)
  * `expand`: triggers the `onExpand` action and expands the navbar (mobile)
+ * `toggleNavbar`: triggers the `toggleNavbar` action and toggles the navbar (mobile)
 
  ### Responsive Design
 

--- a/addon/templates/components/bs3/bs-navbar.hbs
+++ b/addon/templates/components/bs3/bs-navbar.hbs
@@ -6,6 +6,7 @@
       nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
+      toggleNavbar=(action 'toggleNavbar')
     )
   }}
 </div>

--- a/addon/templates/components/bs4/bs-navbar.hbs
+++ b/addon/templates/components/bs4/bs-navbar.hbs
@@ -6,6 +6,7 @@
       nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
+      toggleNavbar=(action 'toggleNavbar')
     )
   }}
 {{else}}
@@ -17,6 +18,7 @@
         nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
         collapse=(action "collapse")
         expand=(action "expand")
+        toggleNavbar=(action 'toggleNavbar')
       )
     }}
   </div>

--- a/tests/integration/components/bs-navbar-test.js
+++ b/tests/integration/components/bs-navbar-test.js
@@ -93,6 +93,8 @@ module('Integration | Component | bs-navbar', function(hooks) {
     );
   });
 
+
+
   testBS3('it exposes all the requisite contextual components', async function(assert) {
     await render(hbs`
       {{#bs-navbar as | navbar | }}
@@ -371,6 +373,24 @@ module('Integration | Component | bs-navbar', function(hooks) {
 
     await click('button');
     assert.ok(action.calledOnce, 'onExpand action has been called.');
+  });
+
+  test('Navbar yields toggleNavbar action', async function(assert) {
+    let expanded = this.spy();
+    this.actions.expanded = expanded;
+
+    let collapsed = this.spy();
+    this.actions.collapsed = collapsed;
+
+    await render(hbs`{{#bs-navbar collapsed=true onExpand=(action "expanded") onCollapse=(action "collapsed") as |navbar|}}
+        <button {{action navbar.toggleNavbar}}>Expand</button>
+    {{/bs-navbar}}`);
+
+    await click('button');
+    assert.ok(expanded.calledOnce, 'onExpand action has been called.');
+
+    await click('button');
+    assert.ok(collapsed.calledOnce, 'onCollapse action has been called.');
   });
 
   test('Clicking expanded navbar link collapses navbar', async function(assert) {


### PR DESCRIPTION
As requested in #587, here is the other half of that PR that touches `bs-navbar`.

Unfortunately, upon closer inspection I found I could not rename `toggleNavbar` here either because (again) there's [already an item in that hash named `toggle`](https://github.com/boundless-inc/ember-bootstrap/blob/d1a826bbbfd28c9b2c3285049356f45f40f2b076/addon/templates/components/bs3/bs-navbar.hbs#L4) ([same](https://github.com/boundless-inc/ember-bootstrap/blob/d1a826bbbfd28c9b2c3285049356f45f40f2b076/addon/templates/components/bs4/bs-navbar.hbs#L4) for bs4). And renaming that would break backwards compatibility. 😞