### PR TITLE
Workaround for Ember CLI 3.13 bug (Depreciated/Removed treeForAddonTemplates)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
 branches:
   only:
     - master
+    - v2
     # npm version tags
     - /^v\d+\.\d+\.\d+/
 

--- a/addon/components/base/bs-form.js
+++ b/addon/components/base/bs-form.js
@@ -3,6 +3,7 @@ import { set, computed } from '@ember/object';
 import { gt } from '@ember/object/computed';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
+import { schedule } from '@ember/runloop';
 import layout from 'ember-bootstrap/templates/components/bs-form';
 import RSVP from 'rsvp';
 
@@ -408,7 +409,7 @@ export default Component.extend({
 
               // reset forced hiding of validations
               if (this.get('showAllValidations') === false) {
-                this.set('showAllValidations', undefined);
+                schedule('afterRender', () => this.set('showAllValidations', undefined));
               }
             });
         },

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -671,7 +671,9 @@ export default FormGroup.extend({
     get() {
     },
     set(key, value) {
-      this.set('showOwnValidation', false);
+      if (value === false) {
+        this.set('showOwnValidation', false);
+      }
       return value;
     }
   }),

--- a/index.js
+++ b/index.js
@@ -240,18 +240,28 @@ module.exports = {
     let bsVersion = this.getBootstrapVersion();
     let otherBsVersion = this.getOtherBootstrapVersion();
     let componentsPath = 'components/';
+    let templatePath = 'templates/components/';
 
     tree = this.debugTree(tree, 'addon-tree:input');
     tree = mv(tree, `${componentsPath}bs${bsVersion}/`, componentsPath);
     tree = rm(tree, `${componentsPath}bs${otherBsVersion}/**/*`);
 
+    tree = mv(tree, `${templatePath}common/`, templatePath);
+    tree = mv(tree, `${templatePath}bs${bsVersion}/`, templatePath);
+    tree = rm(tree, `${templatePath}bs${otherBsVersion}/**/*`);
+    
     tree = this.debugTree(tree, 'addon-tree:bootstrap-version');
     tree = this.filterComponents(tree);
     tree = this.debugTree(tree, 'addon-tree:tree-shaken');
-
+  
     return this._super.treeForAddon.call(this, tree);
   },
 
+  /*
+    This method is depreciated by ember-cli when building other apps
+    but it is still called when building ember-bootstrap
+    https://github.com/kaliber5/ember-bootstrap/pull/883
+  */
   treeForAddonTemplates(tree) {
     let bsVersion = this.getBootstrapVersion();
     let otherBsVersion = this.getOtherBootstrapVersion();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^2.1.0",
     "ember-cli-yuidoc": "^0.8.7",
-    "ember-code-snippet": "^2.3.1",
+    "ember-code-snippet": "2.4.0",
     "ember-cp-validations": "^3.1.4",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -105,6 +105,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
   });
 
   async function controlTypeLayoutTest(assert, controlType, selector) {
+    this.set('formLayout', 'vertical');
     this.set('controlType', controlType);
     await render(hbs`{{bs-form/element controlType=controlType formLayout=formLayout horizontalLabelGridClass="col-md-4"}}`);
 
@@ -219,6 +220,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
     });
 
     test('controlType "radio" is supported', async function(assert) {
+      this.set('formLayout', 'vertical');
       await render(hbs`{{bs-form/element controlType="radio" formLayout=formLayout options=simpleOptions horizontalLabelGridClass="col-md-4"}}`);
 
       formLayouts.forEach((layout) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4645,9 +4645,9 @@ ember-source-channel-url@^1.0.1, ember-source-channel-url@^1.1.0:
     got "^8.0.1"
 
 ember-source@~3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.8.0.tgz#b84ba995d5049514a146c6df20c2fe20de08f211"
-  integrity sha512-iar9EL0AglbwgsLl8jeh++2mnnpBL2u/JUttP6jjkN/pItHfBGlgBtQ3GH0xyG37DH2SbP5bsj3pBM3xm7rTdA==
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.8.2.tgz#0f70dcb6067d79816a97b14cba6bae5e7518742f"
+  integrity sha512-mHsHIhHs9rsprrKq92YjHO58p49HPcg2dxJV//4+0hVSlDw5yPKAzLiB33LijkJV3ivqHxKFhz8bUs+UV5bW5Q==
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,7 +4366,7 @@ ember-cli@~3.8.1:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-code-snippet@^2.3.1:
+ember-code-snippet@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/ember-code-snippet/-/ember-code-snippet-2.4.0.tgz#3ed901ee0c6458019b67733e923056d5b9f74bc2"
   integrity sha512-MLnUxsbxoW1njWYrIRB0T0AbH8Ng2IJTUMXSmR/40z4Hnu6ykC7sCFJyzxcmdIj6IVPmOcFN7WpOMEfPWjKmIQ==


### PR DESCRIPTION
Backport of #883 to `v2` branch