### PR TITLE
Fix IE 11 throws if form.element is used with a not-supported controlType

### DIFF
--- a/addon/components/base/bs-form/element/control/input.js
+++ b/addon/components/base/bs-form/element/control/input.js
@@ -1,5 +1,28 @@
 import Control from '../control';
 import ControlAttributes from 'ember-bootstrap/mixins/control-attributes';
+import { computed } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+
+const allowedTypes = new Map();
+function canUseType(type) {
+  if (typeof document !== 'object' || typeof document.createElement !== 'function') {
+    // consider all types as supported if running in an
+    // environment that doesn't support DOM
+    return true;
+  }
+
+  if (!allowedTypes.has(type)) {
+    try {
+      let inputElement = document.createElement('input');
+      inputElement.type = type;
+      allowedTypes.set(type, true);
+    } catch (error) {
+      allowedTypes.set(type, false);
+    }
+  }
+
+  return allowedTypes.get(type);
+}
 
 /**
 
@@ -36,7 +59,28 @@ export default Control.extend(ControlAttributes, {
    * @type {String}
    * @public
    */
-  type: 'text',
+  type: computed({
+    get() {
+      return 'text';
+    },
+    set(key, value) {
+      // fallback to 'text' if value is empty
+      if (isEmpty(value)) {
+        return 'text';
+      }
+
+      // IE 11 throws if setting an unsupported type via DOM.
+      // We guard against that behaviour by testing if user
+      // agent throws on setting the provided type.
+      // This is inspired by input helper shipped with Ember.js:
+      // https://github.com/emberjs/ember.js/blob/30137796af42c63b28ead127cba0e43e45a773c1/packages/%40ember/-internals/glimmer/lib/components/text_field.ts#L93-L115
+      if (!canUseType(value)) {
+        return 'text';
+      }
+
+      return value;
+    },
+  }),
 
   change(event) {
     this.get('onChange')(event.target.value);

--- a/tests/integration/components/bs-form/element/control/input-test.js
+++ b/tests/integration/components/bs-form/element/control/input-test.js
@@ -1,17 +1,26 @@
 import { module, test } from 'qunit';
 import { testBS4 } from "../../../../../helpers/bootstrap-test";
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | bs form/element/control/input', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-
     await render(hbs`{{bs-form/element/control/input}}`);
 
     assert.dom('input[type=text]').exists({ count: 1 });
+  });
+
+  test('it falls back to text if type is not supported by browser', async function(assert) {
+    // This also asserts that IE 11 issue of throwing if setting an unsupported type
+    // is set via DOM (e.g. document.createElement('input').type = "foo") is handled
+    // well.
+    await render(hbs`{{bs-form/element/control/input type="foo"}}`);
+
+    // qunit-dom does not provide a method to assert that a property equals a value
+    assert.equal(find('input').type, 'text');
   });
 
   testBS4('support size classes', async function(assert) {


### PR DESCRIPTION
`{{input}}` helper shipped with Ember.js addresses this issue by discarding input types that aren't supported: https://github.com/emberjs/ember.js/blob/30137796af42c63b28ead127cba0e43e45a773c1/packages/%40ember/-internals/glimmer/lib/components/text_field.ts#L93-L115 Seems like we need something similar.