### PR TITLE
use ember-concurrency@^1.0.0 in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,6 @@
   },
   "resolutions": {
     "ip-regex": "^2.1.0",
-    "ember-concurrency": "^0.10.0"
+    "ember-concurrency": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5661,17 +5661,7 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-concurrency@^0.10.0, ember-concurrency@^0.8.26, "ember-concurrency@^0.8.27 || ^0.9.0 || ^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.10.0.tgz#9c7c79dca411e01466119f02d7197c0a4ff0df08"
-  integrity sha512-KhNNkUqnAN0isuAwSHaTJtmY/MdHJogSSAj7lCigzfJn2+21yafQcwzoVqf5LdMOn2+owWYURr1YiwzuOvlGyQ==
-  dependencies:
-    babel-core "^6.24.1"
-    ember-cli-babel "^6.8.2"
-    ember-compatibility-helpers "^1.2.0"
-    ember-maybe-import-regenerator "^0.1.5"
-
-ember-concurrency@^1.0.0:
+ember-concurrency@^0.8.26, "ember-concurrency@^0.8.27 || ^0.9.0 || ^0.10.0", ember-concurrency@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.0.0.tgz#3b650672fdd5dc1d45007626119135829076c2b6"
   integrity sha512-76aKC0lo2LAPoQYz7vMRlpolWTIQerszr8PPf3JMM5cTOzPwXUtzDcjfso3JAEDdhyUF9fkv2V1DmHagFbC2YQ==


### PR DESCRIPTION
Still need to use yarn's resolutions features as we can not upgrade Ember Power Select (see #898 for details). But we can configure it to use an up-to-date version of ember-concurrency.