### PR TITLE
feat(Form): optional prevent concurrent submissions

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -183,6 +183,20 @@ export default Component.extend({
   submitOnEnter: false,
 
   /**
+   * Controls if `onSubmit` action is fired concurrently. If `true` submitting form multiple
+   * times will not trigger `onSubmit` action if a Promise returned by previous submission is
+   * not settled yet.
+   *
+   * Droping a submission also prevents rerunning validation and `onBefore` hook.
+   *
+   * @property preventConcurrency
+   * @type Boolean
+   * @default false
+   * @public
+   */
+  preventConcurrency: false,
+
+  /**
    * If set to true novalidate attribute is present on form element
    *
    * @property novalidate
@@ -256,12 +270,17 @@ export default Component.extend({
    * @private
    */
   submit(e) {
-    this.set('isSubmitting', true);
-    this.incrementProperty('pendingSubmissions');
-
     if (e) {
       e.preventDefault();
     }
+
+    if (this.get('preventConcurrency') && this.get('isSubmitting')) {
+      return;
+    }
+
+    this.set('isSubmitting', true);
+    this.incrementProperty('pendingSubmissions');
+
     let model = this.get('model');
 
     this.get('onBefore')(model);


### PR DESCRIPTION
Adds a `preventConcurrency` option to `{{bs-form}}`. If `true`, submission will not fire `onSubmit` action if a promise returned by an earlier execution is still pending. It will also not fire `validate` and `onBefore` if a concurrent submission is dropped.

This allows to replace ember-concurrency for simple use cases. It's basically the same as using an ember-concurrency task with `drop()` modifier as `onSubmit` action but also prevents validation and `onBefore` hook execution in these cases.

Implementation follows the related one for `{{bs-button}}`: https://github.com/kaliber5/ember-bootstrap/pull/669

Part of #638