### PR TITLE
Form's and Button's preventConcurrency defaults to true

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -251,10 +251,10 @@ export default Component.extend(TypeClass, SizeClass, {
    *
    * @property preventConcurrency
    * @type Boolean
-   * @default false
+   * @default true
    * @public
    */
-  preventConcurrency: false,
+  preventConcurrency: true,
 
   /**
    * State of the button. The button's label (if not used as a block component) will be set to the

--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -244,10 +244,10 @@ export default Component.extend({
    *
    * @property preventConcurrency
    * @type Boolean
-   * @default false
+   * @default true
    * @public
    */
-  preventConcurrency: false,
+  preventConcurrency: true,
 
   /**
    * If true, after successful validation and upon submitting the form, all current element validations will be hidden.

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -326,9 +326,6 @@ module('Integration | Component | bs-button', function(hooks) {
   });
 
   test('preventConcurrency=false allows onClick action to be fired concurrently', async function(assert) {
-    // assertions are done implicitly by awaiting the expected result
-    assert.expect(0);
-
     let deferredClickAction = defer();
     let clickActionExecutionCount = 0;
 
@@ -338,10 +335,11 @@ module('Integration | Component | bs-button', function(hooks) {
     });
     await render(hbs`{{bs-button onClick=clickAction preventConcurrency=false}}`);
 
-    click('button');
-    await waitUntil(() => clickActionExecutionCount === 1);
-    click('button');
-    await waitUntil(() => clickActionExecutionCount === 2);
+    await click('button');
+    assert.equal(clickActionExecutionCount, 1);
+
+    await click('button');
+    assert.equal(clickActionExecutionCount, 2);
 
     deferredClickAction.resolve();
   });

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -298,7 +298,7 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.ok(parentClick.called);
   });
 
-  test('preventConcurrency=true prevents onClick action to be fired concurrently', async function(assert) {
+  test('prevents onClick action to be fired concurrently', async function(assert) {
     let deferredClickAction = defer();
     let clickActionHasBeenExecuted = false;
     this.set('clickAction', () => {
@@ -306,7 +306,7 @@ module('Integration | Component | bs-button', function(hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`{{bs-button onClick=clickAction preventConcurrency=true}}`);
+    await render(hbs`{{bs-button onClick=clickAction}}`);
     click('button');
     await waitUntil(() => clickActionHasBeenExecuted);
 
@@ -323,5 +323,26 @@ module('Integration | Component | bs-button', function(hooks) {
     });
     await click('button');
     assert.verifySteps(['onClick action'], 'onClick action is fired again after pending click action is settled');
+  });
+
+  test('preventConcurrency=false allows onClick action to be fired concurrently', async function(assert) {
+    // assertions are done implicitly by awaiting the expected result
+    assert.expect(0);
+
+    let deferredClickAction = defer();
+    let clickActionExecutionCount = 0;
+
+    this.set('clickAction', () => {
+      clickActionExecutionCount++;
+      return deferredClickAction.promise;
+    });
+    await render(hbs`{{bs-button onClick=clickAction preventConcurrency=false}}`);
+
+    click('button');
+    await waitUntil(() => clickActionExecutionCount === 1);
+    click('button');
+    await waitUntil(() => clickActionExecutionCount === 2);
+
+    deferredClickAction.resolve();
   });
 });

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -809,10 +809,11 @@ module('Integration | Component | bs-form', function(hooks) {
       {{/bs-form}}
     `);
 
-    triggerEvent('form', 'submit');
-    await waitUntil(() => submitActionExecutionCounter === 1);
-    triggerEvent('form', 'submit');
-    await waitUntil(() => submitActionExecutionCounter === 2);
+    await triggerEvent('form', 'submit');
+    assert.equal(submitActionExecutionCounter, 1);
+
+    await triggerEvent('form', 'submit');
+    assert.equal(submitActionExecutionCounter, 2);
 
     assert.ok(beforeActionFake.calledTwice);
     assert.ok(validateFake.calledTwice);

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -615,7 +615,7 @@ module('Integration | Component | bs-form', function(hooks) {
       deferredSubmitActions.push(deferred);
       return deferred.promise;
     });
-    await this.render(hbs`{{#bs-form onSubmit=submitAction as |form|}}
+    await this.render(hbs`{{#bs-form onSubmit=submitAction preventConcurrency=false as |form|}}
       <div class='state {{if form.isSubmitting 'is-submitting'}}'></div>
     {{/bs-form}}`);
 
@@ -753,7 +753,7 @@ module('Integration | Component | bs-form', function(hooks) {
     assert.ok(submit.calledOnce, 'onSubmit action has been called');
   });
 
-  test('preventConcurrency=true prevents submission to be fired concurrently', async function(assert) {
+  test('prevents submission to be fired concurrently', async function(assert) {
     let deferredSubmitAction = defer();
     let submitActionHasBeenExecuted = false;
     this.set('submitAction', () => {
@@ -763,10 +763,7 @@ module('Integration | Component | bs-form', function(hooks) {
     this.set('beforeAction', () => {});
     this.set('validate', () => { return resolve(); });
     await render(hbs`
-      {{#bs-form
-        preventConcurrency=true
-        onSubmit=submitAction onBefore=beforeAction validate=validate hasValidator=true
-      }}{{/bs-form}}
+      {{#bs-form onSubmit=submitAction onBefore=beforeAction validate=validate hasValidator=true}}{{/bs-form}}
     `);
 
     triggerEvent('form', 'submit');
@@ -792,6 +789,35 @@ module('Integration | Component | bs-form', function(hooks) {
     this.set('validate', () => { return resolve(); });
     await triggerEvent('form', 'submit');
     assert.verifySteps(['onSubmit action'], 'onSubmit action is fired again after pending submission is settled');
+  });
+
+  test('preventConcurrency=false allows submission to be fired concurrently', async function(assert) {
+    let deferredSubmitAction = defer();
+    let submitActionExecutionCounter = 0;
+
+    let beforeActionFake = this.fake();
+    let validateFake = this.fake();
+
+    this.set('submitAction', () => {
+      submitActionExecutionCounter++;
+      return deferredSubmitAction.promise;
+    });
+    this.set('beforeAction', beforeActionFake);
+    this.set('validate', validateFake);
+    await render(hbs`
+      {{#bs-form preventConcurrency=false onSubmit=submitAction onBefore=beforeAction validate=validate hasValidator=true}}
+      {{/bs-form}}
+    `);
+
+    triggerEvent('form', 'submit');
+    await waitUntil(() => submitActionExecutionCounter === 1);
+    triggerEvent('form', 'submit');
+    await waitUntil(() => submitActionExecutionCounter === 2);
+
+    assert.ok(beforeActionFake.calledTwice);
+    assert.ok(validateFake.calledTwice);
+
+    deferredSubmitAction.resolve();
   });
 
   test('supports novalidate attribute', async function(assert) {


### PR DESCRIPTION
As discussed in #822. Does not touch `disabled` property of `<BsButton>` yet.

This is a breaking change.