### PR TITLE
Propagate `disabled` and `readonly` property to all yielded form elements

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -276,6 +276,26 @@ export default Component.extend({
   }),
 
   /**
+   * If set to true the `readonly` property of all yielded form elements will be set, making their form controls read-only.
+   *
+   * @property readonly
+   * @type boolean
+   * @default false
+   * @public
+   */
+  readonly: false,
+
+  /**
+   * If set to true the `disabled` property of all yielded form elements will be set, making their form controls disabled.
+   *
+   * @property disabled
+   * @type boolean
+   * @default false
+   * @public
+   */
+  disabled: false,
+
+  /**
    * Validate hook which will return a promise that will either resolve if the model is valid
    * or reject if it's not. This should be overridden to add validation support.
    *

--- a/addon/templates/components/common/bs-form.hbs
+++ b/addon/templates/components/common/bs-form.hbs
@@ -5,6 +5,8 @@
       formLayout=formLayout
       horizontalLabelGridClass=horizontalLabelGridClass
       showAllValidations=showAllValidations
+      disabled=this.disabled
+      readonly=this.readonly
       onChange=(action "change")
       _onChange=(action "resetSubmissionState")
     )

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -662,4 +662,26 @@ module('Integration | Component | bs-form', function(hooks) {
       this.element.querySelector('form').getAttribute('novalidate') === ''
     );
   });
+
+  test('disabled property propagates to all its elements', async function(assert) {
+    await render(
+      hbs`
+        {{#bs-form model=this disabled=true as |form|}}
+          {{form.element property="dummy"}}
+        {{/bs-form}}`
+    );
+
+    assert.dom('.form-group input').hasAttribute('disabled');
+  });
+
+  test('readOnly property propagates to all its elements', async function(assert) {
+    await render(
+      hbs`
+        {{#bs-form model=this readonly=true as |form|}}
+          {{form.element property="dummy"}}
+        {{/bs-form}}`
+    );
+
+    assert.dom('.form-group input').hasAttribute('readonly');
+  });
 });


### PR DESCRIPTION
This will make it easy to make all form elements disabled or readonly, by setting the property on the form itself.