### PR TITLE
Adds accesibility tags for dialog modals

### DIFF
--- a/addon/components/base/bs-modal/dialog.js
+++ b/addon/components/base/bs-modal/dialog.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { bind } from '@ember/runloop';
-import { alias } from '@ember/object/computed';
+import { readOnly } from '@ember/object/computed';
 import layout from 'ember-bootstrap/templates/components/bs-modal/dialog';
 
 /**
@@ -21,7 +21,7 @@ export default Component.extend({
   attributeBindings: ['tabindex', 'style', 'aria-labelledby'],
   ariaRole: 'dialog',
   tabindex: '-1',
-  "aria-labelledby": alias('titleId'),
+  "aria-labelledby": readOnly('titleId'),
 
   /**
    * Set to false to disable fade animations.

--- a/addon/components/base/bs-modal/dialog.js
+++ b/addon/components/base/bs-modal/dialog.js
@@ -155,18 +155,18 @@ export default Component.extend({
    */
   getOrSetTitleId() {
       //Title element may be set by user so we have to try and find it to set the id
-      const modalNode = document.getElementById(this.get('id'));
+      const modalNode = this.get('element');
       let nodeId = null;
 
       if (modalNode) {
-        const titleNode = modalNode.getElementsByClassName('modal-title');
-        if (titleNode[0]) {
+        const titleNode = modalNode.querySelector('.modal-title');
+        if (titleNode) {
           //Get title id of .modal-title
-          nodeId = titleNode[0].id
+          nodeId = titleNode.id
           if (!nodeId) {
             //no title id so we set one
             nodeId = `${this.get('id')}-title`;
-            titleNode[0].id = nodeId;
+            titleNode.id = nodeId;
           }
         }
       }

--- a/addon/components/base/bs-modal/dialog.js
+++ b/addon/components/base/bs-modal/dialog.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { bind } from '@ember/runloop';
+import { alias } from '@ember/object/computed';
 import layout from 'ember-bootstrap/templates/components/bs-modal/dialog';
 
 /**
@@ -17,9 +18,10 @@ export default Component.extend({
   layout,
   classNames: ['modal'],
   classNameBindings: ['fade'],
-  attributeBindings: ['tabindex', 'style'],
+  attributeBindings: ['tabindex', 'style', 'aria-labelledby'],
   ariaRole: 'dialog',
   tabindex: '-1',
+  "aria-labelledby": alias('titleId'),
 
   /**
    * Set to false to disable fade animations.
@@ -134,6 +136,44 @@ export default Component.extend({
     return isBlank(size) ? null : `modal-${size}`;
   }).readOnly(),
 
+
+   /**
+   * The id of the `.modal-title` element
+   *
+   * @property titleId
+   * @type string
+   * @default null
+   * @private
+   */
+  titleId: null,
+
+/**
+   * Gets or sets the id of the title element for aria accessibility tags
+   *
+   * @method getSetTitleID
+   * @private
+   */
+  getOrSetTitleId() {
+      //Title element may be set by user so we have to try and find it to set the id
+      const modalNode = document.getElementById(this.get('id'));
+      let nodeId = null;
+
+      if (modalNode) {
+        const titleNode = modalNode.getElementsByClassName('modal-title');
+        if (titleNode[0]) {
+          //Get title id of .modal-title
+          nodeId = titleNode[0].id
+          if (!nodeId) {
+            //no title id so we set one
+            nodeId = `${this.get('id')}-title`;
+            titleNode[0].id = nodeId;
+          }
+        }
+      }
+      this.set('titleId', nodeId)
+  },
+
+
   /**
    * @event onClose
    * @public
@@ -160,6 +200,7 @@ export default Component.extend({
     // iOS to allow clicking the div. So a `click(){}` method here won't work, we need to attach an event listener
     // directly to the element
     this.element.onclick = bind(this, this._click);
+    this.getOrSetTitleId();
   },
 
   willDestroyElement() {

--- a/addon/templates/components/common/bs-modal/dialog.hbs
+++ b/addon/templates/components/common/bs-modal/dialog.hbs
@@ -1,4 +1,4 @@
-<div class="modal-dialog {{sizeClass}} {{if centered "modal-dialog-centered"}}">
+<div class="modal-dialog {{sizeClass}} {{if centered "modal-dialog-centered"}}" role="document">
   <div class="modal-content">
     {{yield}}
   </div>

--- a/tests/integration/components/bs-modal-simple-test.js
+++ b/tests/integration/components/bs-modal-simple-test.js
@@ -514,4 +514,15 @@ module('Integration | Component | bs-modal-simple', function(hooks) {
     assert.dom('.modal-dialog').hasClass('modal-dialog-centered');
   });
 
+  test('Modal has accesibility attributes with default title', async function(assert) {
+    await render(hbs`{{#bs-modal-simple open=true title="Simple Dialog"}}Hello world!{{/bs-modal-simple}}`);
+    await settled();
+
+    const modalTitleId = document.getElementsByClassName('modal-title')[0].id;
+    assert.dom('.modal').exists({ count: 1 }, 'Modal exists.');
+    assert.dom('.modal').hasAttribute('role', 'dialog');
+    assert.dom('.modal-dialog').hasAttribute('role', 'document');
+    assert.dom('.modal').hasAttribute('aria-labelledby', modalTitleId);
+  });
+
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | bs-modal', function(hooks) {
           {{modal.footer}}
         {{/my-component}}
       {{/bs-modal}}
-      
+
     `);
 
     await click('.modal .modal-footer button');
@@ -89,5 +89,41 @@ module('Integration | Component | bs-modal', function(hooks) {
 
     await click('#submit');
     assert.ok(submitAction.calledOnce, 'submit action has been called.');
+  });
+
+  test('Modal has accesibility attributes with custom title', async function(assert) {
+
+    await render(hbs`{{#bs-modal as |modal|}}
+      {{#modal.header}}
+        <h4 class="modal-title">
+          Custom Dialog title
+        </h4>
+      {{/modal.header}}
+      {{#modal.body}}Hello world!{{/modal.body}}
+      {{modal.footer}}
+    {{/bs-modal}}`);
+
+    const modalTitleId = document.getElementsByClassName('modal-title')[0].id;
+
+    assert.dom('.modal').exists({ count: 1 }, 'Modal exists.');
+    assert.dom('.modal').hasAttribute('role', 'dialog');
+    assert.dom('.modal-dialog').hasAttribute('role', 'document');
+    assert.dom('.modal').hasAttribute('aria-labelledby', modalTitleId);
+  });
+
+  test('Modal has accesibility attributes with default title', async function(assert) {
+
+    await render(hbs`{{#bs-modal as |modal|}}
+      {{modal.header title="Some title"}}
+      {{#modal.body}}Hello world!{{/modal.body}}
+      {{modal.footer}}
+    {{/bs-modal}}`);
+
+    const modalTitleId = document.getElementsByClassName('modal-title')[0].id;
+
+    assert.dom('.modal').exists({ count: 1 }, 'Modal exists.');
+    assert.dom('.modal').hasAttribute('role', 'dialog');
+    assert.dom('.modal-dialog').hasAttribute('role', 'document');
+    assert.dom('.modal').hasAttribute('aria-labelledby', modalTitleId);
   });
 });


### PR DESCRIPTION
This was for issue #674

It got a bit more complicated than expected as the aria-labelledby attribute requires the id of the modal-title.  So had to use some js dom calls to get that as we don't know the ember id until it's rendered and there might be a custom modal-title the user creates in their template.

Let me know if it needs any tweaking.