### PR TITLE
Change nav.item link support to match Ember's `<LinkTo>`

### DIFF
--- a/addon/components/base/bs-nav.js
+++ b/addon/components/base/bs-nav.js
@@ -16,10 +16,10 @@ import layout from 'ember-bootstrap/templates/components/bs-nav';
 
   ```hbs
   <BsNav @type="pills" as |nav|>
-    <nav.item @linkTo="foo">
+    <nav.item @route="foo">
       Foo
     </nav.item>
-    <nav.item @linkTo=(array "bar" model)>
+    <nav.item @route="bar" @model={{this.model}}>
       Bar
     </nav.item>
   </BsNav>
@@ -33,9 +33,9 @@ import layout from 'ember-bootstrap/templates/components/bs-nav';
   ### Active items
 
   Bootstrap expects to have the `active` class on the `<li>` element that should be the active (highlighted)
-  navigation item. To achieve that just use the `link-to` helper as usual. If the link is active, i.e
-  it points to the current route, the `bs-nav-item` component will detect that and apply the `active` class
-  automatically. The same applies for the `disabled` state.
+  navigation item. To achieve that use the `@route` and optionally `@model` (or `@models`) and `@query` properties
+  of the yielded `nav.item` component just as you would for Ember's `<LinkTo>` component to create a link with proper
+  `active` class support.
 
   ### Dropdowns
 
@@ -44,7 +44,7 @@ import layout from 'ember-bootstrap/templates/components/bs-nav';
 
   ```hbs
   <BsNav @type="pills" as |nav|>
-    <nav.item @linkTo="index">Home</nav.item>
+    <nav.item @route="index">Home</nav.item>
     <nav.dropdown as |dd|>
       <dd.toggle>Dropdown <span class="caret"></span></dd.toggle>
       <dd.menu as |ddm|>
@@ -57,12 +57,9 @@ import layout from 'ember-bootstrap/templates/components/bs-nav';
 
   ### Bootstrap 3/4 Notes
 
-  Use [`nav.item#linkTo`](Components.NavItem.html) for in-app links to ensure proper styling regardless of
+  Use [`nav.item#route`](Components.NavItem.html) for in-app links to ensure proper styling regardless of
   Bootstrap version. Explicit use of `<a>` tags in Bootstrap 4 must apply the `nav-link` class and manage
   the `active` state explicitly.
-
-  You can override `tagName` if you want to use Bootstrap 4's ability to represent more structural
-  components with `div` tags.
 
   The `fill` styling is only available with Bootstrap 4
 

--- a/addon/components/base/bs-nav/item.js
+++ b/addon/components/base/bs-nav/item.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { observer, computed } from '@ember/object';
+import { observer } from '@ember/object';
 import { filter, filterBy, gt } from '@ember/object/computed';
 import { scheduleOnce } from '@ember/runloop';
 import LinkComponent from '@ember/routing/link-component';
@@ -7,7 +7,7 @@ import layout from 'ember-bootstrap/templates/components/bs-nav/item';
 import ComponentParent from 'ember-bootstrap/mixins/component-parent';
 import overrideableCP from '../../../utils/overrideable-cp';
 import { inject as service } from '@ember/service';
-import { isArray } from '@ember/array';
+import { assert } from '@ember/debug';
 
 /**
 
@@ -26,19 +26,40 @@ export default Component.extend(ComponentParent, {
   router: service(),
 
   /**
-   * If set will wrap the item's content in a link. Accepts either a string with the route name, or an array
-   * with the route name and one or multiple models / query params, similar to the positional params of `{{link-to ...}}`
+   * If set will wrap the item's content in a link to the given route name. Same as the `route` property of `<LinkTo>`,
+   * see https://api.emberjs.com/ember/3.10/classes/LinkComponent/properties/route?anchor=route
    *
-   * @property linkTo
-   * @type {string|array}
+   * @property route
+   * @type {string}
    * @public
    */
-  linkTo: undefined,
 
-  linkToParams: computed('linkTo', function() {
-    let params = this.get('linkTo');
-    return params ? (isArray(params) ? params : [params]) : undefined;
-  }),
+  /**
+   * The model of a dynamic route. Same as the `model` property of `<LinkTo>`,
+   * see https://api.emberjs.com/ember/3.10/classes/LinkComponent/properties/route?anchor=model
+   *
+   * @property model
+   * @type {object|string}
+   * @public
+   */
+
+  /**
+   * The models of a dynamic route. Same as the `models` property of `<LinkTo>`,
+   * see https://api.emberjs.com/ember/3.10/classes/LinkComponent/properties/route?anchor=models
+   *
+   * @property models
+   * @type {array}
+   * @public
+   */
+
+  /**
+   * The query params of a dynamic route. Same as the `query` property of `<LinkTo>`,
+   * see https://api.emberjs.com/ember/3.10/classes/LinkComponent/properties/route?anchor=query
+   *
+   * @property query
+   * @type {object}
+   * @public
+   */
 
   /**
    * Render the nav item as disabled (see [Bootstrap docs](http://getbootstrap.com/components/#nav-disabled-links)).
@@ -64,10 +85,27 @@ export default Component.extend(ComponentParent, {
    * @type boolean
    * @public
    */
-  active: overrideableCP('_active', 'linkToParams.[]', 'router.currentURL', function() {
-    let params = this.get('linkToParams');
+  active: overrideableCP('_active', 'route', 'model', 'models', 'query', 'router.currentURL', function() {
+    let { route, model, models, query } = this.getProperties('route', 'model', 'models', 'query');
+    let params = [];
 
-    return params ? this.get('router').isActive(...params) : this.get('_active');
+    if (route) {
+      params.push(route);
+    }
+
+    if (model) {
+      params.push(model);
+    }
+
+    if (models) {
+      params.push(...models);
+    }
+
+    if (query) {
+      params.push({ queryParams: true, ...query});
+    }
+
+    return params.length ? this.get('router').isActive(...params) : this.get('_active');
   }),
   _active: false,
 
@@ -101,6 +139,9 @@ export default Component.extend(ComponentParent, {
 
   init() {
     this._super(...arguments);
+    let { model, models } = this.getProperties('model', 'models');
+    assert('You cannot pass both `@model` and `@models` to a nav item component!', !model || !models);
+
     this.get('activeChildLinks');
     this.get('disabledChildLinks');
   },

--- a/addon/components/base/bs-nav/item.js
+++ b/addon/components/base/bs-nav/item.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { observer } from '@ember/object';
-import { filter, filterBy, gt } from '@ember/object/computed';
+import { filter, filterBy, gt, or } from '@ember/object/computed';
 import { scheduleOnce } from '@ember/runloop';
 import LinkComponent from '@ember/routing/link-component';
 import layout from 'ember-bootstrap/templates/components/bs-nav/item';
@@ -124,6 +124,8 @@ export default Component.extend(ComponentParent, {
 
   disabledChildLinks: filterBy('childLinks', 'disabled'),
   hasDisabledChildLinks: gt('disabledChildLinks.length', 0),
+
+  hasLink: or('route', 'model', 'models', 'query'),
 
   /**
    * Called when clicking the nav item

--- a/addon/templates/components/common/bs-nav/item.hbs
+++ b/addon/templates/components/common/bs-nav/item.hbs
@@ -1,4 +1,4 @@
-{{#if @route}}
+{{#if this.hasLink}}
   {{#if @model}}
     <LinkTo @route={{@route}} @model={{@model}} @query={{@query}} @disabled={{this.disabled}} class={{this.linkClass}}>
       {{yield}}

--- a/addon/templates/components/common/bs-nav/item.hbs
+++ b/addon/templates/components/common/bs-nav/item.hbs
@@ -1,5 +1,17 @@
-{{#if this.linkTo}}
-  {{#link-to params=linkToParams class=this.linkClass disabled=this.disabled}}{{yield}}{{/link-to}}
+{{#if @route}}
+  {{#if @model}}
+    <LinkTo @route={{@route}} @model={{@model}} @query={{@query}} @disabled={{this.disabled}} class={{this.linkClass}}>
+      {{yield}}
+    </LinkTo>
+  {{else if @models}}
+    <LinkTo @route={{@route}} @models={{@models}} @query={{@query}} @disabled={{this.disabled}} class={{this.linkClass}}>
+      {{yield}}
+    </LinkTo>
+  {{else}}
+    <LinkTo @route={{@route}} @query={{@query}} @disabled={{this.disabled}} class={{this.linkClass}}>
+      {{yield}}
+    </LinkTo>
+  {{/if}}
 {{else}}
   {{yield}}
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "broccoli-merge-trees": "^3.0.1",
     "broccoli-stew": "^2.0.0",
     "chalk": "^2.1.0",
-    "ember-angle-bracket-invocation-polyfill": "^1.3.1",
+    "ember-angle-bracket-invocation-polyfill": "^2.0.1",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-build-config-editor": "0.5.0",
     "ember-cli-htmlbars": "^3.0.1",

--- a/tests/acceptance/bs-nav-link-test.js
+++ b/tests/acceptance/bs-nav-link-test.js
@@ -16,7 +16,7 @@ module('Acceptance | bs-nav-link', function(hooks) {
     assert.dom(this.element.querySelectorAll('#nav-link-test li')[2]).hasClass('active');
   });
 
-  test('active linkTo property marks nav item as active', async function(assert) {
+  test('active @route property marks nav item as active', async function(assert) {
     await visit('/acceptance/link/1');
     assert.dom(this.element.querySelectorAll('#nav-link-test2 li')[0]).hasClass('active');
     assert.dom(this.element.querySelectorAll('#nav-link-test2 li')[1]).hasNoClass('active');

--- a/tests/dummy/app/templates/acceptance/link.hbs
+++ b/tests/dummy/app/templates/acceptance/link.hbs
@@ -1,11 +1,29 @@
-{{#bs-nav id="nav-link-test" as |nav|}}
-  {{#nav.item}}{{#nav.link-to "acceptance.link" "1"}}first{{/nav.link-to}}{{/nav.item}}
-  {{#nav.item}}{{#nav.link-to "acceptance.link" "2"}}second{{/nav.link-to}}{{/nav.item}}
-  {{#nav.item}}{{#nav.link-to "acceptance.link" model}}current{{/nav.link-to}}{{/nav.item}}
-{{/bs-nav}}
+<BsNav @id="nav-link-test" as |nav|>
+  <nav.item>
+    {{#nav.link-to "acceptance.link" "1"}}
+      first
+    {{/nav.link-to}}
+  </nav.item>
+  <nav.item>
+    {{#nav.link-to "acceptance.link" "2"}}
+      second
+    {{/nav.link-to}}
+  </nav.item>
+  <nav.item>
+    {{#nav.link-to "acceptance.link" model}}
+      current
+    {{/nav.link-to}}
+  </nav.item>
+</BsNav>
 
-{{#bs-nav id="nav-link-test2" as |nav|}}
-  {{#nav.item linkTo=(array "acceptance.link" "1")}}first{{/nav.item}}
-  {{#nav.item linkTo=(array "acceptance.link" "2")}}second{{/nav.item}}
-  {{#nav.item linkTo=(array "acceptance.link" model)}}current{{/nav.item}}
-{{/bs-nav}}
+<BsNav @id="nav-link-test2" as |nav|>
+  <nav.item @route="acceptance.link" @model="1">
+    first
+  </nav.item>
+  <nav.item @route="acceptance.link" @model="2">
+    second
+  </nav.item>
+  <nav.item @route="acceptance.link" @model={{this.model}}>
+    current
+  </nav.item>
+</BsNav>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,32 +1,71 @@
-{{#bs-navbar fluid=false type="dark" backgroundColor="primary" as |navbar|}}
-  {{#link-to "index" class="navbar-brand"}}ember-bootstrap{{/link-to}}
+<BsNavbar @fluid={{false}} @type="dark" @backgroundColor="primary" as |navbar|>
+  <LinkTo @route="index" class="navbar-brand">
+    ember-bootstrap
+  </LinkTo>
   {{navbar.toggle}}
-  {{#navbar.content}}
-    {{#navbar.nav class="mr-auto" as |nav|}}
-      {{#nav.item linkTo="getting-started"}}Getting Started{{/nav.item}}
-      {{#nav.item linkTo="demo"}}Components{{/nav.item}}
-      {{#nav.item}}<a href="/api" class="nav-link">API</a>{{/nav.item}}
-      {{#nav.item linkTo="addons"}}Addons{{/nav.item}}
-    {{/navbar.nav}}
-    {{#navbar.nav as |nav|}}
-      {{#nav.item}}
-        <a href="https://discord.gg/zT3asNS" class="nav-link" target="_blank" rel="noopener"><i class="fab fa-discord"></i> e-bootstrap</a>
-      {{/nav.item}}
-      {{#nav.item}}
-        <a href="https://twitter.com/simonihmig" class="nav-link" target="_blank" rel="noopener"><i class="fab fa-twitter"></i></a>
-      {{/nav.item}}
-      {{#nav.item class="visible-sm-block visible-xs-block"}}
-        <a href="https://github.com/kaliber5/ember-bootstrap" class="nav-link" target="_blank" rel="noopener"><i class="fab fa-github"></i></a>
-      {{/nav.item}}
-      {{#nav.item class="hidden-sm hidden-xs"}}
+  <navbar.content>
+    <navbar.nav class="mr-auto" as |nav|>
+      <nav.item @route="getting-started">
+        Getting Started
+      </nav.item>
+      <nav.item @route="demo">
+        Components
+      </nav.item>
+      <nav.item>
+        <a href="/api" class="nav-link">
+          API
+        </a>
+      </nav.item>
+      <nav.item @route="addons">
+        Addons
+      </nav.item>
+    </navbar.nav>
+    <navbar.nav as |nav|>
+      <nav.item>
+        <a
+          href="https://discord.gg/zT3asNS"
+          class="nav-link"
+          target="_blank"
+          rel="noopener"
+        >
+          <i class="fab fa-discord"></i>
+          e-bootstrap
+        </a>
+      </nav.item>
+      <nav.item>
+        <a
+          href="https://twitter.com/simonihmig"
+          class="nav-link"
+          target="_blank"
+          rel="noopener"
+        >
+          <i class="fab fa-twitter"></i>
+        </a>
+      </nav.item>
+      <nav.item class="visible-sm-block visible-xs-block">
+        <a
+          href="https://github.com/kaliber5/ember-bootstrap"
+          class="nav-link"
+          target="_blank"
+          rel="noopener"
+        >
+          <i class="fab fa-github"></i>
+        </a>
+      </nav.item>
+      <nav.item class="hidden-sm hidden-xs">
         <div class="navbar-text">
-          <iframe src="https://ghbtns.com/github-btn.html?user=kaliber5&repo=ember-bootstrap&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=kaliber5&repo=ember-bootstrap&type=star&count=true"
+            frameborder="0"
+            scrolling="0"
+            width="100px"
+            height="20px"
+          ></iframe>
         </div>
-      {{/nav.item}}
-    {{/navbar.nav}}
-  {{/navbar.content}}
-{{/bs-navbar}}
-
+      </nav.item>
+    </navbar.nav>
+  </navbar.content>
+</BsNavbar>
 <div class="container">
   {{outlet}}
 </div>

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -1,33 +1,32 @@
 <div class="row">
   <div class="col-sm-4 col-md-3 order-last">
-
-    <h3 class="sr-only">Components</h3>
-
-    {{#bs-nav type="pills" stacked=true as |nav|}}
-      {{#each model as |comp|}}
-        {{#nav.item linkTo=comp.demoRoute}}{{comp.title}}{{/nav.item}}
+    <h3 class="sr-only">
+      Components
+    </h3>
+    <BsNav @type="pills" @stacked={{true}} as |nav|>
+      {{#each this.model as |comp|}}
+        <nav.item @route={{comp.demoRoute}}>
+          {{comp.title}}
+        </nav.item>
       {{/each}}
-    {{/bs-nav}}
+    </BsNav>
   </div>
   <div class="col-sm-8 col-sm-pull-4 col-md-9 col-md-pull-3">
-
-    {{#if isDetailPage}}
-      <h1>{{currentComponent.title}}</h1>
-
+    {{#if this.isDetailPage}}
+      <h1>
+        {{currentComponent.title}}
+      </h1>
       <div class="row">
         <div class="col-md-8">
-
-          <p class="lead">{{currentComponent.description}}</p>
+          <p class="lead">
+            {{currentComponent.description}}
+          </p>
         </div>
-
         <div class="col-md-4">
-          {{api-reference model=currentComponent}}
+          <ApiReference @model={{this.currentComponent}} />
         </div>
-
       </div>
-
     {{/if}}
-
     {{outlet}}
   </div>
 </div>

--- a/tests/dummy/app/templates/demo/navbars.hbs
+++ b/tests/dummy/app/templates/demo/navbars.hbs
@@ -38,8 +38,8 @@
     </div>
     <navbar.content>
       <navbar.nav as |nav|>
-        <nav.item @linkTo="index">Home</nav.item>
-        <nav.item @linkTo="demo.navbars">Navbars</nav.item>
+        <nav.item @route="index">Home</nav.item>
+        <nav.item @route="demo.navbars">Navbars</nav.item>
         <nav.dropdown as |dd|>
           <dd.toggle>Dropdown <span class="caret"></span></dd.toggle>
           <dd.menu as |ddm|>

--- a/tests/dummy/app/templates/demo/navs.hbs
+++ b/tests/dummy/app/templates/demo/navs.hbs
@@ -38,8 +38,8 @@
     @stacked={{stacked}}
     @fill={{fill}} as |nav|
   >
-    <nav.item @linkTo="index">Home</nav.item>
-    <nav.item @linkTo="demo.navs">Nav</nav.item>
+    <nav.item @route="index">Home</nav.item>
+    <nav.item @route="demo.navs">Nav</nav.item>
     <nav.dropdown as |dd|>
       <dd.toggle>
         Dropdown

--- a/tests/dummy/app/templates/demo/tabs.hbs
+++ b/tests/dummy/app/templates/demo/tabs.hbs
@@ -87,8 +87,8 @@
   <!-- BEGIN-SNIPPET tab-route-->
   <div>
     <BsNav @type="tabs" as |nav|>
-      <nav.item @linkTo="demo.tabs.index">Tab 1</nav.item>
-      <nav.item @linkTo="demo.tabs.other">Tab 2</nav.item>
+      <nav.item @route="demo.tabs.index">Tab 1</nav.item>
+      <nav.item @route="demo.tabs.other">Tab 2</nav.item>
     </BsNav>
     {{outlet}}
   </div>

--- a/tests/integration/components/bs-nav/item-test.js
+++ b/tests/integration/components/bs-nav/item-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import test from 'ember-sinon-qunit/test-support/test';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
@@ -13,7 +13,7 @@ module('Integration | Component | bs-nav/item', function(hooks) {
   hooks.beforeEach(function() {
     this.actions = {};
     this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
-    this.owner.lookup('router:main').setupRouter();
+    this.owner.setupRouter();
   });
 
   test('it has correct markup', async function(assert) {
@@ -50,32 +50,6 @@ module('Integration | Component | bs-nav/item', function(hooks) {
     assert.dom('li').hasClass('active', 'has active class');
   });
 
-  test('simple linkTo property adds link', async function(assert) {
-    await render(hbs`{{bs-nav/item linkTo="index"}}`);
-
-    assert.dom('li a').exists({ count: 1 });
-    assert.dom('li a').hasAttribute('href', '/');
-  });
-
-  test('complex linkTo property adds link', async function(assert) {
-    await render(hbs`{{bs-nav/item linkTo=(array "acceptance.link" "1" (query-params foo="bar"))}}`);
-
-    assert.dom('li a').exists({ count: 1 });
-    assert.dom('li a').hasAttribute('href', '/acceptance/link/1?foo=bar');
-  });
-
-  testBS4('link has nav-link class', async function(assert) {
-    await render(hbs`{{bs-nav/item linkTo="index"}}`);
-
-    assert.dom('li a').hasClass('nav-link');
-  });
-
-  test('disabled and linkTo property adds disabled link', async function(assert) {
-    await render(hbs`{{bs-nav/item linkTo="index" disabled=true}}`);
-
-    assert.dom('li a').hasClass('disabled');
-  });
-
   test('[DEPRECATED] active link-to makes nav item active', async function(assert) {
 
     await render(hbs`
@@ -105,5 +79,40 @@ module('Integration | Component | bs-nav/item', function(hooks) {
     await click('li');
 
     assert.ok(action.calledOnce, 'action has been called');
+  });
+
+  module('link', function() {
+    test('simple route link', async function(assert) {
+      await render(hbs`<BsNav::item @route="index" />`);
+
+      assert.dom('li a').exists({ count: 1 });
+      assert.dom('li a').hasAttribute('href', '/');
+    });
+
+    test('link with model', async function(assert) {
+      await render(hbs`<BsNav::item @route="acceptance.link" @model="1" @query={{hash foo="bar"}} />`);
+
+      assert.dom('li a').exists({ count: 1 });
+      assert.dom('li a').hasAttribute('href', '/acceptance/link/1?foo=bar');
+    });
+
+    test('link with models', async function(assert) {
+      await render(hbs`<BsNav::item @route="acceptance.link" @models={{array "1"}} @query={{hash foo="bar"}} />`);
+
+      assert.dom('li a').exists({ count: 1 });
+      assert.dom('li a').hasAttribute('href', '/acceptance/link/1?foo=bar');
+    });
+
+    testBS4('link has nav-link class', async function(assert) {
+      await render(hbs`<BsNav::item @route="index" />`);
+
+      assert.dom('li a').hasClass('nav-link');
+    });
+
+    test('disabled link', async function(assert) {
+      await render(hbs`<BsNav::item @route="index" @disabled={{true}} />`);
+
+      assert.dom('li a').hasClass('disabled');
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,12 +4164,21 @@ electron-to-chromium@^1.3.47:
 
 ember-angle-bracket-invocation-polyfill@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz#3dd0b91b3776a8048a943889c031fa7f9ea44ec4"
-  integrity sha512-eeE4LBFIxJ5EclTIydPMPs04vvSDv64m+1fxwN2UKdSdRDWwus36k4B/LquDfWuG1WI0Dk3R4WoTFcRYlbNTWg==
+  resolved "https://codeload.github.com/rwjblue/ember-angle-bracket-invocation-polyfill/tar.gz/7cacd379bbcebb662cae2e14055b67840cbb2614"
   dependencies:
     ember-cli-babel "^6.17.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.0.2"
+
+ember-angle-bracket-invocation-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.1.tgz#52308fa5b2ef80ef3cfda92b71068d54fd23bdac"
+  integrity sha512-MMrxh5tyVb5iOfZHk2jYgeZFg1AU9VagDzl9uM+7c6p3fBi9VywIsNuTwQiZLlH24LKlXQ1Ts2gM/Iym/JS9wg==
+  dependencies:
+    ember-cli-babel "^6.17.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.0.2"
+    silent-error "^1.1.1"
 
 ember-array-helper@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This removes the `@linkTo` property that was introduced in 3.0.0-rc.0 in favor of `@route`, `@model`/`@models` and `@query` to match the API of Ember's angle bracket `<LinkTo>` component (RFC459).

Fixes #852

*Waiting for a new release of `ember-angle-bracket-invocation-polyfill` (needs https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/pull/72) before this can be merged,*