### PR TITLE
Render Modals, Tooltips and Popovers in a wormhole even in tests

### DIFF
--- a/addon/components/base/bs-contextual-help.js
+++ b/addon/components/base/bs-contextual-help.js
@@ -6,6 +6,7 @@ import EmberObject, { observer, computed } from '@ember/object';
 import { next, schedule, cancel, later, run } from '@ember/runloop';
 import TransitionSupport from 'ember-bootstrap/mixins/transition-support';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
+import { getDestinationElement } from '../../utils/dom';
 
 const InState = EmberObject.extend({
   hover: false,
@@ -182,6 +183,18 @@ let component = Component.extend(TransitionSupport, {
   arrowElement: null,
 
   /**
+   * The wormhole destinationElement
+   *
+   * @property destinationElement
+   * @type object
+   * @readonly
+   * @private
+   */
+  destinationElement: computed(function() {
+    return getDestinationElement(this)
+  }),
+
+  /**
    * The DOM element of the viewport element.
    *
    * @property viewportElement
@@ -265,7 +278,7 @@ let component = Component.extend(TransitionSupport, {
    * @private
    */
   _renderInPlace: computed('renderInPlace', function() {
-    return this.get('renderInPlace') || typeof document === 'undefined' || !document.getElementById('ember-bootstrap-wormhole');
+    return this.get('renderInPlace') || !this.destinationElement;
   }),
 
   /**

--- a/addon/components/base/bs-dropdown/menu.js
+++ b/addon/components/base/bs-dropdown/menu.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu';
 import { next } from '@ember/runloop';
+import { getDestinationElement } from '../../../utils/dom';
 
 /**
  Component for the dropdown menu.
@@ -69,9 +70,20 @@ export default Component.extend({
   _renderInPlace: computed('renderInPlace', function() {
     return (
       this.get('renderInPlace') ||
-      typeof document === 'undefined' ||
-      !document.getElementById('ember-bootstrap-wormhole')
+      !this.destinationElement
     );
+  }),
+
+  /**
+   * The wormhole destinationElement
+   *
+   * @property destinationElement
+   * @type object
+   * @readonly
+   * @private
+   */
+  destinationElement: computed(function() {
+    return getDestinationElement(this)
   }),
 
   alignClass: computed('align', function() {

--- a/addon/components/base/bs-modal.js
+++ b/addon/components/base/bs-modal.js
@@ -8,7 +8,7 @@ import layout from 'ember-bootstrap/templates/components/bs-modal';
 import TransitionSupport from 'ember-bootstrap/mixins/transition-support';
 import listenTo from 'ember-bootstrap/utils/listen-to-cp';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
-import { findElementById, getDOM } from '../../utils/dom';
+import { getDestinationElement } from '../../utils/dom';
 import { guidFor } from '@ember/object/internals';
 
 /**
@@ -684,14 +684,12 @@ let component = Component.extend(TransitionSupport, {
     if (fade === undefined) {
       fade = !isFastBoot;
     }
-    let dom = getDOM(this);
-    let destinationElement = findElementById(dom, 'ember-bootstrap-wormhole');
     this.setProperties({
       showModal: isOpen && (!fade || isFastBoot),
       showBackdrop: isOpen && backdrop,
       inDom: isOpen,
       fade,
-      destinationElement
+      destinationElement: getDestinationElement(this)
     });
   }
 });

--- a/addon/templates/components/bs3/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs3/bs-dropdown/menu.hbs
@@ -4,7 +4,7 @@
     @placement={{this.popperPlacement}}
     @popperTarget={{this.toggleElement}}
     @renderInPlace={{this._renderInPlace}}
-    @popperContainer="#ember-bootstrap-wormhole"
+    @popperContainer={{this.destinationElement}}
     @modifiers={{this.popperModifiers}}
   >
     <ul

--- a/addon/templates/components/bs4/bs-dropdown/menu.hbs
+++ b/addon/templates/components/bs4/bs-dropdown/menu.hbs
@@ -5,7 +5,7 @@
     @placement={{this.popperPlacement}}
     @popperTarget={{this.toggleElement}}
     @renderInPlace={{this._renderInPlace}}
-    @popperContainer="#ember-bootstrap-wormhole"
+    @popperContainer={{this.destinationElement}}
     @modifiers={{this.popperModifiers}}
     ...attributes
   >

--- a/addon/templates/components/common/bs-popover.hbs
+++ b/addon/templates/components/common/bs-popover.hbs
@@ -9,6 +9,7 @@
       @title={{@title}}
       @renderInPlace={{this._renderInPlace}}
       @popperTarget={{this.triggerTargetElement}}
+      @destinationElement={{this.destinationElement}}
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}
       @viewportPadding={{this.viewportPadding}}

--- a/addon/templates/components/common/bs-popover/element.hbs
+++ b/addon/templates/components/common/bs-popover/element.hbs
@@ -4,7 +4,7 @@
   @renderInPlace={{this.renderInPlace}}
   @popperTarget={{this.popperTarget}}
   @modifiers={{this.popperModifiers}}
-  @popperContainer="#ember-bootstrap-wormhole"
+  @popperContainer={{@destinationElement}}
   @onCreate={{action "updatePlacement"}}
   @onUpdate={{action "updatePlacement"}}
   @id={{@id}}

--- a/addon/templates/components/common/bs-tooltip.hbs
+++ b/addon/templates/components/common/bs-tooltip.hbs
@@ -7,6 +7,7 @@
       @fade={{this.fade}}
       @showHelp={{this.showHelp}}
       @renderInPlace={{this._renderInPlace}}
+      @destinationElement={{this.destinationElement}}
       @popperTarget={{this.triggerTargetElement}}
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}

--- a/addon/templates/components/common/bs-tooltip/element.hbs
+++ b/addon/templates/components/common/bs-tooltip/element.hbs
@@ -4,7 +4,7 @@
   @renderInPlace={{this.renderInPlace}}
   @popperTarget={{this.popperTarget}}
   @modifiers={{this.popperModifiers}}
-  @popperContainer="#ember-bootstrap-wormhole"
+  @popperContainer={{@destinationElement}}
   @onCreate={{action "updatePlacement"}}
   @onUpdate={{action "updatePlacement"}}
   @id={{@id}}

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -8,6 +8,7 @@
 import { getOwner } from '@ember/application';
 import { DEBUG } from '@glimmer/env';
 import requirejs from 'require';
+import { warn } from '@ember/debug';
 
 function childNodesOfElement(element) {
   let children = [];
@@ -79,6 +80,12 @@ export function getDestinationElement(context) {
       }
       return document.getElementById(id)
     }
+
+    warn(
+      `No wormhole destination element found for component ${context}. If you have set \`insertEmberWormholeElementToDom\` to false, you should insert a \`div#ember-bootstrap-wormhole\` manually!`,
+      false,
+      { id: 'ember-bootstrap.no-destination-element' }
+    );
   }
 
   return destinationElement;

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,4 @@
 {
-  "jquery-integration": false
+  "jquery-integration": false,
+  "application-template-wrapper": false
 }

--- a/tests/integration/components/bs-modal-simple-test.js
+++ b/tests/integration/components/bs-modal-simple-test.js
@@ -415,7 +415,7 @@ module('Integration | Component | bs-modal-simple', function(hooks) {
     assert.notOk(hideSpy.called);
   });
 
-  test('Renders in wormhole if renderInPlace is not set', async function(assert) {
+  test('Renders in wormhole\'s default destination if renderInPlace is not set', async function(assert) {
     this.set('show', false);
     await render(
       hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}{{#bs-modal-simple title="Simple Dialog"}}Hello world!{{/bs-modal-simple}}{{/if}}`
@@ -427,15 +427,26 @@ module('Integration | Component | bs-modal-simple', function(hooks) {
     assert.dom('#ember-bootstrap-wormhole .modal').exists({ count: 1 }, 'Modal exists in wormhole');
   });
 
+  test('Renders in test container if renderInPlace is not set', async function(assert) {
+    this.set('show', false);
+    await render(
+      hbs`<div id="wrapper">{{#if show}}{{#bs-modal-simple title="Simple Dialog"}}Hello world!{{/bs-modal-simple}}{{/if}}</div>`
+    );
+    this.set('show', true);
+    await settled();
+
+    assert.dom('.modal').exists({ count: 1 }, 'Modal exists.');
+    assert.dom('#wrapper .modal').doesNotExist();
+  });
+
   test('Renders in place (no wormhole) if renderInPlace is set', async function(assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}{{#bs-modal-simple title="Simple Dialog" renderInPlace=true}}Hello world!{{/bs-modal-simple}}{{/if}}`
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}{{#bs-modal-simple title="Simple Dialog" renderInPlace=true}}Hello world!{{/bs-modal-simple}}{{/if}}</div>`
     );
     this.set('show', true);
 
-    assert.dom('.modal').exists({ count: 1 }, 'Modal exists.');
-    assert.dom('#ember-bootstrap-wormhole .modal').doesNotExist('Modal exists outside wormhole');
+    assert.dom('#wrapper .modal').exists({ count: 1 }, 'Modal exists in place');
   });
 
   test('Removes "modal-open" class when component is removed from view', async function(assert) {

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -1,6 +1,6 @@
 import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerEvent } from '@ember/test-helpers';
+import { render, click, triggerEvent, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { test, versionDependent, visibilityClass, popoverPositionClass } from '../../helpers/bootstrap-test';
 import {
@@ -191,5 +191,39 @@ module('Integration | Component | bs-popover', function(hooks) {
     assert.dom('.popover').hasClass('wide');
     assert.dom('.popover').hasAttribute('role', 'foo');
     assert.dom('.popover').hasAttribute('data-test');
+  });
+
+  test('Renders in wormhole\'s default destination if renderInPlace is not set', async function(assert) {
+    this.set('show', false);
+    await render(
+      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}{{bs-popover title="Simple popover" visible=true fade=false}}{{/if}}`
+    );
+    this.set('show', true);
+    await settled();
+
+    assert.dom('#ember-bootstrap-wormhole .popover').exists({ count: 1 }, 'Popover exists in wormhole');
+  });
+
+  test('Renders in test container if renderInPlace is not set', async function(assert) {
+    this.set('show', false);
+    await render(
+      hbs`{{#if show}}{{bs-popover title="Simple popover" visible=true fade=false}}{{/if}}`
+    );
+    this.set('show', true);
+    await settled();
+
+    assert.dom('.popover').exists({ count: 1 }, 'Popover exists.');
+    assert.dom('#wrapper .popover').doesNotExist();
+  });
+
+  test('Renders in place (no wormhole) if renderInPlace is set', async function(assert) {
+    this.set('show', false);
+    await render(
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}{{bs-popover title="Simple popover" visible=true fade=false renderInPlace=true}}{{/if}}</div>`
+    );
+    this.set('show', true);
+    await settled();
+
+    assert.dom('#wrapper .popover').exists({ count: 1 }, 'Popover exists in place.');
   });
 });

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -217,7 +217,7 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     assert.dom('.tooltip').exists({ count: 1 }, 'tooltip is visible');
   });
 
-  test('Renders in wormhole if renderInPlace is not set', async function(assert) {
+  test('Renders in wormhole\'s default destination if renderInPlace is not set', async function(assert) {
     this.set('show', false);
     await render(
       hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}{{bs-tooltip title="Simple Tooltip" visible=true fade=false}}{{/if}}`
@@ -225,20 +225,30 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     this.set('show', true);
     await settled();
 
-    assert.dom('.tooltip').exists({ count: 1 }, 'Tooltip exists.');
-    assert.equal(this.element.querySelector('.tooltip').parentNode.getAttribute('id'), 'ember-bootstrap-wormhole');
+    assert.dom('#ember-bootstrap-wormhole .tooltip').exists({ count: 1 }, 'Tooltip exists in wormhole');
   });
 
-  test('Renders in place (no wormhole) if renderInPlace is set', async function(assert) {
+  test('Renders in test container if renderInPlace is not set', async function(assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}{{bs-tooltip title="Simple Tooltip" visible=true fade=false renderInPlace=true}}{{/if}}`
+      hbs`{{#if show}}{{bs-tooltip title="Simple Tooltip" visible=true fade=false}}{{/if}}`
     );
     this.set('show', true);
     await settled();
 
     assert.dom('.tooltip').exists({ count: 1 }, 'Tooltip exists.');
-    assert.notEqual(this.element.querySelector('.tooltip').parentNode.getAttribute('id'), 'ember-bootstrap-wormhole');
+    assert.dom('#wrapper .tooltip').doesNotExist();
+  });
+
+  test('Renders in place (no wormhole) if renderInPlace is set', async function(assert) {
+    this.set('show', false);
+    await render(
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}{{bs-tooltip title="Simple Tooltip" visible=true fade=false renderInPlace=true}}{{/if}}</div>`
+    );
+    this.set('show', true);
+    await settled();
+
+    assert.dom('#wrapper .tooltip').exists({ count: 1 }, 'Tooltip exists in place.');
   });
 
   test('should place tooltip on top of element', async function(assert) {


### PR DESCRIPTION
Previously those components would fallback to `renderInPlace=true` if the wormhole destination is not found, which was the case in tests. Now they will render wormholed to the test container element, so they work just as they would in the real app. This might break some tests, if they make assumptions about the place in DOM of those components in tests.