### PR TITLE
support hash helper used as form model

### DIFF
--- a/addon/templates/components/common/bs-form.hbs
+++ b/addon/templates/components/common/bs-form.hbs
@@ -1,7 +1,7 @@
 {{yield
   (hash
     element=(component this.elementComponent
-      model=@model
+      model=this.model
       formLayout=this.formLayout
       horizontalLabelGridClass=this.horizontalLabelGridClass
       showAllValidations=this.showAllValidations

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -404,6 +404,24 @@ module('Integration | Component | bs-form', function(hooks) {
       assert.dom(`.${formFeedbackClass()}`).hasText('There is an error');
     });
 
+  test('it supports hash helper as model', async function(assert) {
+    this.set('submitAction', function(model) {
+      assert.step('submit');
+      assert.equal(model.name, 'Moritz');
+    });
+
+    await render(hbs`
+      <BsForm @model={{hash name="Max"}} @onSubmit={{this.submitAction}} as |form|>
+        <form.element @property="name" />
+      </BsForm>
+    `);
+
+    await fillIn('input', 'Moritz');
+    await triggerEvent('form', 'submit');
+
+    assert.verifySteps(['submit']);
+  });
+
   test('it yields submit action', async function(assert) {
     let submit = this.spy();
     this.actions.submit = submit;


### PR DESCRIPTION
I'm not sure why, but if yielding `{{@model}}` the model objects used in `<BsForm>` and `<FormElement>` are not the same. I guess `{{@model}}` yields the hash helper but not it's result.