### PR TITLE
Revert ember-cli-babel update

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "broccoli-stew": "^2.0.0",
     "chalk": "^2.1.0",
     "ember-assign-polyfill": "^2.0.1",
-    "ember-cli-babel": "^7.1.2",
+    "ember-cli-babel": "^6.16.0",
     "ember-cli-build-config-editor": "0.5.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-version-checker": "^3.0.0",


### PR DESCRIPTION
Done accidentally with ember-cli-update, but needs to be reverted in master as this is a breaking change