### PR TITLE
replace SauceLab badge with BrowserStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # ember-bootstrap
 
 [![Build Status](https://travis-ci.org/kaliber5/ember-bootstrap.svg?branch=master)](https://travis-ci.org/kaliber5/ember-bootstrap)
+[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=UzdFQU9hSW1FdjhLU3hDU0I3ZXF6WG1YSWp2TGRHaU9tYmhNT0pPdUNhQT0tLWZqTkNQUzBjNFUvcFhlWTA0YitETmc9PQ==--2f9e373be422d4fcc56c8d658afc55f1938a721e)](https://www.browserstack.com/automate/public-build/UzdFQU9hSW1FdjhLU3hDU0I3ZXF6WG1YSWp2TGRHaU9tYmhNT0pPdUNhQT0tLWZqTkNQUzBjNFUvcFhlWTA0YitETmc9PQ==--2f9e373be422d4fcc56c8d658afc55f1938a721e)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-bootstrap.svg)](http://emberobserver.com/addons/ember-bootstrap)
 [![npm version](https://badge.fury.io/js/ember-bootstrap.svg)](https://badge.fury.io/js/ember-bootstrap)
 [![Dependency Status](https://david-dm.org/kaliber5/ember-bootstrap.svg)](https://david-dm.org/kaliber5/ember-bootstrap)
 [![devDependency Status](https://david-dm.org/kaliber5/ember-bootstrap/dev-status.svg)](https://david-dm.org/kaliber5/ember-bootstrap#info=devDependencies)
 [![Greenkeeper badge](https://badges.greenkeeper.io/kaliber5/ember-bootstrap.svg)](https://greenkeeper.io/)
-
-[![Browser Status](https://badges.herokuapp.com/sauce/ember-bootstrap)](https://saucelabs.com/u/ember-bootstrap)
-
 
 An [ember-cli](http://www.ember-cli.com) addon for using [Bootstrap](http://getbootstrap.com/) 3 or 4 in Ember applications.
 


### PR DESCRIPTION
This was missed in #764. I guess cause of https://github.com/kategengler/ember-cli-browserstack/issues/6.

Got the `badge_key` as described here: https://www.browserstack.com/automate/status-badges

Required credentials are available in `.travis.yml`. :stuck_out_tongue_closed_eyes: