### PR TITLE
Form submission state reflects Promise returned by onInvalid action

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -300,27 +300,23 @@ export default Component.extend({
     this.get('onBefore')(model);
 
     RSVP.resolve(this.get('hasValidator') ? this.validate(this.get('model')) : null)
-      .then((r) => {
-        RSVP.resolve(this.get('onSubmit')(model, r))
-          .finally(() => {
-            if (!this.get('isDestroyed')) {
-              if (this.get('pendingSubmissions') === 1) {
-                this.set('isSubmitting', false);
-              }
-              this.decrementProperty('pendingSubmissions');
-            }
-          });
-      })
-      .catch((err) => {
-        if (!this.get('isDestroyed')) {
+      .then(
+        (r) => {
+          return this.get('onSubmit')(model, r);
+        },
+        (err) => {
           this.set('showAllValidations', true);
 
+          return this.get('onInvalid')(model, err);
+        }
+      )
+      .finally(() => {
+        if (!this.get('isDestroyed')) {
           if (this.get('pendingSubmissions') === 1) {
             this.set('isSubmitting', false);
           }
-          this.decrementProperty('pendingSubmissions');
 
-          this.get('onInvalid')(model, err);
+          this.decrementProperty('pendingSubmissions');
         }
       });
   },


### PR DESCRIPTION
Assuming we have a form that binds same action to onInvalid and onSubmit events:
`{{bs-form onSubmit=(action "save") onInvalid=(action "save")}}`

In that case only difference caused by having validation errors should be that they are shown to user. It should not be any difference in submission state. Especially yielded `isSubmitting` property of `{{bs-form}}` should be `true` as long as promise returned by `save` action is pending regardless of validation.

This problem was raised in #716.