### PR TITLE
Dropdown respects closeOnMenuClick=false even after re-opening the menu

### DIFF
--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -214,7 +214,7 @@ export default Component.extend({
    */
   menuElement: computed(function() {
     return document.getElementById(`${this.get('elementId')}__menu`);
-  }),
+  }).volatile(),
 
   /**
    * @property toggleElement

--- a/addon/components/base/bs-dropdown.js
+++ b/addon/components/base/bs-dropdown.js
@@ -147,7 +147,7 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown';
  @extends Ember.Component
  @public
  */
-export default Component.extend({
+let component = Component.extend({
   layout,
   classNameBindings: ['containerClass'],
 
@@ -207,14 +207,6 @@ export default Component.extend({
       return `drop${this.get('direction')}`;
     }
   }),
-
-  /**
-   * @property menuElement
-   * @private
-   */
-  menuElement: computed(function() {
-    return document.getElementById(`${this.get('elementId')}__menu`);
-  }).volatile(),
 
   /**
    * @property toggleElement
@@ -330,3 +322,20 @@ export default Component.extend({
    */
   menuComponent: 'bs-dropdown/menu'
 });
+
+Object.defineProperties(component.prototype, {
+
+  /**
+   * The DOM element of the `.dropdown-menu` element
+   * @type object
+   * @readonly
+   * @private
+   */
+  menuElement: {
+    get() {
+      return document.getElementById(`${this.get('elementId')}__menu`);
+    }
+  }
+});
+
+export default component;

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -137,6 +137,32 @@ module('Integration | Component | bs-dropdown', function(hooks) {
     assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
   });
 
+  test('clicking dropdown menu when closeOnMenuClick is false will not close it, even after opening the menu again', async function (assert) {
+    await render(
+      hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`
+    );
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('.dropdown-menu a');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    // close the menu to validate again
+    await click(document.body);
+    assert.dom('.dropdown-menu').doesNotExist();
+
+    // toggle the menu again
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('.dropdown-menu a');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+  });
+
   test('clicking outside dropdown menu when closeOnMenuClick is false will close it', async function(assert) {
     await render(
       hbs`{{#bs-dropdown closeOnMenuClick=false as |dd|}}{{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}{{#dd.menu}}<li><a href="#">Something</a></li>{{/dd.menu}}{{/bs-dropdown}}`


### PR DESCRIPTION
If we don't add the volatile in the menuElement, it will cache the first dom element generated for the menu, but because is being lazily rendered the menuElement will not be the same dom element next time is opened.