### PR TITLE
Form: click on input group button should not show validations

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -687,11 +687,11 @@ export default FormGroup.extend({
 
   /**
    * Event or list of events which enable form validation markup rendering.
-   * Supported events: ['focusOut', 'change', 'input']
+   * Supported events: ['focusout', 'change', 'input']
    *
    * @property showValidationOn
    * @type string|array
-   * @default ['focusOut']
+   * @default ['focusout']
    * @public
    */
   showValidationOn: null,
@@ -707,23 +707,45 @@ export default FormGroup.extend({
 
     assert('showValidationOn must be a String or an Array', isArray(showValidationOn) || typeOf(showValidationOn) === 'string');
     if (isArray(showValidationOn)) {
-      return showValidationOn;
+      return showValidationOn.map((type) => {
+        return type.toLowerCase();
+      });
     }
 
     if (typeof showValidationOn.toString === 'function') {
-      return [showValidationOn];
+      return [showValidationOn.toLowerCase()];
     }
     return [];
   }),
 
   /**
    * @method showValidationOnHandler
+   * @params {Event} event
    * @private
    */
-  showValidationOnHandler(event) {
-    if (this.get('_showValidationOn').indexOf(event) !== -1) {
-      this.set('showOwnValidation', true);
+  showValidationOnHandler({ target, type }) {
+    let inputGroupClasses = [
+      // Bootstrap 4
+      '.input-group-append',
+      '.input-group-prepend',
+      // Bootstrap 3
+      '.input-group-addon',
+      '.input-group-btn',
+    ];
+
+    // Should not do anything if
+    if (
+      // validations are already shown or
+      this.get('showOwnValidation') ||
+      // validations should not be shown for this event type or
+      this.get('_showValidationOn').indexOf(type) === -1 ||
+      // event target was inside an input group (e.g. a input group button)
+      [...this.element.querySelectorAll(inputGroupClasses.join(','))].some((el) => el.contains(target))
+    ) {
+      return;
     }
+
+    this.set('showOwnValidation', true);
   },
 
   /**
@@ -891,8 +913,8 @@ export default FormGroup.extend({
    * @event focusOut
    * @private
    */
-  focusOut() {
-    this.showValidationOnHandler('focusOut');
+  focusOut(event) {
+    this.showValidationOnHandler(event);
   },
 
   /**
@@ -902,8 +924,8 @@ export default FormGroup.extend({
    * @event change
    * @private
    */
-  change() {
-    this.showValidationOnHandler('change');
+  change(event) {
+    this.showValidationOnHandler(event);
   },
 
   /**
@@ -913,8 +935,8 @@ export default FormGroup.extend({
    * @event input
    * @private
    */
-  input() {
-    this.showValidationOnHandler('input');
+  input(event) {
+    this.showValidationOnHandler(event);
   },
 
   /**

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -724,29 +724,41 @@ export default FormGroup.extend({
    * @private
    */
   showValidationOnHandler({ target, type }) {
-    let inputGroupClasses = [
-      // Bootstrap 4
-      '.input-group-append',
-      '.input-group-prepend',
-      // Bootstrap 3
-      '.input-group-addon',
-      '.input-group-btn',
-    ];
-
     // Should not do anything if
     if (
       // validations are already shown or
       this.get('showOwnValidation') ||
       // validations should not be shown for this event type or
       this.get('_showValidationOn').indexOf(type) === -1 ||
-      // event target was inside an input group (e.g. a input group button)
-      [...this.element.querySelectorAll(inputGroupClasses.join(','))].some((el) => el.contains(target))
+      // validation should not be shown for this event target
+      (
+        isArray(this.get('doNotShowValidationForEventTargets')) &&
+        this.get('doNotShowValidationForEventTargets.length') > 0 &&
+        [...this.element.querySelectorAll(this.get('doNotShowValidationForEventTargets').join(','))]
+          .some((el) => el.contains(target))
+      )
     ) {
       return;
     }
 
     this.set('showOwnValidation', true);
   },
+
+  /**
+   * Controls if validation should be shown for specified event targets.
+   *
+   * It expects an array of query selectors. If event target is a children of an event that matches
+   * these selectors, an event triggered for it will not trigger validation errors to be shown.
+   *
+   * By default events fired on elements inside an input group are skipped.
+   *
+   * If `null` or an empty array is passed validation errors are shown for all events regardless
+   * of event target.
+   *
+   * @property doNotShowValidationForEventTargets
+   * @type ?array
+   * @public
+   */
 
   /**
    * The validation ("error" (BS3)/"danger" (BS4), "warning", or "success") or null if no validation is to be shown. Automatically computed from the

--- a/addon/components/bs3/bs-form/element.js
+++ b/addon/components/bs3/bs-form/element.js
@@ -1,1 +1,11 @@
-export { default } from 'ember-bootstrap/components/base/bs-form/element';
+import FormElement from 'ember-bootstrap/components/base/bs-form/element';
+import { computed } from '@ember/object';
+
+export default FormElement.extend({
+  doNotShowValidationForEventTargets: computed(function() {
+    return [
+      '.input-group-addon',
+      '.input-group-btn',
+    ];
+  }),
+});

--- a/addon/components/bs4/bs-form/element.js
+++ b/addon/components/bs4/bs-form/element.js
@@ -1,2 +1,11 @@
-export { default } from 'ember-bootstrap/components/base/bs-form/element';
+import FormElement from 'ember-bootstrap/components/base/bs-form/element';
+import { computed } from '@ember/object';
 
+export default FormElement.extend({
+  doNotShowValidationForEventTargets: computed(function() {
+    return [
+      '.input-group-append',
+      '.input-group-prepend',
+    ];
+  }),
+});

--- a/tests/helpers/bootstrap-test.js
+++ b/tests/helpers/bootstrap-test.js
@@ -134,6 +134,22 @@ export function testRequiringFocus(name, fn) {
   }
 }
 
+export function testBS3RequiringFocus(name, fn) {
+  if (document.hasFocus()) {
+    return testBS3(name, fn);
+  } else {
+    skip(name);
+  }
+}
+
+export function testBS4RequiringFocus(name, fn) {
+  if (document.hasFocus()) {
+    return testBS4(name, fn);
+  } else {
+    skip(name);
+  }
+}
+
 export function testRequiringTransitions(name, fn) {
   return test(name, fn);
 }

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -270,7 +270,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
       await render(hbs`
         {{#bs-form/element controlType="radio" options=simpleOptions as |Element|}}
           {{Element.control inline=true}}
-        {{/bs-form/element}}  
+        {{/bs-form/element}}
       `);
 
       assert.dom('.radio').doesNotExist();
@@ -290,7 +290,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
       await render(hbs`
         {{#bs-form/element controlType="radio" options=simpleOptions as |Element|}}
           {{Element.control inline=true}}
-        {{/bs-form/element}}  
+        {{/bs-form/element}}
       `);
 
       assert.dom('.form-check.form-check-inline').exists({ count: 2 });
@@ -842,6 +842,28 @@ module('Integration | Component | bs-form/element', function(hooks) {
     assert.dom(formFeedbackElement()).hasClass(
       validationErrorClass(),
       'events present in `showValidationOn` trigger validation'
+    );
+  });
+
+  testRequiringFocus('event triggered on input group button does not enable validation', async function(assert) {
+    this.set('errors', A(['Invalid']));
+    this.set('model', EmberObject.create({ name: null }));
+    await render(hbs`
+      {{#bs-form as |form|}}
+        {{#form.element property='name' hasValidator=true errors=errors model=model as |el|}}
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <button class="btn btn-outline-secondary" type="button">Button</button>
+            </div>
+            {{el.control}}
+          </div>
+        {{/form.element}}
+      {{/bs-form}}
+    `);
+    await click('button');
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation warnings aren\'t shown before user interaction'
     );
   });
 

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -8,9 +8,11 @@ import { clearRender, render, click, fillIn, triggerEvent, focus, blur } from '@
 import {
   formFeedbackClass,
   test,
-  testRequiringFocus,
   testBS3,
   testBS4,
+  testRequiringFocus,
+  testBS3RequiringFocus,
+  testBS4RequiringFocus,
   validationSuccessClass,
   validationErrorClass,
   validationWarningClass,
@@ -845,7 +847,29 @@ module('Integration | Component | bs-form/element', function(hooks) {
     );
   });
 
-  testRequiringFocus('event triggered on input group button does not enable validation', async function(assert) {
+  testBS3RequiringFocus('event triggered on input group button does not enable validation', async function(assert) {
+    this.set('errors', A(['Invalid']));
+    this.set('model', EmberObject.create({ name: null }));
+    await render(hbs`
+      {{#bs-form as |form|}}
+        {{#form.element property='name' hasValidator=true errors=errors model=model as |el|}}
+          <div class="input-group">
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button">Button</button>
+            </span>
+            {{el.control}}
+          </div>
+        {{/form.element}}
+      {{/bs-form}}
+    `);
+    await click('button');
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation warnings aren\'t shown before user interaction'
+    );
+  });
+
+  testBS4RequiringFocus('event triggered on input group button does not enable validation', async function(assert) {
     this.set('errors', A(['Invalid']));
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
@@ -865,6 +889,29 @@ module('Integration | Component | bs-form/element', function(hooks) {
       validationErrorClass(),
       'validation warnings aren\'t shown before user interaction'
     );
+  });
+
+  testRequiringFocus('event targets not enabling validation are configurable per `doNotShowValidationForEventTargets`', async function(assert) {
+    this.set('doNotShowValidationForEventTargets', ['[data-trigger-validation="false"]']);
+    this.set('errors', A(['Invalid']));
+    this.set('model', EmberObject.create({ name: null }));
+    await render(hbs`
+      {{#bs-form as |form|}}
+        {{#form.element property='name' hasValidator=true errors=errors model=model
+          doNotShowValidationForEventTargets=doNotShowValidationForEventTargets
+        as |el|
+        }}
+          {{el.control}}
+          <button data-trigger-validation="false">Test</button>
+        {{/form.element}}
+      {{/bs-form}}
+    `);
+    await click('button');
+    assert.dom(formFeedbackElement()).hasNoClass(validationErrorClass());
+
+    this.set('doNotShowValidationForEventTargets', []);
+    await click('button');
+    assert.dom(formFeedbackElement()).hasNoClass(validationErrorClass());
   });
 
   test('it uses custom control component when registered in DI container', async function(assert) {


### PR DESCRIPTION
Before this change a click on an input group button triggered validation to be shown by default if bubbling of focus out event was not prevented.