### PR TITLE
Workaround for Ember CLI 3.13 bug (Depreciated/Removed treeForAddonTemplates)

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,16 +234,31 @@ module.exports = {
     let componentsPath = 'components/';
     let templatePath = 'templates/components/';
 
-    // Merge bs3 or bs4 component files
     tree = this.debugTree(tree, 'addon-tree:input');
     tree = mv(tree, `${componentsPath}bs${bsVersion}/`, componentsPath);
     tree = rm(tree, `${componentsPath}bs${otherBsVersion}/**/*`);
 
+    tree = mv(tree, `${templatePath}common/`, templatePath);
+    tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
+    tree = rm(tree, `${templatePath}bs${otherBsVersion}/**/*`);
+    
     tree = this.debugTree(tree, 'addon-tree:bootstrap-version');
     tree = this.filterComponents(tree);
     tree = this.debugTree(tree, 'addon-tree:tree-shaken');
+  
+    return this._super.treeForAddon.call(this, tree);
+  },
 
-    // Merge bs3 or bs4 template files
+  /*
+    This method is depreciated by ember-cli when building other apps
+    but it is still called when building ember-bootstrap
+    https://github.com/kaliber5/ember-bootstrap/pull/883
+  */
+  treeForAddonTemplates(tree) {
+    let bsVersion = this.getBootstrapVersion();
+    let otherBsVersion = this.getOtherBootstrapVersion();
+    let templatePath = 'components/';
+
     tree = this.debugTree(tree, 'addon-templates-tree:input');
     tree = mv(tree, `${templatePath}common/`, templatePath);
     tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
@@ -253,7 +268,7 @@ module.exports = {
     tree = this.filterComponents(tree);
     tree = this.debugTree(tree, 'addon-templates-tree:tree-shaken');
 
-    return this._super.treeForAddon.call(this, tree);
+    return this._super.treeForAddonTemplates.call(this, tree);
   },
 
   contentFor(type, config) {

--- a/index.js
+++ b/index.js
@@ -232,7 +232,9 @@ module.exports = {
     let bsVersion = this.getBootstrapVersion();
     let otherBsVersion = this.getOtherBootstrapVersion();
     let componentsPath = 'components/';
+    let templatePath = 'templates/components/';
 
+    // Merge bs3 or bs4 component files
     tree = this.debugTree(tree, 'addon-tree:input');
     tree = mv(tree, `${componentsPath}bs${bsVersion}/`, componentsPath);
     tree = rm(tree, `${componentsPath}bs${otherBsVersion}/**/*`);
@@ -241,14 +243,7 @@ module.exports = {
     tree = this.filterComponents(tree);
     tree = this.debugTree(tree, 'addon-tree:tree-shaken');
 
-    return this._super.treeForAddon.call(this, tree);
-  },
-
-  treeForAddonTemplates(tree) {
-    let bsVersion = this.getBootstrapVersion();
-    let otherBsVersion = this.getOtherBootstrapVersion();
-    let templatePath = 'components/';
-
+    // Merge bs3 or bs4 template files
     tree = this.debugTree(tree, 'addon-templates-tree:input');
     tree = mv(tree, `${templatePath}common/`, templatePath);
     tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
@@ -258,7 +253,7 @@ module.exports = {
     tree = this.filterComponents(tree);
     tree = this.debugTree(tree, 'addon-templates-tree:tree-shaken');
 
-    return this._super.treeForAddonTemplates.call(this, tree);
+    return this._super.treeForAddon.call(this, tree);
   },
 
   contentFor(type, config) {


### PR DESCRIPTION
See https://github.com/kaliber5/ember-bootstrap/issues/881