### PR TITLE
CSP: refactor to not require `style-src 'unsafe-inline` and add test coverage

### DIFF
--- a/addon/components/base/bs-collapse.js
+++ b/addon/components/base/bs-collapse.js
@@ -1,10 +1,11 @@
 import { not, alias, and } from '@ember/object/computed';
 import Component from '@ember/component';
-import { isPresent, isEmpty } from '@ember/utils';
-import { observer, computed } from '@ember/object';
+import { isPresent } from '@ember/utils';
+import { observer } from '@ember/object';
 import { next } from '@ember/runloop';
-import { htmlSafe, camelize } from '@ember/string';
+import { camelize } from '@ember/string';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
+import { assert } from '@ember/debug';
 
 /**
  An Ember component that mimics the behaviour of [Bootstrap's collapse.js plugin](http://getbootstrap.com/javascript/#collapse)
@@ -28,7 +29,6 @@ import transitionEnd from 'ember-bootstrap/utils/transition-end';
 export default Component.extend({
 
   classNameBindings: ['collapse', 'collapsing'],
-  attributeBindings: ['style'],
 
   /**
    * Collapsed/expanded state
@@ -60,13 +60,6 @@ export default Component.extend({
    * @private
    */
   transitioning: false,
-
-  /**
-   * @property collapseSize
-   * @type number
-   * @private
-   */
-  collapseSize: null,
 
   /**
    * The size of the element when collapsed. Defaults to 0.
@@ -120,14 +113,14 @@ export default Component.extend({
    */
   transitionDuration: 350,
 
-  style: computed('collapseSize', function() {
-    let size = this.get('collapseSize');
-    let dimension = this.get('collapseDimension');
-    if (isEmpty(size)) {
-      return htmlSafe('');
-    }
-    return htmlSafe(`${dimension}: ${size}px`);
-  }),
+  setCollapseSize() {
+    let { collapseSize: size, collapseDimension: dimension } = this.getProperties('collapseSize', 'collapseDimension');
+
+    assert(`collapseDimension must be either "width" or "height". ${dimension} given.`, ["width", "height"].includes(dimension));
+
+    this.element.style.width = dimension === 'width' && size ? `${size}px` : '';
+    this.element.style.height = dimension === 'height' && size ? `${size}px` : '';
+  },
 
   /**
    * The action to be sent when the element is about to be hidden.
@@ -182,14 +175,14 @@ export default Component.extend({
       }
       this.set('transitioning', false);
       if (this.get('resetSizeWhenNotCollapsing')) {
-        this.set('collapseSize', null);
+        this.setCollapseSize(null);
       }
       this.get('onShown')();
     });
 
     next(this, function() {
       if (!this.get('isDestroyed')) {
-        this.set('collapseSize', this.getExpandedSize('show'));
+        this.setCollapseSize(this.getExpandedSize('show'));
       }
     });
   },
@@ -225,9 +218,9 @@ export default Component.extend({
 
     this.setProperties({
       transitioning: true,
-      collapseSize: this.getExpandedSize('hide'),
       active: false
     });
+    this.setCollapseSize(this.getExpandedSize('hide'));
 
     transitionEnd(this.get('element'), this.get('transitionDuration')).then(() => {
       if (this.get('isDestroyed')) {
@@ -235,14 +228,14 @@ export default Component.extend({
       }
       this.set('transitioning', false);
       if (this.get('resetSizeWhenNotCollapsing')) {
-        this.set('collapseSize', null);
+        this.setCollapseSize(null);
       }
       this.get('onHidden')();
     });
 
     next(this, function() {
       if (!this.get('isDestroyed')) {
-        this.set('collapseSize', this.get('collapsedSize'));
+        this.setCollapseSize(this.get('collapsedSize'));
       }
     });
   },
@@ -267,13 +260,13 @@ export default Component.extend({
 
   _updateCollapsedSize: observer('collapsedSize', function() {
     if (!this.get('resetSizeWhenNotCollapsing') && this.get('collapsed') && !this.get('collapsing')) {
-      this.set('collapseSize', this.get('collapsedSize'));
+      this.setCollapseSize(this.get('collapsedSize'));
     }
   }),
 
   _updateExpandedSize: observer('expandedSize', function() {
     if (!this.get('resetSizeWhenNotCollapsing') && !this.get('collapsed') && !this.get('collapsing')) {
-      this.set('collapseSize', this.get('expandedSize'));
+      this.setCollapseSize(this.get('expandedSize'));
     }
   })
 });

--- a/addon/components/base/bs-progress/bar.js
+++ b/addon/components/base/bs-progress/bar.js
@@ -1,7 +1,6 @@
 import { readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
 import layout from 'ember-bootstrap/templates/components/bs-progress/bar';
 import TypeClass from 'ember-bootstrap/mixins/type-class';
 
@@ -20,7 +19,7 @@ export default Component.extend(TypeClass, {
   classNames: ['progress-bar'],
   classNameBindings: ['progressBarStriped'],
 
-  attributeBindings: ['style', 'ariaValuenow', 'ariaValuemin', 'ariaValuemax'],
+  attributeBindings: ['ariaValuenow', 'ariaValuemin', 'ariaValuemax'],
 
   /**
    * The lower limit of the value range
@@ -139,14 +138,19 @@ export default Component.extend(TypeClass, {
   }).readOnly(),
 
   /**
-   * @property style
-   * @type string
+   * @method updateStyles
+   * @return void
    * @private
-   * @readonly
    */
-  style: computed('percent', function() {
-    let percent = this.get('percent');
-    return htmlSafe(`width: ${percent}%`);
-  })
+  updateStyles() {
+    let percent = Number.parseFloat(this.get('percent'));
+    this.element.style.width = !Number.isNaN(percent) ? `${percent}%` : '';
+  },
 
+  didInsertElement() {
+    this.updateStyles();
+  },
+  didUpdateAttrs() {
+    this.updateStyles();
+  }
 });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli": "~3.5.0",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
+    "ember-cli-content-security-policy": "^1.0.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^5.0.0",
     "ember-cli-fastboot": "^2.0.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,6 +18,8 @@ module.exports = function(environment) {
       // when it is created
     },
 
+    contentSecurityPolicyMeta: true,
+
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/]
     },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,17 +20,23 @@ module.exports = function(environment) {
 
     contentSecurityPolicy: {
       'default-src': ["'none'"],
-      'script-src':  ["'self'"],
+      'script-src':  [
+        "'self'",
+        // test file loaded assertion injected as <script> tag by ember-cli
+        "'sha256-37u63EBe1EibDZ3vZNr6mxLepqlY1CQw+4N89HrzP9s='",
+      ],
       'font-src':    ["'self'"],
       'connect-src': ["'self'"],
       'img-src':     [
         "'self'",
-        "data:", // Bootstrap 4 uses data URL for some SVG images in CSS
+        // Bootstrap 4 uses data URL for some SVG images in CSS
+        "data:",
       ],
       'style-src':   ["'self'"],
       'media-src':   ["'self'"],
       'frame-src':   [
-        "https://ghbtns.com/", // iframe used in application template of dummy app
+        // iframe used in application template of dummy app
+        "https://ghbtns.com/",
       ],
     },
 
@@ -64,9 +70,6 @@ module.exports = function(environment) {
     // testem requires frame-src 'self' to run
     // https://github.com/rwjblue/ember-cli-content-security-policy/blob/v1.0.0/index.js#L85-L88
     ENV.contentSecurityPolicy['frame-src'].push('self');
-
-    // test should fail if they require a CSP violation
-    ENV.contentSecurityPolicyHeader = 'Content-Security-Policy';
   }
 
   if (environment === 'production') {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,6 +18,16 @@ module.exports = function(environment) {
       // when it is created
     },
 
+    contentSecurityPolicy: {
+      'default-src': ["'none'"],
+      'script-src':  ["'self'"],
+      'font-src':    ["'self'"],
+      'connect-src': ["'self'"],
+      'img-src':     ["'self'"],
+      'style-src':   ["'self'"],
+      'media-src':   ["'self'"],
+      'frame-src':   ["https://ghbtns.com/"],
+    },
     contentSecurityPolicyMeta: true,
 
     fastboot: {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -23,12 +23,16 @@ module.exports = function(environment) {
       'script-src':  ["'self'"],
       'font-src':    ["'self'"],
       'connect-src': ["'self'"],
-      'img-src':     ["'self'"],
+      'img-src':     [
+        "'self'",
+        "data:", // Bootstrap 4 uses data URL for some SVG images in CSS
+      ],
       'style-src':   ["'self'"],
       'media-src':   ["'self'"],
-      'frame-src':   ["https://ghbtns.com/"],
+      'frame-src':   [
+        "https://ghbtns.com/", // iframe used in application template of dummy app
+      ],
     },
-    contentSecurityPolicyMeta: true,
 
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/]
@@ -56,6 +60,13 @@ module.exports = function(environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    // testem requires frame-src 'self' to run
+    // https://github.com/rwjblue/ember-cli-content-security-policy/blob/v1.0.0/index.js#L85-L88
+    ENV.contentSecurityPolicy['frame-src'].push('self');
+
+    // test should fail if they require a CSP violation
+    ENV.contentSecurityPolicyHeader = 'Content-Security-Policy';
   }
 
   if (environment === 'production') {

--- a/tests/helpers/setup-stylesheet-support.js
+++ b/tests/helpers/setup-stylesheet-support.js
@@ -1,0 +1,21 @@
+export default function({ beforeEach, afterEach }) {
+  let styleSheet = [...document.styleSheets].find((sheet) => sheet.href.includes('test-support.css'));
+  let numberOfInsertedRules;
+
+  beforeEach(function() {
+    numberOfInsertedRules = 0;
+
+    this.insertCSSRule = function(rule) {
+      styleSheet.insertRule(rule, styleSheet.length);
+      numberOfInsertedRules++;
+    };
+  });
+
+  afterEach(function() {
+    // since we insert the rules at the end of the stylesheet, we could safely
+    // remove the same amount of rules from the end as we have inserted
+    for (let i = 1; i <= numberOfInsertedRules; i++) {
+      styleSheet.removeRule(styleSheet.length);
+    }
+  });
+}

--- a/tests/helpers/setup-stylesheet-support.js
+++ b/tests/helpers/setup-stylesheet-support.js
@@ -15,7 +15,7 @@ export default function({ beforeEach, afterEach }) {
     // since we insert the rules at the end of the stylesheet, we could safely
     // remove the same amount of rules from the end as we have inserted
     for (let i = 1; i <= numberOfInsertedRules; i++) {
-      styleSheet.removeRule(styleSheet.length);
+      styleSheet.deleteRule(styleSheet.length);
     }
   });
 }

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -33,12 +33,14 @@ module('Integration | Component | bs-popover', function(hooks) {
     let placements = ['top', 'left', 'bottom', 'right'];
     this.set('placement', placements[0]);
     await render(hbs`
-      <div style="margin: 200px">
+      <div id="wrapper">
         {{#bs-popover/element id="popover-element" placement=placement title="dummy title"}}
           template block text
         {{/bs-popover/element}}
       </div>
     `);
+    this.element.querySelector('wrapper').style.margin = '200px';
+
     for (let placement of placements) {
       this.set('placement', placement);
       let placementClass = popoverPositionClass(placement);
@@ -47,9 +49,17 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   test('should place popover on top of element', async function(assert) {
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper"><p style="margin-top: 200px"><button class="btn" id="target">Click me{{#bs-popover placement="top" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}</button></p></div>`
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="wrapper">
+        <p>
+          <button class="btn" id="target">
+            Click me{{#bs-popover placement="top" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}
+          </button>
+        </p>
+      </div>`
     );
+    this.element.querySelector('#wrapper p').style.marginTop = '200px';
 
     setupForPositioning();
 
@@ -59,9 +69,17 @@ module('Integration | Component | bs-popover', function(hooks) {
 
   test('should adjust popover arrow', async function(assert) {
     let expectedArrowPosition = versionDependent(225, 219);
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper"><p style="margin-top: 200px"><button class="btn" id="target">Click me{{#bs-popover placement="top" autoPlacement=true viewportSelector="#wrapper" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}</button></p></div>`
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="wrapper">
+        <p>
+          <button class="btn" id="target">
+            Click me{{#bs-popover placement="top" autoPlacement=true viewportSelector="#wrapper" title="very very very very very very very long popover" fade=false}}very very very very very very very long popover{{/bs-popover}}
+          </button>
+        </p>
+      </div>`
     );
+    this.element.querySelector('#wrapper p').style.marginTop = '200px';
 
     setupForPositioning('right');
 

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -7,9 +7,11 @@ import {
   setupForPositioning,
   assertPositioning
 } from '../../helpers/contextual-help';
+import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 
 module('Integration | Component | bs-popover', function(hooks) {
   setupRenderingTest(hooks);
+  setupStylesheetSupport(hooks);
 
   test('it has correct markup', async function(assert) {
     // Template block usage:
@@ -30,6 +32,8 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   skip('it supports different placements', async function(assert) {
+    this.insertCSSRule('#wrapper { margin: 200px }');
+
     let placements = ['top', 'left', 'bottom', 'right'];
     this.set('placement', placements[0]);
     await render(hbs`
@@ -39,7 +43,6 @@ module('Integration | Component | bs-popover', function(hooks) {
         {{/bs-popover/element}}
       </div>
     `);
-    this.element.querySelector('wrapper').style.margin = '200px';
 
     for (let placement of placements) {
       this.set('placement', placement);
@@ -49,6 +52,8 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   test('should place popover on top of element', async function(assert) {
+    this.insertCSSRule('#wrapper p { margin-top: 200px }');
+
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
       <div id="wrapper">
@@ -59,7 +64,6 @@ module('Integration | Component | bs-popover', function(hooks) {
         </p>
       </div>`
     );
-    this.element.querySelector('#wrapper p').style.marginTop = '200px';
 
     setupForPositioning();
 
@@ -68,6 +72,8 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   test('should adjust popover arrow', async function(assert) {
+    this.insertCSSRule('#wrapper p { margin-top: 200px }');
+
     let expectedArrowPosition = versionDependent(225, 219);
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
@@ -79,7 +85,6 @@ module('Integration | Component | bs-popover', function(hooks) {
         </p>
       </div>`
     );
-    this.element.querySelector('#wrapper p').style.marginTop = '200px';
 
     setupForPositioning('right');
 

--- a/tests/integration/components/bs-progress-test.js
+++ b/tests/integration/components/bs-progress-test.js
@@ -40,10 +40,19 @@ module('Integration | Component | bs-progress', function(hooks) {
         maxValue: 10
       }
     ];
+    let cssRules = [
+      '.progress-bar { transition: none; }',
+      '.width-500 { width: 500px }',
+    ];
+    let styleSheet = document.styleSheets[document.styleSheets.length - 1];
+
+    // inject css rules required for testing
+    cssRules.forEach((rule) => {
+      styleSheet.insertRule(rule, styleSheet.cssRules.length);
+    });
 
     await render(hbs`
-        <style type="text/css">.progress-bar { transition: none; }</style>
-        <div style="width: 500px">
+        <div class="width-500">
           {{#bs-progress as |p|}}
             {{p.bar value=value minValue=minValue maxValue=maxValue}}
           {{/bs-progress}}
@@ -61,6 +70,12 @@ module('Integration | Component | bs-progress', function(hooks) {
       assert.equal(this.element.querySelector('.progress-bar').offsetWidth, expectedWidth, 'Progress bar has expected width.');
     });
 
+    // remove CSS rules injected for testing
+    // since they had been injected at the end of the stylesheet,
+    // we could remove safely remove the last rules in stylesheet
+    for (let i = 0; i < cssRules.length; i++) {
+      styleSheet.deleteRule(styleSheet.cssRules.length - 1);
+    }
   });
 
   test('progress bar has invisible label for screen readers', async function(assert) {

--- a/tests/integration/components/bs-progress-test.js
+++ b/tests/integration/components/bs-progress-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
+import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 
 module('Integration | Component | bs-progress', function(hooks) {
   setupRenderingTest(hooks);
+  setupStylesheetSupport(hooks);
 
   test('bs-progress has correct markup', async function(assert) {
     // Template block usage:
@@ -40,16 +42,9 @@ module('Integration | Component | bs-progress', function(hooks) {
         maxValue: 10
       }
     ];
-    let cssRules = [
-      '.progress-bar { transition: none; }',
-      '.width-500 { width: 500px }',
-    ];
-    let styleSheet = document.styleSheets[document.styleSheets.length - 1];
 
-    // inject css rules required for testing
-    cssRules.forEach((rule) => {
-      styleSheet.insertRule(rule, styleSheet.cssRules.length);
-    });
+    this.insertCSSRule('.progress-bar { transition: none; }');
+    this.insertCSSRule('.width-500 { width: 500px }');
 
     await render(hbs`
         <div class="width-500">
@@ -69,13 +64,6 @@ module('Integration | Component | bs-progress', function(hooks) {
 
       assert.equal(this.element.querySelector('.progress-bar').offsetWidth, expectedWidth, 'Progress bar has expected width.');
     });
-
-    // remove CSS rules injected for testing
-    // since they had been injected at the end of the stylesheet,
-    // we could remove safely remove the last rules in stylesheet
-    for (let i = 0; i < cssRules.length; i++) {
-      styleSheet.deleteRule(styleSheet.cssRules.length - 1);
-    }
   });
 
   test('progress bar has invisible label for screen readers', async function(assert) {

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -16,9 +16,11 @@ import {
   setupForPositioning,
   assertPositioning
 } from '../../helpers/contextual-help';
+import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 
 module('Integration | Component | bs-tooltip', function(hooks) {
   setupRenderingTest(hooks);
+  setupStylesheetSupport(hooks);
 
   hooks.beforeEach(function() {
     this.actions = {};
@@ -237,8 +239,16 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should place tooltip on top of element', async function(assert) {
-    await render(
-      hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false}}</a></p></div>`
+    this.insertCSSRule('.margin-top { margin-top: 200px; }');
+
+    await render(hbs`
+      <div id="wrapper">
+        <p class="margin-top">
+          <a href="#" id="target">
+            Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false}}
+          </a>
+        </p>
+      </div>`
     );
 
     setupForPositioning();
@@ -248,8 +258,18 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should place tooltip on top of element if already visible', async function(assert) {
-    await render(
-      hbs`<div id="wrapper">{{#if visible}}<p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=true}}</a></p>{{/if}}</div>`
+    this.insertCSSRule('.margin-top { margin-top: 200px; }');
+
+    await render(hbs`
+      <div id="wrapper">
+        {{#if visible}}
+          <p class="margin-top">
+            <a href="#" id="target">
+              Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=true}}
+            </a>
+          </p>
+        {{/if}}
+      </div>`
     );
 
     setupForPositioning();
@@ -259,9 +279,17 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should place tooltip on top of element if visible is set to true', async function(assert) {
+    this.insertCSSRule('.margin-top { margin-top: 200px; }');
+
     this.set('visible', false);
-    await render(
-      hbs`<div id="wrapper"><p style="margin-top: 200px"><a href="#" id="target">Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=visible}}</a></p></div>`
+    await render(hbs`
+      <div id="wrapper">
+        <p class="margin-top">
+          <a href="#" id="target">
+            Hover me{{bs-tooltip title="very very very very very very very long tooltip" fade=false visible=visible}}
+          </a>
+        </p>
+      </div>`
     );
 
     setupForPositioning();
@@ -330,9 +358,18 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should position tooltip arrow centered', async function(assert) {
+    this.insertCSSRule('.margin-top { margin-top: 200px; }');
+
     let expectedArrowPosition = versionDependent(95, 94);
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper"><p style="margin-top: 200px"><button class="btn" id="target">Click me{{bs-tooltip placement="top" title="very very very very very very very long tooltip" fade=false}}</button></p></div>`
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="wrapper">
+        <p class="margin-top">
+          <button class="btn" id="target">
+            Click me{{bs-tooltip placement="top" title="very very very very very very very long tooltip" fade=false}}
+          </button>
+        </p>
+      </div>`
     );
 
     setupForPositioning();
@@ -343,9 +380,18 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should adjust tooltip arrow', async function(assert) {
+    this.insertCSSRule('.margin-top { margin-top: 200px; }');
+
     let expectedArrowPosition = versionDependent(155, 150);
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper"><p style="margin-top: 200px"><button class="btn" id="target">Click me{{bs-tooltip autoPlacement=true viewportSelector="#wrapper" placement="top" title="very very very very very very very long tooltip" fade=false}}</button></p></div>`
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="wrapper">
+        <p class="margin-top">
+          <button class="btn" id="target">
+            Click me{{bs-tooltip autoPlacement=true viewportSelector="#wrapper" placement="top" title="very very very very very very very long tooltip" fade=false}}
+          </button>
+        </p>
+      </div>`
     );
 
     setupForPositioning('right');
@@ -362,8 +408,17 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('should adjust placement if not fitting in viewport', async function(assert) {
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper"><p style="margin-top: 300px"><button class="btn" id="target">Click me{{bs-tooltip placement="bottom" autoPlacement=true title="very very very very very very very long tooltip" fade=false}}</button></p></div>`
+    this.insertCSSRule('.margin-top { margin-top: 300px; }');
+
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="wrapper">
+        <p class="margin-top">
+          <button class="btn" id="target">
+            Click me{{bs-tooltip placement="bottom" autoPlacement=true title="very very very very very very very long tooltip" fade=false}}
+          </button>
+        </p>
+      </div>`
     );
 
     setupForPositioning('right');

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -8,5 +8,24 @@ if (typeof Promise === 'undefined') {
   window.Promise = EmberPromise;
 }
 
+document.addEventListener('securitypolicyviolation', function({ blockedURI, target, violatedDirective }) {
+  // ignore CSP violation by qunit
+  // This couldn't be whitelisted using SHA hash cause it's style-src-attribute violation.
+  // Could be removed after upstream fix is merged and released upstream:
+  // https://github.com/qunitjs/qunit/pull/1369
+  if (
+    violatedDirective.startsWith('style-src') &&
+    target.parentNode.id === 'qunit-modulefilter-actions'
+  ) {
+    return;
+  }
+
+  throw new Error(
+    'Content-Security-Policy violation detected: ' +
+    `Violated directive: ${violatedDirective}. ` +
+    `Blocked URI: ${blockedURI}`
+  );
+});
+
 setApplication(Application.create(config.APP));
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,7 +1755,7 @@ bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
-body-parser@1.18.3:
+body-parser@1.18.3, body-parser@^1.17.0:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   dependencies:
@@ -3471,6 +3471,14 @@ ember-cli-build-config-editor@^0.5.0:
   resolved "https://registry.yarnpkg.com/ember-cli-build-config-editor/-/ember-cli-build-config-editor-0.5.1.tgz#0847d07b6cb6c80bc64d47c2b9dbe0d484707395"
   dependencies:
     recast "^0.12.0"
+
+ember-cli-content-security-policy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-content-security-policy/-/ember-cli-content-security-policy-1.0.0.tgz#4f7d72997d4209cd59f10d3b0070fdb39593ed2d"
+  integrity sha512-5JSm22epRFkMH5h+/HgfnspjYPIXNP4RXUUSS8mj1KV3ZJZzcY3835YNnYYi3Tx5SLLHFqadT851zCXfcQei9w==
+  dependencies:
+    body-parser "^1.17.0"
+    chalk "^2.0.0"
 
 ember-cli-dependency-checker@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This PR fixes all violations of a strict Content-Security-Policy and add test coverage to prevent regression. Tests will fail if they trigger a CSP violation.

Fixes for CSP are binding of style attribute which requires `unsafe-inline` cause Glimmer will do a `element.setAttribute('style', value)`. This is true for `Component.extend({ attributeBindings: ['style'], style: '...' })` as well as `<div style="...">` in templates. The last case was often present in tests. For that one a test helper that inserts CSS rules needed for testing is added. Attribute binding was mostly refactored to methods that changes the style using CSSOM and triggered in component lifecycle hooks. There might still be room for optimization.

I'm not convinced by the code needed to dynamically bind style. That doesn't feel correct in an ember environment. But as far as I know there isn't any better way currently. Hopefully there will be as soon as Element Modifiers ([RFC 353](https://github.com/emberjs/rfcs/pull/353)) land and are supported by all targeted version. But that may need a while and would also require a refactor for outer HTML.