### PR TITLE
Adds outline property to bs-button

### DIFF
--- a/addon/components/bs4/bs-button.js
+++ b/addon/components/bs4/bs-button.js
@@ -2,7 +2,6 @@ import Button from 'ember-bootstrap/components/base/bs-button';
 
 export default Button.extend({
   type: 'secondary',
-  classNameBindings: ['outline:btn-outline'],
 
   /**
    * Property to create outline buttons (BS4+ only)

--- a/addon/components/bs4/bs-button.js
+++ b/addon/components/bs4/bs-button.js
@@ -1,5 +1,16 @@
 import Button from 'ember-bootstrap/components/base/bs-button';
 
 export default Button.extend({
-  type: 'secondary'
+  type: 'secondary',
+  classNameBindings: ['outline:btn-outline'],
+
+  /**
+   * Property to create outline buttons (BS4+ only)
+   *
+   * @property disabled
+   * @type boolean
+   * @default false
+   * @public
+   */
+  outline: false
 });

--- a/addon/mixins/type-class.js
+++ b/addon/mixins/type-class.js
@@ -24,6 +24,10 @@ export default Mixin.create({
   typeClass: computed('type', function() {
     let prefix = this.get('classTypePrefix');
     let type = this.get('type') || 'default';
+
+    if (this.get('outline')) {
+      return `${prefix}-outline-${type}`;
+    }
     return `${prefix}-${type}`;
   }),
 

--- a/tests/dummy/app/templates/demo/button.hbs
+++ b/tests/dummy/app/templates/demo/button.hbs
@@ -15,6 +15,7 @@
 
 <div class="bs-example">
   <!-- BEGIN-SNIPPET button-options -->
+  <p> Solid buttons </p>
   <p>
     {{#bs-button type="primary" onClick=(action "submit")}}Primary{{/bs-button}}
     {{#bs-button type="secondary" onClick=(action "submit")}}Secondary{{/bs-button}}
@@ -25,6 +26,18 @@
     {{#bs-button type="light" onClick=(action "submit")}}Light{{/bs-button}}
     {{#bs-button type="dark" onClick=(action "submit")}}Dark{{/bs-button}}
     {{#bs-button disabled=true onClick=(action "submit")}}Disabled{{/bs-button}}
+  </p>
+   <p> Outlined buttons </p>
+   <p>
+    {{#bs-button type="primary" outline=true onClick=(action "submit")}}Primary{{/bs-button}}
+    {{#bs-button type="secondary" outline=true onClick=(action "submit")}}Secondary{{/bs-button}}
+    {{#bs-button type="success" outline=true onClick=(action "submit")}}Success{{/bs-button}}
+    {{#bs-button type="danger" outline=true onClick=(action "submit")}}Danger{{/bs-button}}
+    {{#bs-button type="warning" outline=true onClick=(action "submit")}}Warning{{/bs-button}}
+    {{#bs-button type="info" outline=true onClick=(action "submit")}}Info{{/bs-button}}
+    {{#bs-button type="light" outline=true onClick=(action "submit")}}Light{{/bs-button}}
+    {{#bs-button type="dark" outline=true onClick=(action "submit")}}Dark{{/bs-button}}
+    {{#bs-button disabled=true outline=true onClick=(action "submit")}}Disabled{{/bs-button}}
   </p>
   <p>
     {{#bs-button block=true onClick=(action "submit")}}Block Button{{/bs-button}}

--- a/tests/dummy/app/templates/demo/button.hbs
+++ b/tests/dummy/app/templates/demo/button.hbs
@@ -27,8 +27,8 @@
     {{#bs-button type="dark" onClick=(action "submit")}}Dark{{/bs-button}}
     {{#bs-button disabled=true onClick=(action "submit")}}Disabled{{/bs-button}}
   </p>
-   <p> Outlined buttons </p>
-   <p>
+  <p> Outlined buttons </p>
+  <p>
     {{#bs-button type="primary" outline=true onClick=(action "submit")}}Primary{{/bs-button}}
     {{#bs-button type="secondary" outline=true onClick=(action "submit")}}Secondary{{/bs-button}}
     {{#bs-button type="success" outline=true onClick=(action "submit")}}Success{{/bs-button}}

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -33,6 +33,7 @@ module('Integration | Component | bs-button', function(hooks) {
 
     assert.dom('button').hasClass('btn', 'button has btn class');
     assert.dom('button').hasClass('btn-primary', 'button has type class');
+    assert.dom('button').doesNotHaveClass('btn-outline-primary', 'button does not have outline class');
   });
 
   test('button can be active', async function(assert) {
@@ -80,11 +81,7 @@ module('Integration | Component | bs-button', function(hooks) {
   testBS4('button with outline property shows as outline', async function(assert) {
     await render(hbs`{{bs-button type="primary" outline=true}}`);
     assert.dom('button').hasClass('btn-outline-primary');
-  });
-
-  testBS4('button with does not have outline class when outline is null', async function(assert) {
-    await render(hbs`{{bs-button type="primary"}}`);
-    assert.dom('button').doesNotHaveClass('btn-outline-primary');
+    assert.dom('button').doesNotHaveClass('btn-primary');
   });
 
   test('button with iconActive and iconInactive properties shows icon depending on active state', async function(assert) {

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -82,6 +82,11 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.dom('button').hasClass('btn-outline-primary');
   });
 
+  testBS4('button with does not have outline class when outline is null', async function(assert) {
+    await render(hbs`{{bs-button type="primary"}}`);
+    assert.dom('button').doesNotHaveClass('btn-outline-primary');
+  });
+
   test('button with iconActive and iconInactive properties shows icon depending on active state', async function(assert) {
     this.set('active', false);
     await render(hbs`{{bs-button active=active iconInactive="fas fa-plus" iconActive="fas fa-minus"}}`);

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -3,7 +3,8 @@ import { defer, reject, resolve } from 'rsvp';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, click, settled, waitUntil } from '@ember/test-helpers';
-import { test, defaultButtonClass } from '../../helpers/bootstrap-test';
+import { test, testBS4, defaultButtonClass } from '../../helpers/bootstrap-test';
+
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | bs-button', function(hooks) {
@@ -74,6 +75,11 @@ module('Integration | Component | bs-button', function(hooks) {
 
     assert.dom('button i').hasClass('fas');
     assert.dom('button i').hasClass('fa-check');
+  });
+
+  testBS4('button with outline property shows as outline', async function(assert) {
+    await render(hbs`{{bs-button type="primary" outline=true}}`);
+    assert.dom('button').hasClass('btn-outline-primary');
   });
 
   test('button with iconActive and iconInactive properties shows icon depending on active state', async function(assert) {
@@ -147,7 +153,7 @@ module('Integration | Component | bs-button', function(hooks) {
 
     await render(
       hbs`{{bs-button
-      defaultText="default text"      
+      defaultText="default text"
       onClick=clickAction
     }}`);
     assert.dom('button').hasText('default text');


### PR DESCRIPTION
I think this should do it, and it leaves `outline-primary` as still valid. I was a little unsure on the docs on if I set that up correct for you.  Also I could add a test for each style of outline button, but that didn't seem necessary. As usual, leave me any suggestions and I'll address them.

This is as per Issue #673