### PR TITLE
Make FormElement a tagless component, not extending FormGroup anymore

### DIFF
--- a/addon/templates/components/common/bs-form/element.hbs
+++ b/addon/templates/components/common/bs-form/element.hbs
@@ -1,82 +1,91 @@
-{{#component this.layoutComponent
-  hasLabel=this.hasLabel
-  formElementId=this.formElementId
-  horizontalLabelGridClass=this.horizontalLabelGridClass
-  errorsComponent=(component this.errorsComponent
-    messages=this.validationMessages
-    show=this.showValidationMessages
-    showMultipleErrors=this.showMultipleErrors
-  )
-  feedbackIconComponent=(component this.feedbackIconComponent
-    iconName=@iconName
-    show=this.hasFeedback
-  )
-  labelComponent=(component this.labelComponent
-    label=@label
-    invisibleLabel=this.invisibleLabel
+<BsForm::Group
+  @validation={{this.validation}}
+  @focusOut={{action "handleEvent"}}
+  @change={{action "handleEvent"}}
+  @input={{action "handleEvent"}}
+  class="{{if @disabled "disabled"}} {{if @required "is-required"}} {{if this.isValidating "isValidating"}}"
+  id={{this.groupElementId}}
+>
+  {{#component this.layoutComponent
+    hasLabel=this.hasLabel
     formElementId=this.formElementId
-    controlType=this.controlType
-    formLayout=this.formLayout
-    size=@size
-  )
-  helpTextComponent=(if this.hasHelpText
-    (component this.helpTextComponent
-      text=@helpText
-      id=this.ariaDescribedBy
+    horizontalLabelGridClass=this.horizontalLabelGridClass
+    errorsComponent=(component this.errorsComponent
+      messages=this.validationMessages
+      show=this.showValidationMessages
+      showMultipleErrors=this.showMultipleErrors
     )
-  )
-}}
-  {{#let
-    (component this.controlComponent
-      value=this.value
-      id=this.formElementId
-      name=@name
-      type=this.controlType
+    feedbackIconComponent=(component this.feedbackIconComponent
+      iconName=@iconName
+      show=this.hasFeedback
+    )
+    labelComponent=(component this.labelComponent
       label=@label
-      placeholder=placeholder
-      autofocus=autofocus
-      disabled=disabled
-      readonly=readonly
-      required=required
-      controlSize=controlSize
-      tabindex=tabindex
-      minlength=minlength
-      maxlength=maxlength
-      min=min
-      max=max
-      pattern=pattern
-      accept=accept
-      autocomplete=autocomplete
-      autocapitalize=autocapitalize
-      autocorrect=autocorrect
-      autosave=autosave
-      inputmode=inputmode
-      multiple=multiple
-      step=step
-      form=form
-      spellcheck=spellcheck
-      cols=cols
-      rows=rows
-      wrap=wrap
-      title=title
-      options=options
-      optionLabelPath=optionLabelPath
-      ariaDescribedBy=(if hasHelpText ariaDescribedBy)
-      onChange=(action "change")
-      validationType=validation
-      size=size
-  ) as |Control|}}
-    {{#if hasBlock}}
-      {{yield
-        (hash
-          value=value
-          id=formElementId
-          validation=validation
-          control=Control
-        )
-      }}
-    {{else}}
-      <Control ...attributes />
-    {{/if}}
-  {{/let}}
-{{/component}}
+      invisibleLabel=this.invisibleLabel
+      formElementId=this.formElementId
+      controlType=this.controlType
+      formLayout=this.formLayout
+      size=@size
+    )
+    helpTextComponent=(if this.hasHelpText
+      (component this.helpTextComponent
+        text=@helpText
+        id=this.ariaDescribedBy
+      )
+    )
+  }}
+    {{#let
+      (component this.controlComponent
+        value=this.value
+        id=this.formElementId
+        name=@name
+        type=this.controlType
+        label=@label
+        placeholder=placeholder
+        autofocus=autofocus
+        disabled=disabled
+        readonly=readonly
+        required=required
+        controlSize=controlSize
+        tabindex=tabindex
+        minlength=minlength
+        maxlength=maxlength
+        min=min
+        max=max
+        pattern=pattern
+        accept=accept
+        autocomplete=autocomplete
+        autocapitalize=autocapitalize
+        autocorrect=autocorrect
+        autosave=autosave
+        inputmode=inputmode
+        multiple=multiple
+        step=step
+        form=form
+        spellcheck=spellcheck
+        cols=cols
+        rows=rows
+        wrap=wrap
+        title=title
+        options=options
+        optionLabelPath=optionLabelPath
+        ariaDescribedBy=(if hasHelpText ariaDescribedBy)
+        onChange=(action "change")
+        validationType=validation
+        size=size
+    ) as |Control|}}
+      {{#if hasBlock}}
+        {{yield
+          (hash
+            value=this.value
+            id=this.formElementId
+            validation=this.validation
+            control=Control
+          )
+        }}
+      {{else}}
+        <Control ...attributes />
+      {{/if}}
+    {{/let}}
+  {{/component}}
+</BsForm::Group>

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -465,7 +465,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
     assert.dom('#value').exists({ count: 1 }, 'block template is rendered');
     assert.dom('#value').hasText('male', 'value is yielded to block template');
     assert.dom('#id').hasText(
-      `${this.element.querySelector('.form-group').getAttribute('id')}-field`,
+      this.element.querySelector('#control > *').getAttribute('id'),
       'id is yielded to block template'
     );
     assert.dom('#validation').hasText('success');
@@ -792,6 +792,12 @@ module('Integration | Component | bs-form/element', function(hooks) {
         }
       }
     }
+  });
+
+  (gte('3.4.0') ? test : skip)('input attributes are applied only once w/ angle brackets', async function(assert) {
+    await render(hbs`<BsForm::element data-test-foo />`);
+
+    assert.dom('[data-test-foo').exists({ count: 1 });
   });
 
   test('required property propagates', async function(assert) {


### PR DESCRIPTION
Extending from FormGroup looks like a bad decision anyway, *using* it seems more appropriate. This also makes FormElement a tagless component, allowing to use `...attributes` without applying HTML attributes twice. Fixes #844