### PR TITLE
Workaround nav.item not applying `active` class correctly due to Ember 3.12-beta bug

### DIFF
--- a/addon/components/base/bs-nav/item.js
+++ b/addon/components/base/bs-nav/item.js
@@ -105,7 +105,11 @@ export default Component.extend(ComponentParent, {
       params.push({ queryParams: true, ...query});
     }
 
-    return params.length ? this.get('router').isActive(...params) : this.get('_active');
+    // workaround for https://github.com/emberjs/ember.js/issues/18264
+    // @todo remove once this is resolved
+    this.get('router.currentURL');
+
+    return params.length > 0 ? this.get('router').isActive(...params) : this.get('_active');
   }),
   _active: false,
 


### PR DESCRIPTION
Was caused by the CP not recomputing when `router.currentURL` changes.