### PR TITLE
Warn if configured to import Glyphicon but Boostrap 4 is used

### DIFF
--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -190,12 +190,8 @@ module.exports = {
       bootstrapVersion
     };
 
-    if (bootstrapVersion === 4) {
-      settings.importBootstrapFont = false;
-    } else if (config.hasOwnProperty('importBootstrapFont')) {
-      settings.importBootstrapFont = config.importBootstrapFont;
-    } else {
-      settings.importBootstrapFont = true;
+    if (bootstrapVersion === 3) {
+      settings.importBootstrapFont = config.hasOwnProperty('importBootstrapFont') ? config.importBootstrapFont : true;
     }
 
     if (preprocessor !== 'none') {

--- a/index.js
+++ b/index.js
@@ -61,6 +61,12 @@ module.exports = {
     this.app = app;
 
     let options = Object.assign({}, defaultOptions, app.options['ember-bootstrap']);
+    if (options.bootstrapVersion === 4 && app.options['ember-bootstrap'].importBootstrapFont) {
+      this.warn(
+        'Inclusion of the Glyphicon font is only supported for Bootstrap 3. ' +
+        'Set Ember Bootstrap\'s `importBootstrapFont` option to `false` to hide this warning.'
+      );
+    }
     if (process.env.BOOTSTRAPVERSION) {
       // override bootstrapVersion config when environment variable is set
       options.bootstrapVersion = parseInt(process.env.BOOTSTRAPVERSION);


### PR DESCRIPTION
Adds a warning if Bootstrap 4 is used and `importBootstrapFont` is `true`. Also removes `importBootstrapFont` from configuration injected by default blueprint if Bootstrap 4 is used. This should help to reduce confusion about that config option. It's related to #858.