### PR TITLE
Fix FastBoot tests

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -89,7 +89,7 @@ module.exports = function() {
         },
         {
           name: 'fastboot-addon-tests',
-          command: 'DEBUG=ember-cli-addon-tests ember fastboot:test',
+          command: 'DEBUG=ember-cli-addon-tests ember fastboot:test --ember-data-version=3.10.0',
           npm: {
             devDependencies: {}
           }


### PR DESCRIPTION
Latest ember-data complains about missing ember-fetch. This is a simple workaround, until the FastBoot tests undergo a more substantial refactoring.