### PR TITLE
Autocapitalize and autocorrect attributes

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -179,7 +179,19 @@ const nonDefaultLayouts = A([
  <td>✔︎</td>
  </tr>
  <tr>
+ <td>autocapitalize</td>
+ <td>✔︎</td>
+ <td></td>
+ <td>✔︎</td>
+ </tr>
+ <tr>
  <td>autocomplete</td>
+ <td>✔︎</td>
+ <td></td>
+ <td>✔︎</td>
+ </tr>
+ <tr>
+ <td>autocorrect</td>
  <td>✔︎</td>
  <td></td>
  <td>✔︎</td>

--- a/addon/components/base/bs-form/element/control/input.js
+++ b/addon/components/base/bs-form/element/control/input.js
@@ -21,6 +21,8 @@ export default Control.extend(ControlAttributes, {
     'pattern',
     'accept',
     'autocomplete',
+    'autocapitalize',
+    'autocorrect',
     'autosave',
     'inputmode',
     'multiple',

--- a/addon/components/base/bs-form/element/control/textarea.js
+++ b/addon/components/base/bs-form/element/control/textarea.js
@@ -15,6 +15,8 @@ export default Control.extend(ControlAttributes, {
     'minlength',
     'maxlength',
     'autocomplete',
+    'autocapitalize',
+    'autocorrect',
     'spellcheck',
     'rows',
     'cols',

--- a/addon/templates/components/common/bs-form/element.hbs
+++ b/addon/templates/components/common/bs-form/element.hbs
@@ -47,6 +47,8 @@
       pattern=pattern
       accept=accept
       autocomplete=autocomplete
+      autocapitalize=autocapitalize
+      autocorrect=autocorrect
       autosave=autosave
       inputmode=inputmode
       multiple=multiple

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -36,6 +36,8 @@ const supportedInputAttributes = {
   pattern: 'dummy',
   accept: 'dummy',
   autocomplete: 'on',
+  autocapitalize: 'on',
+  autocorrect: 'on',
   autosave: 'true',
   inputmode: 'latin',
   multiple: true,
@@ -57,6 +59,8 @@ const supportedTextareaAttributes = {
   maxlength: 50,
   minlength: 50,
   autocomplete: 'on',
+  autocapitalize: 'on',
+  autocorrect: 'on',
   form: 'dummy',
   spellcheck: true,
   wrap: 'hard',
@@ -263,6 +267,8 @@ module('Integration | Component | bs-form/element', function(hooks) {
         pattern=pattern
         accept=accept
         autocomplete=autocomplete
+        autocapitalize=autocapitalize
+        autocorrect=autocorrect
         autosave=autosave
         inputmode=inputmode
         multiple=multiple
@@ -308,6 +314,8 @@ module('Integration | Component | bs-form/element', function(hooks) {
         minlength=minlength
         maxlength=maxlength
         autocomplete=autocomplete
+        autocapitalize=autocapitalize
+        autocorrect=autocorrect
         form=form
         spellcheck=spellcheck
         wrap=wrap


### PR DESCRIPTION
Adds `autocapitalize` and `autocorrect` attributes to text inputs and textareas, to provide more control of typing behavior on iOS devices (and maybe others)