### PR TITLE
feat - allow overriding various yielded components for dropdown & navbar

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -307,5 +307,26 @@ export default Component.extend({
       && ((menuElement && !menuElement.contains(target)) || this.get('closeOnMenuClick'))) {
       this.send('closeDropdown');
     }
-  }
+  },
+
+  /**
+   * @property buttonComponent
+   * @type {String}
+   * @private
+   */
+  buttonComponent: 'bs-dropdown/button',
+
+  /**
+   * @property toggleComponent
+   * @type {String}
+   * @private
+   */
+  toggleComponent: 'bs-dropdown/toggle',
+
+  /**
+   * @property menuComponent
+   * @type {String}
+   * @private
+   */
+  menuComponent: 'bs-dropdown/menu'
 });

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -84,7 +84,7 @@ export default Component.extend({
       return `dropdown-menu-${this.get('align')}`;
     }
   }),
-  
+
   isOpen: computed({
     get() {
       return false;
@@ -137,5 +137,26 @@ export default Component.extend({
         enabled: this.get('flip')
       }
     };
-  })
+  }),
+
+  /**
+   * @property itemComponent
+   * @type {String}
+   * @private
+   */
+  itemComponent: 'bs-dropdown/menu/item',
+
+  /**
+   * @property linkToComponent
+   * @type {String}
+   * @private
+   */
+  linkToComponent: 'bs-dropdown/menu/link-to',
+
+  /**
+   * @property dividerComponent
+   * @type {String}
+   * @private
+   */
+  dividerComponent: 'bs-dropdown/menu/divider'
 });

--- a/addon/components/base/bs-navbar.js
+++ b/addon/components/base/bs-navbar.js
@@ -242,7 +242,7 @@ export default Component.extend(TypeClass, {
         this.collapse();
       }
     }
-  }
+  },
 
   /**
    * Bootstrap 4 Only: Defines the responsive toggle breakpoint size. Options are the standard
@@ -265,4 +265,32 @@ export default Component.extend(TypeClass, {
    * @default 'light'
    * @public
    */
+
+  /**
+   * @property toggleComponent
+   * @type {String}
+   * @private
+   */
+  toggleComponent: 'bs-navbar/toggle',
+
+  /**
+   * @property contentComponent
+   * @type {String}
+   * @private
+   */
+  contentComponent: 'bs-navbar/content',
+
+  /**
+   * @property navComponent
+   * @type {String}
+   * @private
+   */
+  navComponent: 'bs-navbar/nav',
+
+  /**
+   * @property linkToComponent
+   * @type {String}
+   * @private
+   */
+  linkToComponent: 'bs-navbar/link-to'
 });

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -11,9 +11,9 @@
     <ul class={{concat "dropdown-menu " alignClass (if isOpen " show")}} role={{ariaRole}}>
       {{yield
         (hash
-          item=(component "bs-dropdown/menu/item")
-          link-to=(component "bs-dropdown/menu/link-to")
-          divider=(component "bs-dropdown/menu/divider")
+          item=(component itemComponent)
+          link-to=(component linkToComponent)
+          divider=(component dividerComponent)
         )
       }}
     </ul>

--- a/addon/templates/components/bs3/bs-navbar.hbs
+++ b/addon/templates/components/bs3/bs-navbar.hbs
@@ -1,9 +1,9 @@
 <div class={{if fluid "container-fluid" "container"}}>
   {{yield
     (hash
-      toggle=(component "bs-navbar/toggle" onClick=(action "toggleNavbar") collapsed=_collapsed)
-      content=(component "bs-navbar/content" collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
-      nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
+      toggle=(component toggleComponent onClick=(action "toggleNavbar") collapsed=_collapsed)
+      content=(component contentComponent collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
+      nav=(component navComponent linkToComponent=(component linkToComponent onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
       toggleNavbar=(action 'toggleNavbar')

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -10,9 +10,9 @@
   }}
     {{yield
       (hash
-        item=(component "bs-dropdown/menu/item")
-        link-to=(component "bs-dropdown/menu/link-to")
-        divider=(component "bs-dropdown/menu/divider")
+        item=(component itemComponent)
+        link-to=(component linkToComponent)
+        divider=(component dividerComponent)
       )
     }}
   {{/ember-popper}}

--- a/addon/templates/components/bs4/bs-navbar.hbs
+++ b/addon/templates/components/bs4/bs-navbar.hbs
@@ -1,9 +1,9 @@
 {{#if fluid}}
   {{yield
     (hash
-      toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=_collapsed)
-      content=(component 'bs-navbar/content' collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
-      nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
+      toggle=(component toggleComponent onClick=(action 'toggleNavbar') collapsed=_collapsed)
+      content=(component contentComponent collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
+      nav=(component navComponent linkToComponent=(component linkToComponent onCollapse=(action "collapse")))
       collapse=(action "collapse")
       expand=(action "expand")
       toggleNavbar=(action 'toggleNavbar')
@@ -13,9 +13,9 @@
   <div class="container">
     {{yield
       (hash
-        toggle=(component 'bs-navbar/toggle' onClick=(action 'toggleNavbar') collapsed=_collapsed)
-        content=(component 'bs-navbar/content' collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
-        nav=(component "bs-navbar/nav" linkToComponent=(component "bs-navbar/link-to" onCollapse=(action "collapse")))
+        toggle=(component toggleComponent onClick=(action 'toggleNavbar') collapsed=_collapsed)
+        content=(component contentComponent collapsed=_collapsed onHidden=onCollapsed onShown=onExpanded)
+        nav=(component navComponent linkToComponent=(component linkToComponent onCollapse=(action "collapse")))
         collapse=(action "collapse")
         expand=(action "expand")
         toggleNavbar=(action 'toggleNavbar')

--- a/addon/templates/components/common/bs-dropdown.hbs
+++ b/addon/templates/components/common/bs-dropdown.hbs
@@ -1,8 +1,8 @@
 {{yield
   (hash
-    button=(component "bs-dropdown/button" dropdown=this onClick=(action "toggleDropdown"))
-    toggle=(component "bs-dropdown/toggle" dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
-    menu=(component "bs-dropdown/menu" isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement)
+    button=(component buttonComponent dropdown=this onClick=(action "toggleDropdown"))
+    toggle=(component toggleComponent dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
+    menu=(component menuComponent isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement)
     toggleDropdown=(action "toggleDropdown")
     openDropdown=(action "openDropdown")
     closeDropdown=(action "closeDropdown")


### PR DESCRIPTION
The `bs-nav` component allows overriding yielded components.

This PR adds the same functionality to bs-dropdown & bs-navbar.

(Sidenote - should these be marked as `@private` - these are actually a very useful part of the public API when using `ember-bootstrap` with something like `ember-css-modules`)