### PR TITLE
fix(Dropdown): render menu lazily only when opening it.

### DIFF
--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { notEmpty } from '@ember/object/computed';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu';
 
 /**
@@ -99,8 +98,6 @@ export default Component.extend({
   flip: true,
 
   _popperApi: null,
-
-  inDom: notEmpty('toggleElement').readOnly(),
 
   popperPlacement: computed('direction', 'align', function() {
     let placement = 'bottom-start';

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -1,4 +1,4 @@
-{{#if inDom}}
+{{#if isOpen}}
   {{#ember-popper
     class="ember-bootstrap-dropdown-bs3-popper"
     ariaRole=ariaRole

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -1,4 +1,4 @@
-{{#if inDom}}
+{{#if isOpen}}
   {{#ember-popper
     class=(concat "dropdown-menu " alignClass (if isOpen " show"))
     ariaRole=ariaRole

--- a/tests/helpers/bootstrap-test.js
+++ b/tests/helpers/bootstrap-test.js
@@ -117,7 +117,7 @@ export function isVisible(el) {
 export function isHidden(el) {
   // A bit of an odd test, but taken from https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
   // referencing https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
-  return el.offsetParent === null;
+  return !el || el.offsetParent === null;
 }
 
 export { test };

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -70,11 +70,12 @@ module('Integration | Component | bs-dropdown', function(hooks) {
       hbs`{{#bs-dropdown as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
     );
 
-    assert.dom(dropdownVisibilityElementSelector()).hasNoClass(openClass(), 'Dropdown is closed');
+    assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
     await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
     await click('a.dropdown-toggle');
-    assert.dom(dropdownVisibilityElementSelector()).hasNoClass(openClass(), 'Dropdown is closed');
+    assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
   });
 
   test('opened dropdown will close on outside click', async function(assert) {
@@ -86,7 +87,7 @@ module('Integration | Component | bs-dropdown', function(hooks) {
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
 
     await click('*');
-    assert.dom(dropdownVisibilityElementSelector()).hasNoClass(openClass(), 'Dropdown is closed');
+    assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
   });
 
   test('clicking dropdown menu will close it', async function(assert) {
@@ -94,10 +95,11 @@ module('Integration | Component | bs-dropdown', function(hooks) {
       hbs`{{#bs-dropdown as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
     );
     await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
 
     await click('.dropdown-menu a');
-    assert.dom(dropdownVisibilityElementSelector()).hasNoClass(openClass(), 'Dropdown is closed');
+    assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
   });
 
   test('dropdown will close on click, when default is prevented, propagation is stopped', async function(assert) {
@@ -125,9 +127,11 @@ module('Integration | Component | bs-dropdown', function(hooks) {
       hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
     );
     await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
 
     await click('.dropdown-menu a');
+    assert.dom('.dropdown-menu').exists();
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
   });
 
@@ -249,6 +253,7 @@ module('Integration | Component | bs-dropdown', function(hooks) {
         {{/bs-dropdown}}`
     );
 
+    await click('a.dropdown-toggle');
     assert.dom('#ember-bootstrap-wormhole .dropdown-menu').exists({ count: 1 }, 'Menu is rendered in wormhole');
   });
 });

--- a/tests/integration/components/bs-dropdown/menu-test.js
+++ b/tests/integration/components/bs-dropdown/menu-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | bs-dropdown/menu', function(hooks) {
   setupRenderingTest(hooks);
 
   testBS3('dropdown menu has correct markup', async function(assert) {
-    await render(hbs`{{#bs-dropdown/menu align="right" toggleElement=this.element}}Something{{/bs-dropdown/menu}}`);
+    await render(hbs`{{#bs-dropdown/menu align="right" isOpen=true toggleElement=this.element}}Something{{/bs-dropdown/menu}}`);
 
     assert.equal(this.element.querySelector('.dropdown-menu').tagName, 'UL', 'menu is an unordered list (<ul>) by default');
     assert.dom('.dropdown-menu').exists('menu has dropdown-menu class');
@@ -18,7 +18,7 @@ module('Integration | Component | bs-dropdown/menu', function(hooks) {
   });
 
   testBS4('dropdown menu has correct markup', async function(assert) {
-    await render(hbs`{{#bs-dropdown/menu align="right" toggleElement=this.element}}Something{{/bs-dropdown/menu}}`);
+    await render(hbs`{{#bs-dropdown/menu align="right" isOpen=true toggleElement=this.element}}Something{{/bs-dropdown/menu}}`);
 
     assert.equal(this.element.querySelector('.dropdown-menu').tagName, 'DIV', 'menu is a div (<div>) by default');
     assert.dom('.dropdown-menu').exists('menu has dropdown-menu class');
@@ -27,13 +27,13 @@ module('Integration | Component | bs-dropdown/menu', function(hooks) {
   });
 
   testBS3('dropdown menu yields item component', async function(assert) {
-    await render(hbs`{{#bs-dropdown/menu toggleElement=this.element as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`);
+    await render(hbs`{{#bs-dropdown/menu toggleElement=this.element isOpen=true as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`);
 
     assert.dom('li').exists({ count: 1 }, 'has item component');
   });
 
   testBS4('dropdown menu yields item component', async function(assert) {
-    await render(hbs`{{#bs-dropdown/menu toggleElement=this.element as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`
+    await render(hbs`{{#bs-dropdown/menu toggleElement=this.element isOpen=true as |ddm|}}{{#ddm.item}}Dummy{{/ddm.item}}{{/bs-dropdown/menu}}`
     );
 
     assert.dom('.dropdown-item').doesNotExist('has item component with no markup');

--- a/tests/integration/components/bs-nav-test.js
+++ b/tests/integration/components/bs-nav-test.js
@@ -61,7 +61,5 @@ module('Integration | Component | bs-nav', function(hooks) {
     assert.dom('.nav > li').exists({ count: 2 }, 'it has the nav item');
     assert.dom('.nav > li > a[href]').exists({ count: 1 }, 'it has the nav link');
     assert.dom('.nav > li.dropdown').exists({ count: 1 }, 'it has a dropdown as a nav item');
-    assert.dom('.nav > li.dropdown .dropdown-menu').exists({ count: 1 }, 'it has the nav dropdown menu');
-    assert.dom('.nav > li.dropdown .dropdown-menu a').exists({ count: 1 }, 'it has the nav dropdown menu item');
   });
 });

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -147,6 +147,8 @@ module('Integration | Component | bs-tab', function(hooks) {
     assert.dom('ul.nav.nav-tabs > li:nth-child(2) > a').hasText('Tab 2', 'navigation item shows pane title');
     assert.dom('ul.nav.nav-tabs > li:nth-child(3)').hasClass('dropdown', 'adds dropdown for grouped items');
     assert.dom('ul.nav.nav-tabs > li:nth-child(3) > a').hasText('Dropdown', 'drop down item shows pane groupTitle');
+
+    await click('ul.nav.nav-tabs > li:nth-child(3) a');
     assert.equal(this.element.querySelector('ul.nav.nav-tabs > li:nth-child(3) .dropdown-menu').children.length, 2, 'puts items with groupTitle under dropdown menu');
     assert.dom('ul.nav.nav-tabs > li:nth-child(3) .dropdown-menu > :nth-child(1)').hasText('Tab 3', 'dropdown menu item shows pane title');
     assert.dom('ul.nav.nav-tabs > li:nth-child(3) .dropdown-menu > :nth-child(2)').hasText('Tab 4', 'dropdown menu item shows pane title');

--- a/vendor/ember-bootstrap/bs3.css
+++ b/vendor/ember-bootstrap/bs3.css
@@ -43,4 +43,5 @@ Adding this class ensures it appears in front of other elements.
 */
 .ember-bootstrap-dropdown-bs3-popper {
     z-index: 1000;
+    display: inline;
 }


### PR DESCRIPTION
This fixes performance problems due to popper.js adding scroll event listeners when the menu and thus ember-popper is rendered.