### PR TITLE
Fix inline radio element used with optionLabelPath (BS3)

### DIFF
--- a/addon/templates/components/bs3/bs-form/element/control/radio.hbs
+++ b/addon/templates/components/bs3/bs-form/element/control/radio.hbs
@@ -22,7 +22,7 @@
           {{yield}}
         {{else}}
           {{#if optionLabelPath}}
-            {{get option op tionLabelPath}}
+            {{get option optionLabelPath}}
           {{else}}
             {{option}}
           {{/if}}


### PR DESCRIPTION
I've not used this part, but found something that looks like an issue while exploring the code.