### PR TITLE
Form validations are shown only after an eventual promise returned from onInvalid action resolves

### DIFF
--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -416,9 +416,6 @@ export default Component.extend({
             });
         },
         (error) => {
-          // model is invalid
-          this.set('showAllValidations', true);
-
           return RSVP.resolve()
             .then(() => {
               return this.get('onInvalid')(model, error);
@@ -428,8 +425,11 @@ export default Component.extend({
                 return;
               }
 
-              this.set('isRejected', true);
-              this.decrementProperty('pendingSubmissions');
+              this.setProperties({
+                showAllValidations: true,
+                isRejected: true,
+                pendingSubmissions: this.get('pendingSubmissions') - 1
+              });
 
               throw error;
             });


### PR DESCRIPTION
Closes #731

This only delays showing validations, but does not provide means to suppress them, as I think #364 overlaps with that particular feature and is probably better solved in that way!? @jelhan do you agree?