### PR TITLE
run tests against Firefox in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ jobs:
   - env: EMBER_TRY_SCENARIO=fastboot-tests
   - env: EMBER_TRY_SCENARIO=node-tests
   - env: EMBER_TRY_SCENARIO=ember-default TEST_COMMAND="ember test --launch Firefox"
-  - env: EMBER_TRY_SCENARIO=ember-default BOOTSTRAPVERSION=3 TEST_COMMAND="ember test --launch Firefox"
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ jobs:
   - env: EMBER_TRY_SCENARIO=ember-beta BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=fastboot-tests
   - env: EMBER_TRY_SCENARIO=node-tests
+  - env: EMBER_TRY_SCENARIO=ember-default TEST_COMMAND="ember test --launch Firefox"
+  - env: EMBER_TRY_SCENARIO=ember-default BOOTSTRAPVERSION=3 TEST_COMMAND="ember test --launch Firefox"
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/testem.js
+++ b/testem.js
@@ -20,6 +20,12 @@ module.exports = {
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ].filter(Boolean)
-    }
+    },
+    Firefox: {
+      ci: [
+        '--headless',
+        '--window-size=1440,900',
+      ]
+    },
   }
 };

--- a/tests/helpers/user-agent.js
+++ b/tests/helpers/user-agent.js
@@ -1,0 +1,3 @@
+export function isFirefox() {
+  return window.navigator.userAgent.includes('Firefox');
+}

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -10,6 +10,7 @@ import {
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
+import { isFirefox } from '../../helpers/user-agent';
 
 module('Integration | Component | bs-popover', function(hooks) {
   setupRenderingTest(hooks);
@@ -78,6 +79,13 @@ module('Integration | Component | bs-popover', function(hooks) {
     this.insertCSSRule('#wrapper p { margin-top: 200px }');
 
     let expectedArrowPosition = versionDependent(225, 219);
+
+    if (isFirefox()) {
+      // Popover arrow has a different positioning by 4px on Firefox
+      // https://github.com/twbs/bootstrap/issues/29485
+      expectedArrowPosition = versionDependent(225 - 4, 219 - 4);
+    }
+
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
       <div id="wrapper">

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -83,7 +83,7 @@ module('Integration | Component | bs-popover', function(hooks) {
     if (isFirefox()) {
       // Popover arrow has a different positioning by 4px on Firefox
       // https://github.com/twbs/bootstrap/issues/29485
-      expectedArrowPosition = versionDependent(225 - 4, 219 - 4);
+      expectedArrowPosition = expectedArrowPosition - 4;
     }
 
     await render(hbs`

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -395,7 +395,7 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     if (isFirefox()) {
       // Popover arrow has a different positioning by 4px on Firefox
       // https://github.com/twbs/bootstrap/issues/29485
-      expectedArrowPosition = versionDependent(155 - 4, 150 - 4);
+      expectedArrowPosition = expectedArrowPosition - 4;
     }
 
     await render(hbs`

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -19,6 +19,7 @@ import {
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
+import { isFirefox } from '../../helpers/user-agent';
 
 module('Integration | Component | bs-tooltip', function(hooks) {
   setupRenderingTest(hooks);
@@ -390,6 +391,13 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
     let expectedArrowPosition = versionDependent(155, 150);
+
+    if (isFirefox()) {
+      // Popover arrow has a different positioning by 4px on Firefox
+      // https://github.com/twbs/bootstrap/issues/29485
+      expectedArrowPosition = versionDependent(155 - 4, 150 - 4);
+    }
+
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
       <div id="wrapper">


### PR DESCRIPTION
If I didn't missed something the test suite is not run against Firefox at all in CI. It was running tests against Chrome on Travis and IE 11, Safari and Edge on BrowserStack. Seems like Firefox was missed. This PR configures Travis + Testem to run the test suite against Firefox also.