### PR TITLE
Dropdown: fixed actions on dropdown menu's children not being fired

### DIFF
--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu';
+import { next } from '@ember/runloop';
 
 /**
  Component for the dropdown menu.
@@ -89,11 +90,19 @@ export default Component.extend({
       return false;
     },
     set(key, value) {
-      let update = this.get('_popperApi.update');
-      update && update();
+      // delay removing the menu from DOM to allow (delegated Ember) event to fire for the menu's children
+      // Fixes https://github.com/kaliber5/ember-bootstrap/issues/660
+      next(() => {
+        if (this.get('isDestroying') || this.get('isDestroyed')) {
+          return;
+        }
+        this.set('_isOpen', value)
+      });
       return value;
     }
   }),
+
+  _isOpen: false,
 
   flip: true,
 

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -137,11 +137,5 @@ export default Component.extend({
         enabled: this.get('flip')
       }
     };
-  }),
-
-  actions: {
-    registerPopperApi(api) {
-      this.set('_popperApi', api);
-    }
-  }
+  })
 });

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -1,4 +1,4 @@
-{{#if isOpen}}
+{{#if _isOpen}}
   {{#ember-popper
     class="ember-bootstrap-dropdown-bs3-popper"
     ariaRole=ariaRole

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -7,7 +7,6 @@
     renderInPlace=_renderInPlace
     popperContainer="#ember-bootstrap-wormhole"
     modifiers=popperModifiers
-    registerAPI=(action "registerPopperApi")
   }}
     <ul class={{concat "dropdown-menu " alignClass (if isOpen " show")}} role={{ariaRole}}>
       {{yield

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -7,7 +7,6 @@
     renderInPlace=_renderInPlace
     popperContainer="#ember-bootstrap-wormhole"
     modifiers=popperModifiers
-    registerAPI=(action "registerPopperApi")
   }}
     {{yield
       (hash

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -1,4 +1,4 @@
-{{#if isOpen}}
+{{#if _isOpen}}
   {{#ember-popper
     class=(concat "dropdown-menu " alignClass (if isOpen " show"))
     ariaRole=ariaRole

--- a/yarn.lock
+++ b/yarn.lock
@@ -7689,12 +7689,12 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-dom@^0.6.2:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.6.3.tgz#f6d7563218179c4f0ef85f940bb79e10631c14ff"
+qunit-dom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.8.0.tgz#a735e7f6ec2e9d08ec5bb695b3d52c97011e69b8"
   dependencies:
     broccoli-funnel "^2.0.0"
-    broccoli-merge-trees "^2.0.0"
+    broccoli-merge-trees "^3.0.1"
 
 qunit@^2.5.0:
   version "2.6.1"


### PR DESCRIPTION
Fixes #660

The menu was removed from DOM (introduced in 2.1.0) before Ember's event dispatcher handled actions of menu's children elements, preventing the actions to be called correctly. 
The super weird thing was that this was easily reproducible in development, but not at all in tests. The same code somehow behaved slightly different in tests with regards to timing (menu was still in DOM in tests), so no way to catch this! So no regression tests are possible for this unfortunately 🤨