### PR TITLE
Add option to hide all validations after form submission

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -238,10 +238,10 @@ export default Component.extend({
   /**
    * @property showAllValidations
    * @type boolean
-   * @default false
+   * @default undefined
    * @private
    */
-  showAllValidations: false,
+  showAllValidations: undefined,
 
   /**
    * Action is called before the form is validated (if possible) and submitted.
@@ -302,6 +302,7 @@ export default Component.extend({
     RSVP.resolve(this.get('hasValidator') ? this.validate(this.get('model')) : null)
       .then(
         (r) => {
+          this.set('showAllValidations', false);
           return this.get('onSubmit')(model, r);
         },
         (err) => {
@@ -317,6 +318,11 @@ export default Component.extend({
           }
 
           this.decrementProperty('pendingSubmissions');
+
+          // reset forced hiding of validations
+          if (this.get('showAllValidations') === false) {
+            this.set('showAllValidations', undefined);
+          }
         }
       });
   },

--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -211,6 +211,18 @@ export default Component.extend({
   preventConcurrency: false,
 
   /**
+   * If true, after successful validation and upon submitting the form, all current element validations will be hidden.
+   * If the form remains visible, the user would have to focus out of elements of submit the form again for the
+   * validations to show up again, as if a fresh new form component had been rendered.
+   *
+   * @property hideValidationsOnSubmit
+   * @type {Boolean}
+   * @default false
+   * @public
+   */
+  hideValidationsOnSubmit: false,
+
+  /**
    * If set to true novalidate attribute is present on form element
    *
    * @property novalidate
@@ -302,7 +314,9 @@ export default Component.extend({
     RSVP.resolve(this.get('hasValidator') ? this.validate(this.get('model')) : null)
       .then(
         (r) => {
-          this.set('showAllValidations', false);
+          if (this.get('hideValidationsOnSubmit') === true) {
+            this.set('showAllValidations', false);
+          }
           return this.get('onSubmit')(model, r);
         },
         (err) => {

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -667,7 +667,14 @@ export default FormGroup.extend({
    * @default false
    * @private
    */
-  showAllValidations: false,
+  showAllValidations: computed({
+    get() {
+    },
+    set(key, value) {
+      this.set('showOwnValidation', false);
+      return value;
+    }
+  }),
 
   /**
    * @property showModelValidations

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -3,7 +3,7 @@ import { A } from '@ember/array';
 import { resolve, reject } from 'rsvp';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn, triggerKeyEvent, triggerEvent, waitFor, waitUntil, settled } from '@ember/test-helpers';
+import { render, click, fillIn, triggerKeyEvent, triggerEvent, waitFor, waitUntil, settled, focus, blur } from '@ember/test-helpers';
 import {
   formFeedbackClass,
   test,
@@ -15,7 +15,7 @@ import {
 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import { defer } from 'rsvp';
-import { next } from '@ember/runloop';
+import { next, run } from '@ember/runloop';
 
 const nextRunloop = function() {
   return new Promise((resolve) => {
@@ -162,6 +162,101 @@ module('Integration | Component | bs-form', function(hooks) {
     );
     await triggerEvent('form', 'submit');
 
+    assert.dom(formFeedbackElement()).hasClass(
+      validationErrorClass(),
+      'validation errors are shown after form submission'
+    );
+    assert.dom(`.${formFeedbackClass()}`).hasText('There is an error');
+  });
+
+  testRequiringFocus('Submitting the form does not show validation errors while submitting', async function(assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A([]));
+    this.set('validateStub', () => this.get('errors.length') > 0 ? reject() : resolve());
+    let deferredSubmitAction = defer();
+    this.set('submitAction', () => {
+      return deferredSubmitAction.promise;
+    });
+    await render(
+      hbs`
+        {{#bs-form model=model onSubmit=submitAction hasValidator=true validate=validateStub as |form|}}
+          {{form.element property="dummy" hasValidator=true errors=errors}}
+        {{/bs-form}}`
+    );
+
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation errors aren\'t shown before user interaction'
+    );
+
+    await focus('input');
+    await blur('input');
+    await triggerEvent('form', 'submit');
+
+    // simulate validation errors being added while a submission is ongoing
+    run(() => this.get('errors').pushObject('There is an error'));
+    await settled();
+
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation errors aren\'t shown while submitting'
+    );
+
+    deferredSubmitAction.resolve();
+    await settled();
+
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation errors aren\'t shown after submitting'
+    );
+
+    await focus('input');
+    await blur('input');
+
+    // form element has been changed, and has errors now, so validations must show up
+    assert.dom(formFeedbackElement()).hasClass(
+      validationErrorClass(),
+      'validation errors are shown after form submission'
+    );
+    assert.dom(`.${formFeedbackClass()}`).hasText('There is an error');
+  });
+
+  testRequiringFocus('Submitting the form does not show validation errors after submission', async function(assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A([]));
+    this.set('validateStub', () => this.get('errors.length') > 0 ? reject() : resolve());
+    this.set('submitAction', () => {});
+    await render(
+      hbs`
+        {{#bs-form model=model onSubmit=submitAction hasValidator=true validate=validateStub as |form|}}
+          {{form.element property="dummy" hasValidator=true errors=errors}}
+        {{/bs-form}}`
+    );
+
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation errors aren\'t shown before user interaction'
+    );
+
+    await focus('input');
+    await blur('input');
+    await triggerEvent('form', 'submit');
+
+    // simulate validation errors being added while a submission is ongoing
+    run(() => this.get('errors').pushObject('There is an error'));
+    await settled();
+
+    assert.dom(formFeedbackElement()).hasNoClass(
+      validationErrorClass(),
+      'validation errors aren\'t shown after submitting'
+    );
+
+    await focus('input');
+    await blur('input');
+
+    // form element has been changed, and has errors now, so validations must show up
     assert.dom(formFeedbackElement()).hasClass(
       validationErrorClass(),
       'validation errors are shown after form submission'


### PR DESCRIPTION
After a successful form submission (i.e. no validation errors) which changes some state (e.g. creates a record), this could make the model's validation invalid (think of an `exclude` validation that a property is unique when creating an model, which becomes invalid after the form has been submitted and the new name has been added to a live updating collection). Previously if the form remains visible this would show a new validation error, after a successful form submission, because the form elements `showOwnValidation` has been activated before!

With this change, the display of validations is resetted after a successful submission, as if a fresh form component was rendered, so the user would have to resubmit or trigger the element's validation display (focusout) again to show the validation error that has been added meanwhile.