### PR TITLE
Feat: Enables setting supplied classes on dropdown/ember-popper

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -209,6 +209,13 @@ export default Component.extend({
   }),
 
   /**
+   * @property menuClassNames
+   * @type {array}
+   * @private
+   */
+  menuClassNames: null,
+
+  /**
    * @property menuElement
    * @private
    */

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -106,6 +106,24 @@ export default Component.extend({
     }
   }),
 
+  /**
+   * @property menuClassNames
+   * @type {array}
+   * @private
+   */
+  menuClassNames: null,
+
+  /**
+   * @property menuClass
+   * @type {string}
+   * @private
+   */
+  _menuClass: computed('menuClassNames.[]', 'class', function() {
+    let classes = this.get('menuClassNames') || [];
+
+    return classes.join(' ');
+  }),
+
   _isOpen: false,
 
   flip: true,

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -1,6 +1,6 @@
 {{#if _isOpen}}
   {{#ember-popper
-    class="ember-bootstrap-dropdown-bs3-popper"
+    class=(concat "ember-bootstrap-dropdown-bs3-popper" " " this._menuClass)
     ariaRole=ariaRole
     placement=popperPlacement
     popperTarget=toggleElement

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -1,7 +1,7 @@
 {{#if _isOpen}}
   {{#ember-popper
     id=(concat dropdownElementId "__menu")
-    class=(concat "dropdown-menu " alignClass (if isOpen " show") " " class)
+    class=(concat "dropdown-menu " alignClass (if isOpen " show") " " class " " this._menuClass)
     ariaRole=ariaRole
     placement=popperPlacement
     popperTarget=toggleElement

--- a/addon/templates/components/common/bs-dropdown.hbs
+++ b/addon/templates/components/common/bs-dropdown.hbs
@@ -2,7 +2,7 @@
   (hash
     button=(component buttonComponent dropdown=this onClick=(action "toggleDropdown"))
     toggle=(component toggleComponent dropdown=this inNav=inNav onClick=(action "toggleDropdown"))
-    menu=(component menuComponent isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement dropdownElementId=elementId)
+    menu=(component menuComponent isOpen=isOpen direction=direction inNav=inNav toggleElement=toggleElement dropdownElementId=elementId menuClassNames=menuClassNames)
     toggleDropdown=(action "toggleDropdown")
     openDropdown=(action "openDropdown")
     closeDropdown=(action "closeDropdown")

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.0.0",
     "chai-things": "^0.2.0",
+    "ember-array-helper": "^5.0.0",
     "ember-bootstrap-power-select": "^1.0.0-alpha.1",
     "ember-cli": "~3.5.0",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -43,6 +43,18 @@ module('Integration | Component | bs-dropdown', function(hooks) {
     assert.dom('.dropleft').exists('has dropleft class');
   });
 
+  test('dropdown menu has supplied menuClassNames applied', async function(assert) {
+    await render(
+      hbs`{{#bs-dropdown menuClassNames=(array "menu-class-one" "menu-class-two") as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
+    );
+
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+    assert.dom('.dropdown-menu.menu-class-one').exists('has menuClassName class applied to dropdown menu');
+    assert.dom('.dropdown-menu.menu-class-two').exists('has menuClassName class applied to dropdown menu');
+  });
+
   test('dropdown container with dropdown button has btn-group class', async function(assert) {
     await render(
       hbs`{{#bs-dropdown as |dd|}}{{#dd.button}}Dropdown <span class="caret"></span>{{/dd.button}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`

--- a/tests/integration/components/bs-dropdown/menu-test.js
+++ b/tests/integration/components/bs-dropdown/menu-test.js
@@ -73,4 +73,25 @@ module('Integration | Component | bs-dropdown/menu', function(hooks) {
       .dom('.dropdown-menu')
       .hasClass('custom-class-2', 'menu has custom-class-2 class');
   });
+
+
+  test('dropdown menu propagates menuClassNames', async function(assert) {
+    await render(
+      hbs`{{#bs-dropdown/menu align="right" isOpen=true toggleElement=this.element class="custom-class-1 custom-class-2" menuClassNames=(array "menu-class-one" "menu-class-two")}}Something{{/bs-dropdown/menu}}`
+    );
+
+    assert.dom('.dropdown-menu').exists('menu has dropdown-menu class');
+    assert
+      .dom('.dropdown-menu')
+      .hasClass('custom-class-1', 'menu has custom-class-1 class');
+    assert
+      .dom('.dropdown-menu')
+      .hasClass('custom-class-2', 'menu has custom-class-2 class');
+    assert
+      .dom('.dropdown-menu')
+      .hasClass('menu-class-one', 'menu has menu-class-one class');
+    assert
+      .dom('.dropdown-menu')
+      .hasClass('menu-class-two', 'menu has menu-class-two class');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,6 +764,14 @@ amd-name-resolver@1.2.0, amd-name-resolver@^1.2.0:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.1.tgz#cea40abff394268307df647ce340c83eda6e9cfc"
+  integrity sha512-cm0sUV2S8L6pwq0wpu0cHdA2KeEAmCVKy+R/qeZl/VxEn3JmU8WMM0IQrKyrnMXLXbULkZ7ptTaX8vKA0NhNvQ==
+  dependencies:
+    ensure-posix-path "^1.0.1"
+    object-hash "^1.3.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -1300,6 +1308,13 @@ babel-plugin-ember-modules-api-polyfill@^2.5.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.5.0.tgz#860aab9fecbf38c10d1fe0779c6979a854fff154"
   dependencies:
     ember-rfc176-data "^0.3.5"
+
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.6.0.tgz#9524a65ef0c31ee82536a19c243fbaec1b977cbb"
+  integrity sha512-BSbLv3+ju1mcUUoPe7vPJgnGawrNxp6LfFBRHlNOKeMlQlml9Wo2MRRUrbpNDlmVc761xSKj8+cde7R0Lwpq7g==
+  dependencies:
+    ember-rfc176-data "^0.3.6"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.5:
   version "0.2.6"
@@ -3369,6 +3384,13 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.82:
   version "1.3.83"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz#74584eb0972bb6777811c5d68d988c722f5e6666"
 
+ember-array-helper@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-array-helper/-/ember-array-helper-5.0.0.tgz#d2d72f170e15d120bdaffe456d5cdfd8d335de75"
+  integrity sha512-TkmHoOgPmv4QOs8Z/DPA80kas8m8yl3aeuxC1Ph40V3byFEq1A4Z/JNnUNkfRYmWiYveBc996NV/y2wwK/2ptw==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+
 ember-assign-polyfill@^2.0.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.5.0.tgz#0dc7079addbdbad7984ba3f35d970cf07a73f704"
@@ -3452,6 +3474,28 @@ ember-cli-babel@^7.1.0:
     amd-name-resolver "1.2.0"
     babel-plugin-debug-macros "^0.2.0-beta.6"
     babel-plugin-ember-modules-api-polyfill "^2.5.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.2.0.tgz#5c5bd877fb73f6fb198c878d3127ba9e18e9b8a0"
+  integrity sha512-vwx/AgPD7P4ebgTFJMqFovbrSNCA02UMuItlR/Il16njYjgN9ZzjUqgYxaylN7k8RF88wdJq3jrtqyMS/oOq8A==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
     babel-plugin-module-resolver "^3.1.1"
     broccoli-babel-transpiler "^7.1.0"
     broccoli-debug "^0.6.4"
@@ -4033,6 +4077,11 @@ ember-resolver@^5.0.1:
 ember-rfc176-data@^0.3.3, ember-rfc176-data@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.5.tgz#f630e550572c81a5e5c7220f864c0f06eee9e977"
+
+ember-rfc176-data@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz#7138db8dfccec39c9a832adfbd4c49d670028907"
+  integrity sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==
 
 ember-router-generator@^1.2.2, ember-router-generator@^1.2.3:
   version "1.2.3"
@@ -7825,6 +7874,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"


### PR DESCRIPTION
Allows passing an array of `menuClassNames` to a `bs-dropdown` instance and have these propagate to the `bs-dropdown/menu` component.