### PR TITLE
upgrade ember-popper to ^0.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ember-let-polyfill": "^0.1.0",
     "ember-maybe-in-element": "^0.4.0",
     "ember-named-arguments-polyfill": "^1.0.0",
-    "ember-popper": "^0.10.1",
+    "ember-popper": "^0.10.3",
     "findup-sync": "^4.0.0",
     "fs-extra": "^7.0.1",
     "resolve": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5434,7 +5434,7 @@ ember-named-arguments-polyfill@^1.0.0:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.2"
 
-ember-popper@^0.10.1:
+ember-popper@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.10.3.tgz#222ecce35a6777364bec7ec293437f27a28713a1"
   integrity sha512-mSSUHIVGFYr8yYDjPhnIlma/vxMptm7a3pySZWK29YSEDDgsEviL7sAhOiNxvV8/uaRmCbJj/2M68dYYGed1Dw==


### PR DESCRIPTION
ember-popper@^0.10.3 also relies on ember-maybe-in-element@0.4.0. Making this as a minimum version should help preventing dependency linting issues.

This was discussed in https://github.com/kaliber5/ember-bootstrap/pull/896#issuecomment-537671615.