### PR TITLE
fix bs-button text-resolve for statefull texts

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -104,7 +104,7 @@ export default Component.extend(TypeClass, SizeClass, {
    * @type string
    * @public
    */
-  pendingText: null,
+  pendingText: undefined,
 
   /**
    * Label of the button used if `onClick` event has returned a Promise which succeeded.
@@ -114,7 +114,7 @@ export default Component.extend(TypeClass, SizeClass, {
    * @type string
    * @public
    */
-  fulfilledText: null,
+  fulfilledText: undefined,
 
   /**
    * @property resolvedText
@@ -135,7 +135,7 @@ export default Component.extend(TypeClass, SizeClass, {
    * @type string
    * @public
    */
-  rejectedText: null,
+  rejectedText: undefined,
 
   /**
    * Property to disable the button

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -139,6 +139,39 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.dom('button').hasText('text for rejected state');
   });
 
+  test('button text remains to default if no state text wasn\'t set', async function (assert) {
+    let deferredClickAction = defer();
+    this.set('clickAction', () => {
+      return deferredClickAction.promise;
+    });
+
+    await render(
+      hbs`{{bs-button
+      defaultText="default text"      
+      onClick=clickAction
+    }}`);
+    assert.dom('button').hasText('default text');
+
+    click('button');
+    await waitUntil(() => {
+      return find('button').textContent.trim() === 'default text';
+    });
+
+    deferredClickAction.resolve();
+    await settled();
+    assert.dom('button').hasText('default text');
+
+    deferredClickAction = defer();
+    click('button');
+    await waitUntil(() => {
+      return find('button').textContent.trim() === 'default text';
+    });
+
+    deferredClickAction.reject();
+    await settled();
+    assert.dom('button').hasText('default text');
+  });
+
   test('setting reset to true resets button text', async function(assert) {
     this.set('clickAction', () => {
       return resolve();


### PR DESCRIPTION
The button-text resolves to `null` if the texts for the states (`fulfillText`, `rejectedText` and so on...) wasn't set. This fix sets  "state"-text values to `undefined` by default, so the text resolves to the `defaultText` if there no text for a particular state was set.