### PR TITLE
Assertion to prevent setting both property and value on a form element

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -983,7 +983,7 @@ export default FormGroup.extend({
       this.set('showValidationOn', ['focusOut']);
     }
     if (!isBlank(this.get('property'))) {
-      assert('You cannot set both property and value on a form element', isBlank(this.get('value')));
+      assert('You cannot set both property and value on a form element', this.get('value') === null);
       defineProperty(this, 'value', alias(`model.${this.get('property')}`));
       this.setupValidations();
     }

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -983,6 +983,7 @@ export default FormGroup.extend({
       this.set('showValidationOn', ['focusOut']);
     }
     if (!isBlank(this.get('property'))) {
+      assert('You cannot set both property and value on a form element', isBlank(this.get('value')));
       defineProperty(this, 'value', alias(`model.${this.get('property')}`));
       this.setupValidations();
     }


### PR DESCRIPTION
The documentation does mention that the element's value will be bound if you use the `property` property, but we wound up with a few stray `value` properties set along with `property` on form elements in our application which lead to some unexpected bugs cropping up in production. It seems like a mistake that's not too difficult to make, so just an extra safety measure :)!