### PR TITLE
Added changelog entry for making modals tagless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * [#794](https://github.com/kaliber5/ember-bootstrap/pull/794) Add novalidate attribute to forms by default if they support client-side validations ([@simonihmig](https://github.com/simonihmig))
 * [#788](https://github.com/kaliber5/ember-bootstrap/pull/788) Drop node 6 support ([@simonihmig](https://github.com/simonihmig))
 * [#787](https://github.com/kaliber5/ember-bootstrap/pull/787) Dropped support for Ember < 2.18 ([@simonihmig](https://github.com/simonihmig))
+* [#795](https://github.com/kaliber5/ember-bootstrap/pull/795) Modals are tagless (wrapping div has been removed), which might break when setting an ID or `ember-test-selectors` attribute on curly component invocation.
+ Angle bracket component invocation syntax should be used for that use case. E.g. `{{#bs-modal data-test-foo}}` should be refactored to `<BsModal data-test-foo>`.
 
 #### Features
 * [#842](https://github.com/kaliber5/ember-bootstrap/pull/842) Button is disabled by default if in pending state ([@jelhan](https://github.com/jelhan))


### PR DESCRIPTION
Closes #846

@jelhan added this to address your issue. Do you agree, given that setting test selectors on the wrapping div was only in certain cases working kind of accidentally (https://github.com/kaliber5/ember-bootstrap/issues/846#issuecomment-508820072), that we should move forward with full angle bracket invocation support, and accept the change to make the modal tagless?