### PR TITLE
Fix yuidocs for angle bracket invocation starting with (at)

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -14,9 +14,9 @@ import overrideableCP from '../../utils/overrideable-cp';
   ### Basic Usage
 
   ```hbs
-   <BsButton @type="primary" @icon="glyphicon glyphicon-download">
-     Downloads
-   </BsButton>
+  <BsButton @type="primary" @icon="glyphicon glyphicon-download">
+    Downloads
+  </BsButton>
   ```
 
   ### Actions
@@ -25,9 +25,9 @@ import overrideableCP from '../../utils/overrideable-cp';
   (see the `value` property) as an argument.
 
   ```hbs
-   <BsButton @type="primary" @icon="glyphicon glyphicon-download" @onClick=(action "download")>
-     Downloads
-   </BsButton>
+  <BsButton @type="primary" @icon="glyphicon glyphicon-download" @onClick=(action "download")>
+    Downloads
+  </BsButton>
   ```
 
   ### Promise support for automatic state change
@@ -37,37 +37,37 @@ import overrideableCP from '../../utils/overrideable-cp';
   according to the state of the promise:
 
   ```hbs
-   <BsButton
-     @type="primary"
-     @icon="glyphicon glyphicon-download"
-     @defaultText="Download"
-     @pendingText="Loading..."
-     @fulfilledText="Completed!"
-     @rejectedText="Oups!?"
-     @onClick={{action "download"}}
-   />
+  <BsButton
+    (at)type="primary"
+    (at)icon="glyphicon glyphicon-download"
+    (at)defaultText="Download"
+    (at)pendingText="Loading..."
+    (at)fulfilledText="Completed!"
+    (at)rejectedText="Oups!?"
+    (at)onClick={{action "download"}}
+  />
   ```
 
   ```js
   // controller.js
-   export default Ember.Controller.extend({
-     actions: {
-       download(value) {
-         return new Ember.RSVP.Promise(...);
-       }
-     }
-   });
+  export default Ember.Controller.extend({
+    actions: {
+      download(value) {
+        return new Ember.RSVP.Promise(...);
+      }
+    }
+  });
   ```
 
   For further customization `isPending`, `isFulfilled`, `isRejected` and `isSettled` properties are yielded:
 
   ```hbs
-   <BsButton @onClick=(action "download") as |button|>
-     Download
-     {{#if button.isPending}}
-       <span class="loading-spinner"></span>
-     {{/if}}
-   </BsButton>
+  <BsButton @onClick=(action "download") as |button|>
+    Download
+    {{#if button.isPending}}
+      <span class="loading-spinner"></span>
+    {{/if}}
+  </BsButton>
   ```
 
   You can `reset` the state represented by these properties and used for button's text by setting `reset` property to

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -727,7 +727,7 @@ export default FormGroup.extend({
 
   /**
    * @method showValidationOnHandler
-   * @params {Event} event
+   * @param {Event} event
    * @private
    */
   showValidationOnHandler({ target, type }) {

--- a/docs/yuidoc-theme/helpers/index.js
+++ b/docs/yuidoc-theme/helpers/index.js
@@ -1,0 +1,7 @@
+function fixSamples(content) {
+  return content.replace(/\(at\)/g, '@');
+}
+
+module.exports = {
+  fixSamples
+};

--- a/docs/yuidoc-theme/layouts/main.handlebars
+++ b/docs/yuidoc-theme/layouts/main.handlebars
@@ -52,7 +52,7 @@
       <div class="apidocs">
         <div id="docs-main">
           <div class="content">
-            {{>layout_content}}
+{{>layout_content}}
           </div>
         </div>
       </div>

--- a/docs/yuidoc-theme/partials/classes.handlebars
+++ b/docs/yuidoc-theme/partials/classes.handlebars
@@ -2,7 +2,7 @@
   <h1 class="card-header">{{name}} <span class="badge badge-{{access}} small">{{access}}</span></h1>
   <div class="card-body">
 
-    {{{classDescription}}}
+{{{fixSamples classDescription}}}
 
   </div>
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-template-lint": "^1.0.0-beta.2",
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^2.1.0",
-    "ember-cli-yuidoc": "^0.8.7",
+    "ember-cli-yuidoc": "^0.8.8",
     "ember-code-snippet": "^2.3.1",
     "ember-compatibility-helpers": "^1.2.0",
     "ember-cp-validations": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4292,7 +4292,7 @@ ember-cli-version-checker@^3.0.0:
     resolve "^1.9.0"
     semver "^5.6.0"
 
-ember-cli-yuidoc@^0.8.7:
+ember-cli-yuidoc@^0.8.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/ember-cli-yuidoc/-/ember-cli-yuidoc-0.8.8.tgz#3858baaf85388a976024f9de40f1075fea58f606"
   integrity sha1-OFi6r4U4ipdgJPneQPEHX+pY9gY=

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -9,6 +9,7 @@
     ],
     "exclude": "vendor",
     "outdir": "docs/api",
-    "themedir": "docs/yuidoc-theme"
+    "themedir": "docs/yuidoc-theme",
+    "helpers": ["docs/yuidoc-theme/helpers/index.js"]
   }
 }


### PR DESCRIPTION
Yuidocs thinks this is a keyword and just breaks. We have to escape and unescape when rendering.
See https://github.com/yui/yuidoc/issues/347

Fixes also some other formatting issues.