### PR TITLE
apply CSP via meta tag

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,6 +37,7 @@ module.exports = function(environment) {
         "https://ghbtns.com/",
       ],
     },
+    contentSecurityPolicyMeta: true,
 
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/]
@@ -68,7 +69,7 @@ module.exports = function(environment) {
 
     // testem requires frame-src 'self' to run
     // https://github.com/rwjblue/ember-cli-content-security-policy/blob/v1.0.0/index.js#L85-L88
-    ENV.contentSecurityPolicy['frame-src'].push('self');
+    ENV.contentSecurityPolicy['frame-src'].push("'self'");
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
CSP set by header is only available if tests are executed using Ember's built-in development server. This is true for `ember test --server` and visiting http://localhost:4200/tests if running `ember serve` but not for `ember test`. This causes inconsitency in reporting CSP violations between different ways to execute these tests.