### PR TITLE
fix(bs-dropdown): Clicking outside should close the menu when closeOnMenuClick is false

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -213,7 +213,7 @@ export default Component.extend({
    * @private
    */
   menuElement: computed(function() {
-    return this.get('element').querySelector('.dropdown-menu');
+    return document.getElementById(`${this.get('elementId')}__menu`);
   }).volatile(),
 
   /**

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -8,7 +8,7 @@
     popperContainer="#ember-bootstrap-wormhole"
     modifiers=popperModifiers
   }}
-    <ul class={{concat "dropdown-menu " alignClass (if isOpen " show") " " class}} role={{ariaRole}}>
+    <ul id={{concat dropdownElementId "__menu"}} class={{concat "dropdown-menu " alignClass (if isOpen " show") " " class}} role={{ariaRole}}>
       {{yield
         (hash
           item=(component itemComponent)

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -1,5 +1,6 @@
 {{#if _isOpen}}
   {{#ember-popper
+    id=(concat dropdownElementId "__menu")
     class=(concat "dropdown-menu " alignClass (if isOpen " show") " " class)
     ariaRole=ariaRole
     placement=popperPlacement

--- a/addon/templates/components/common/bs-dropdown.hbs
+++ b/addon/templates/components/common/bs-dropdown.hbs
@@ -2,7 +2,7 @@
   (hash
     button=(component buttonComponent dropdown=this onClick=(action "toggleDropdown"))
     toggle=(component toggleComponent dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
-    menu=(component menuComponent isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement)
+    menu=(component menuComponent isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement dropdownElementId=elementId)
     toggleDropdown=(action "toggleDropdown")
     openDropdown=(action "openDropdown")
     closeDropdown=(action "closeDropdown")

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -149,7 +149,9 @@ module('Integration | Component | bs-dropdown', function(hooks) {
 
   test('clicking outside dropdown menu when closeOnMenuClick is false and renderInPlace is false will close it', async function(assert) {
     await render(
-      hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu renderInPlace=false}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
+      hbs`
+        <div id="ember-bootstrap-wormhole"></div> 
+        {{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu renderInPlace=false}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
     );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -135,6 +135,30 @@ module('Integration | Component | bs-dropdown', function(hooks) {
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
   });
 
+  test('clicking outside dropdown menu when closeOnMenuClick is false will close it', async function(assert) {
+    await render(
+      hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
+    );
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click(document.body);
+    assert.dom('.dropdown-menu').doesNotExist();
+  });
+
+  test('clicking outside dropdown menu when closeOnMenuClick is false and renderInPlace is false will close it', async function(assert) {
+    await render(
+      hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu renderInPlace=false}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
+    );
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click(document.body);
+    assert.dom('.dropdown-menu').doesNotExist();
+  });
+
   test('child components can access isOpen property', async function(assert) {
     await render(
       hbs`{{#bs-dropdown as |dd|}}{{#dd.toggle}}<span id="toggleText">{{if dd.isOpen "open" "closed"}}</span>{{/dd.toggle}}{{/bs-dropdown}}`


### PR DESCRIPTION
Currently, when `renderInPlace=false` and `closeOnMenuClick=false`, the menu doesnt close when clicking outside of it since the `menuElement` is outside the scope of the bs-dropdown component.