### PR TITLE
WIP: support toasts

### DIFF
--- a/addon/components/bs4/bs-toast.js
+++ b/addon/components/bs4/bs-toast.js
@@ -1,0 +1,315 @@
+import Component from '@ember/component';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import layout from 'ember-bootstrap/templates/components/bs-toast';
+import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import { cancel, later } from '@ember/runloop';
+import { action } from '@ember/object';
+import { getTransitionDurationFromElement } from 'ember-bootstrap/utils/transition';
+import { assert } from '@ember/debug';
+
+const ClassName = {
+  FADE: 'fade',
+  HIDE: 'hide',
+  SHOW: 'show',
+  SHOWING: 'showing'
+}
+
+@templateLayout(layout)
+@tagName('')
+export default class BsToastComponent extends Component {
+  /**
+   * @property animate
+   * @type Boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  animate = true;
+
+  /**
+   * Controls if the toast is hidden automatically.
+   *
+   * @property autohide
+   * @type Boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  autohide = true;
+
+  /**
+   * Delay after which the toast is hidden if `autohide` is `true` in milliseconds.
+   *
+   * @property delay
+   * @type Number
+   * @default 500
+   * @public
+   */
+  @defaultValue
+  delay = 500;
+
+  /**
+   * Controls if the toast is shown.
+   *
+   * If a visible toast is removed from DOM hiding animations are not shown. Therefore it's
+   * recommended to use the `@show` argument instead of wrapping the `<BsToast />` component
+   * in an `{{if}}`-Block.
+   *
+   * @property show
+   * @type Boolean
+   * @defualt true
+   * @public
+   */
+  @defaultValue
+  show = true;
+
+  /**
+   * Executed after show animation has ended.
+   *
+   * @method onShown
+   * @return void
+   * @public
+   */
+
+  /**
+   * Executed when toast will be hidden.
+   *
+   * It might be triggered by autohide or by user clicking close button.
+   *
+   * @method onHide
+   * @return void
+   * @public
+   */
+
+  /**
+   * Executed after hide animation has ended.
+   *
+   * @method onHidden
+   * @return void
+   * @public
+   */
+
+  /**
+   * @property autohideTimer
+   * @type {Map<string,object>}
+   * @private
+   */
+  _timers = new Map();
+
+  /**
+   * @property toastElement
+   * @type {?Element}
+   * @private
+   */
+  toastElement = null;
+
+  /**
+   * The current state of the toast. Possible states are:
+   * - showing
+   * - shown
+   * - hiding
+   * - hidden
+   *
+   * @property state
+   * @type {String}
+   * @private
+   */
+  get state() {
+    let { toastElement } = this;
+    assert('Toast element must be set before state of toast could be determined', toastElement);
+
+    if (toastElement.classList.contains(ClassName.SHOWING)) {
+      return 'showing';
+    }
+
+    if (toastElement.classList.contains(ClassName.SHOW)) {
+      return 'shown';
+    }
+
+    if (toastElement.classList.contains(ClassName.HIDE)) {
+      return 'hidden';
+    }
+
+    // There is no hiding class. Instead hiding state is determined by not having any of these
+    // state classes. `ClassName.SHOW` is removed on the beginning of hiding animation and
+    // `ClassName.HIDE` not added before the end of the hiding animation.
+    return 'hiding';
+  }
+
+  /**
+   * Shows the toast.
+   *
+   * Should be executed as soon as the toast is inserted into DOM.
+   *
+   * @method _show
+   * @param {?Element} toastElement
+   * @return void
+   * @private
+   */
+  @action
+  _show() {
+    let { toastElement } = this;
+
+    // toast must not be shown if `show` argument is false
+    if (!this.show) {
+      return;
+    }
+
+    // toast is only showable if it's currently hidden or hiding
+    if (!['hiding', 'hidden'].includes(this.state)) {
+      return;
+    }
+
+    toastElement.classList.remove(ClassName.HIDE);
+
+    if (this.animate) {
+      toastElement.classList.add(ClassName.SHOWING);
+
+      let transitionDuration = getTransitionDurationFromElement(toastElement);
+      let timer = later(this, '_onShown', transitionDuration);
+      this._timers.set('onShown', timer);
+    } else {
+      this._onShown();
+    }
+  }
+
+  /**
+   * Executed at the end of show animation.
+   *
+   * @method _onShown
+   * @return void
+   * @private
+   */
+  _onShown() {
+    let { toastElement } = this;
+
+    toastElement.classList.remove(ClassName.SHOWING);
+    toastElement.classList.add(ClassName.SHOW);
+
+    if (typeof this.onShown === 'function') {
+      this.onShown();
+    }
+
+    this._timers.delete('onShown');
+
+    if (this.autohide) {
+      let timer = later(this, '_hide', toastElement, this.delay);
+      this._timers.set('hide', timer);
+    }
+  }
+
+  /**
+   * Hide the toast.
+   *
+   * @method _hide
+   * @return void
+   * @private
+   */
+  @action
+  _hide() {
+    let { toastElement } = this;
+
+    // a toast could only be hidden if in show or showing state
+    if (!['shown', 'showing'].includes(this.state)) {
+      return;
+    }
+
+    // if toast is in showing state the animation must be canceled
+    if (this.state === 'showing') {
+      cancel(this._timers.onShown);
+      this._timers.delete('onShown');
+    }
+
+    if (typeof this.onHide === 'function') {
+      this.onHide();
+    }
+
+    this._timers.delete('hide');
+
+    toastElement.classList.remove(ClassName.SHOW);
+
+    if (this.animate) {
+      let transitionDuration = getTransitionDurationFromElement(toastElement);
+      let timer = later(this, '_onHidden', toastElement, transitionDuration);
+
+      this._timers.set('onHidden', timer);
+    } else {
+      this._onHidden();
+    }
+  }
+
+  /**
+   * Executed at the end of hiding animation.
+   *
+   * @method _onHidden
+   * @return void
+   * @private
+   */
+  _onHidden() {
+    let { toastElement } = this;
+
+    toastElement.classList.add(ClassName.HIDE);
+
+    if (typeof this.onHidden === 'function') {
+      this.onHidden();
+    }
+
+    this._timers.delete('onHidden');
+  }
+
+  /**
+   * Executed when the toast element is rendered.
+   *
+   * Responsible for registering the toastElement and initially showing the toast if `this.show`
+   * is `true`. This two tasks can't be split into two separate ones (e.g. `registerToastElement`
+   * and `_show`) cause the order in which modifiers are executed in not guaranteed but `_show`
+   * depens on toast element being registered.
+   *
+   * @method _insert
+   * @param {Element} toastElement
+   * @return void
+   * @private
+   */
+  @action
+  _insert(toastElement) {
+    this.toastElement = toastElement;
+
+    if (this.show) {
+      this._show();
+    }
+  }
+
+  /**
+   * Executed when ever `@show` argument changes.
+   * Supports programatically showing / hiding the toast.
+   *
+   * @method _showArgumentChanged
+   * @return void
+   * @private
+   */
+  @action
+  _showArgumentChanged() {
+     if (this.show) {
+      this._show();
+    } else {
+      this._hide();
+    }
+  }
+
+  /**
+   * Executed when the toast element will be destroyed.
+   * Responsible for clean up work.
+   *
+   * @method destroy
+   * @return void
+   * @private
+   */
+  @action
+  _destroy() {
+    // cancel all pending timers
+    for (let timer of this._timers.values()) {
+      cancel(timer);
+    }
+    this._timers.clear();
+  }
+}

--- a/addon/templates/components/bs4/bs-toast.hbs
+++ b/addon/templates/components/bs4/bs-toast.hbs
@@ -1,0 +1,32 @@
+<div
+  class="toast hide {{if this.animate "fade"}}"
+  role="alert"
+  aria-live="assertive"
+  aria-atomic="true"
+
+  {{did-insert this._insert}}
+  {{did-update this._showArgumentChanged @show}}
+  {{will-destroy this._destroy}}
+>
+  <div class="toast-header">
+    <span class="icon"></span>
+
+    <strong class="mr-auto">
+      {{@title}}
+    </strong>
+
+    <button
+      type="button"
+      class="ml-2 mb-1 close"
+      data-dismiss="toast"
+      aria-label="Close"
+
+      {{on "click" this._hide}}
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="toast-body">
+    {{@message}}
+  </div>
+</div>

--- a/addon/utils/transition.js
+++ b/addon/utils/transition.js
@@ -1,0 +1,31 @@
+// https://github.com/twbs/bootstrap/blob/2fb6ccf95183cef502445a77610a27c9dc8390b2/js/src/util/index.js#L47-L71
+const MILLISECONDS_MULTIPLIER = 1000;
+function getTransitionDurationFromElement(element) {
+  if (!element) {
+    return 0
+  }
+
+  // Get transition-duration of the element
+  let {
+    transitionDuration,
+    transitionDelay
+  } = window.getComputedStyle(element)
+
+  const floatTransitionDuration = parseFloat(transitionDuration)
+  const floatTransitionDelay = parseFloat(transitionDelay)
+
+  // Return 0 if element or transition duration is not found
+  if (!floatTransitionDuration && !floatTransitionDelay) {
+    return 0
+  }
+
+  // If multiple durations are defined, take the first
+  transitionDuration = transitionDuration.split(',')[0]
+  transitionDelay = transitionDelay.split(',')[0]
+
+  return (parseFloat(transitionDuration) + parseFloat(transitionDelay)) * MILLISECONDS_MULTIPLIER
+}
+
+export {
+  getTransitionDurationFromElement
+}

--- a/app/components/bs-toast.js
+++ b/app/components/bs-toast.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/components/bs-toast';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "@ember/render-modifiers": "^1.0.1",
     "babel-eslint": "^8.0.0",
     "bootstrap": "^4.0.0",
     "bootstrap-sass": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-fetch": "^6.3.1",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-on-modifier": "^1.0.0",
     "ember-power-select": "^2.3.2",
     "ember-power-select-blockless": "^0.5.0",
     "ember-prism": "^0.5.0",

--- a/tests/dummy/app/controllers/demo/toast.js
+++ b/tests/dummy/app/controllers/demo/toast.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class DemoToastController extends Controller {
+  autohideDelay = 500;
+  showToast = false;
+  showAnimatedToast = false;
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,7 @@ Router.map(function() {
     this.route('tabs', function() {
       this.route('other');
     });
+    this.route('toast');
     this.route('tooltip');
   });
   this.route('getting-started', function() {

--- a/tests/dummy/app/services/component.js
+++ b/tests/dummy/app/services/component.js
@@ -90,6 +90,13 @@ const componentData = A([
     bsUrl: 'https://getbootstrap.com/docs/4.3/components/navs/#tabs'
   },
   {
+    id: 'toast',
+    title: 'Toast',
+    className: 'Toast',
+    description: 'Show notifications with toasts.',
+    bsUrl: 'https://getbootstrap.com/docs/4.3/components/toasts/'
+  },
+  {
     id: 'tooltip',
     title: 'Tooltip',
     description: 'Add contextual information to any element.',

--- a/tests/dummy/app/templates/demo/toast.hbs
+++ b/tests/dummy/app/templates/demo/toast.hbs
@@ -1,0 +1,92 @@
+<h2>
+  Simple example
+</h2>
+<div class="bs-example" data-test-fastboot-container>
+  <!-- BEGIN-SNIPPET toast-simple -->
+  <BsToast
+    @title="Toast Support"
+    @message="Ember Bootstrap supports toasts"
+    @autohide={{false}}
+  />
+  <!-- END-SNIPPET -->
+</div>
+<div class="highlight">
+  <CodeSnippet @name="toast-simple.hbs" />
+</div>
+
+<h2>
+  Programatically showing and hiding
+</h2>
+<p>
+  You could programatically control the visibility of a toast using the <code>@show</code>
+  argument.
+</p>
+<div class="bs-example" data-test-fastboot-container>
+  <!-- BEGIN-SNIPPET toast-show -->
+  <BsToast
+    @title="Toast Support"
+    @message="Ember Bootstrap supports toasts"
+    @autohide={{false}}
+    @show={{showToast}}
+    @onHidden={{action (mut showToast) false}}
+  />
+  <!-- END-SNIPPET -->
+  <BsButton
+    @onClick={{action (mut showToast) (if showToast false true)}}
+  >
+    {{#if showToast}}hide{{else}}show{{/if}} toast
+  </BsButton>
+</div>
+<div class="highlight">
+  <CodeSnippet @name="toast-show.hbs" />
+</div>
+<BsAlert @type="warning" @dismissible={{false}}>
+  Be aware that resetting <code>@show</code> from <code>true</code> to <code>true</code>, won't
+  show the modal. It's recommended to set <code>@show</code> to <code>false</code>, when the modal
+  is hidden using <code>@onHidden</code> action.
+</BsAlert>
+
+<h2>
+  Automatically hiding the toast
+</h2>
+<p>
+  By default a toast is hidden automatically after 500ms. You could disable the autohiding
+  using <code>@autohide</code> argument. The delay could be configured by <code>@delay</code>
+  argument.
+</p>
+<div class="bs-example" data-test-fastboot-container>
+  <!-- BEGIN-SNIPPET toast-animated -->
+  <BsToast
+    @title="Toast Support"
+    @message="Ember Bootstrap supports toasts"
+    @delay={{autohideDelay}}
+    @show={{showAnimatedToast}}
+    @onHidden={{action (mut showAnimatedToast) false}}
+  />
+  <!-- END-SNIPPET -->
+  <BsForm @formLayout="inline" class="mb-2" as |form|>
+    <form.element
+      @controlType="number"
+      @label="delay"
+      @onChange={{action (mut autohideDelay)}}
+      @value={{autohideDelay}}
+      as |el|
+    >
+      <el.control class="ml-2" step="500" />
+    </form.element>
+  </BsForm>
+  <BsButton
+    @onClick={{action (mut showAnimatedToast) true}}
+  >
+    show toast
+  </BsButton>
+</div>
+<div class="highlight">
+  <CodeSnippet @name="toast-animated.hbs" />
+</div>
+
+<h2>Placement</h2>
+<p>
+  Bootstrap does not ship with a default placement for toasts nor Ember Bootstrap does. Please find
+  inspirations in <a href="https://getbootstrap.com/docs/4.3/components/toasts/#placement">Boostrap docs</a>.
+</p>

--- a/tests/integration/components/bs-toast-test.js
+++ b/tests/integration/components/bs-toast-test.js
@@ -1,0 +1,205 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, settled, waitFor, waitUntil } from '@ember/test-helpers';
+import test from 'ember-sinon-qunit/test-support/test';
+import hbs from 'htmlbars-inline-precompile';
+import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
+import { versionDependent } from '../../helpers/bootstrap-test';
+
+const DEFAULT_DELAY = 500;
+const DEFAULT_TRANSITION_DURATION = 150;
+
+versionDependent(skip, module)('Integration | Component | bs-toast', function(hooks) {
+  setupRenderingTest(hooks);
+  setupStylesheetSupport(hooks);
+
+  module('visibility', function() {
+    test('toast is shown by default', async function(assert) {
+      this.set('show', true);
+      await render(hbs`<BsToast @show={{show}} @autohide={{false}} />`);
+      assert.dom('.toast').hasClass('show');
+    });
+
+    test('toast is not shown if @show is `false`', async function(assert) {
+      this.set('show', false);
+      await render(hbs`<BsToast @show={{show}} @autohide={{false}} />`);
+      assert.dom('.toast').hasClass('hide');
+    });
+
+    test('toast is shown if @show changes from `false` to `true`', async function(assert) {
+      this.set('show', false);
+      await render(hbs`<BsToast @show={{show}} @autohide={{false}} />`);
+
+      this.set('show', true);
+      await settled();
+      assert.dom('.toast').hasClass('show');
+    });
+
+    test('toast is hidden if @show changes from `true` to `false', async function(assert) {
+      this.set('show', true);
+      await render(hbs`<BsToast @show={{show}} @autohide={{false}} />`);
+
+      this.set('show', false);
+      await settled();
+      assert.dom('.toast').hasClass('hide');
+    });
+  });
+
+  module('interaction', function() {
+    test('it hides toast if user clicks close button', async function(assert) {
+      await render(hbs`<BsToast @autohide={{false}} />`);
+      await click('.close');
+
+      assert.dom('.toast').hasClass('hide');
+    });
+  });
+
+  module('animations', function() {
+    test('it animates toast', async function(assert) {
+      this.sandbox.useFakeTimers();
+
+      render(hbs`<BsToast />`);
+
+      // can not await render as that does not resolve before toast is hidden
+      await waitFor('.toast');
+
+      assert.dom('.toast').hasClass('fade');
+      assert.dom('.toast').hasClass('showing');
+
+      this.sandbox.clock.tick(DEFAULT_TRANSITION_DURATION);
+      assert.dom('.toast').doesNotHaveClass('showing');
+      assert.dom('.toast').hasClass('show');
+
+      this.sandbox.clock.tick(DEFAULT_DELAY);
+      assert.dom('.toast').hasClass('fade');
+      assert.dom('.toast').doesNotHaveClass('show');
+
+      this.sandbox.clock.tick(DEFAULT_TRANSITION_DURATION);
+      assert.dom('.toast').hasClass('hide');
+    });
+
+    test('it determines animation duration by element\'s transition style', async function(assert) {
+      this.sandbox.useFakeTimers();
+
+      // tests asserts that setting a custom transition duration on that element
+      // which is longer than default one cause the transition to be still
+      // ongoing after default time is exceeded but being finished after additional
+      // time has passed
+      let additionalTransitionDuration = 50;
+      this.insertCSSRule(`.fade {
+        transition-duration: ${DEFAULT_TRANSITION_DURATION + additionalTransitionDuration}ms;
+      }`);
+
+      render(hbs`<BsToast @autohide={{false}} />`);
+
+      // can not await render as that does not resolve before toast is hidden
+      await waitFor('.toast');
+
+      this.sandbox.clock.tick(DEFAULT_TRANSITION_DURATION);
+      assert.dom('.toast').hasClass('showing');
+
+      this.sandbox.clock.tick(additionalTransitionDuration);
+      assert.dom('.toast').hasClass('show');
+    });
+  });
+
+  module('autohide', function() {
+    test('it hides toast automatically by default', async function(assert) {
+      await render(hbs`<BsToast />`);
+
+      // test helpers will not consider application to be settled
+      // before timer to hide toast is exceeded
+      assert.dom('.toast').hasClass('hide');
+    });
+
+    test('it does not hide the toast automatically if `autohide` is `false`', async function(assert) {
+      await render(hbs`<BsToast @autohide={{false}} />`);
+
+      assert.dom('.toast').doesNotHaveClass('hide');
+    });
+
+    test('`delay` property allows to configure time toast is shown', async function(assert) {
+      this.sandbox.useFakeTimers();
+
+      let delay = DEFAULT_TRANSITION_DURATION * 2;
+      this.set('delay', delay);
+      render(hbs`<BsToast @delay={{delay}} />`);
+
+      // can not await render cause that would mean to wait until
+      // all timers including autohide timer, to be finished
+      await waitFor('.toast');
+
+      this.sandbox.clock.tick(DEFAULT_TRANSITION_DURATION);
+      assert.dom('.toast').hasClass('show');
+
+      this.sandbox.clock.tick(delay);
+      assert.dom('.toast').doesNotHaveClass('show');
+
+      this.sandbox.clock.tick(DEFAULT_TRANSITION_DURATION);
+      assert.dom('.toast').hasClass('hide');
+
+      this.sandbox.clock.uninstall();
+    });
+  });
+
+  module('events', function() {
+    test('it executes `onShown` action', async function(assert) {
+      let onShownStub = this.stub();
+      this.set('onShown', onShownStub);
+
+      await render(hbs`<BsToast @autohide={{false}} @onShown={{this.onShown}} />`);
+
+      assert.ok(onShownStub.calledOnce);
+    });
+
+    test('it executes `onHide` action if cloded by autohide', async function(assert) {
+      let onHideStub = this.stub();
+      this.set('onHide', onHideStub);
+
+      render(hbs`<BsToast @onHide={{this.onHide}} />`);
+      await waitUntil(() => onHideStub.calledOnce, {
+        timeoutMessage: 'onHide stub was not executed before timeout',
+      });
+
+      assert.dom('.toast')
+        .doesNotHaveClass('.hide', 'onHide action is executed before hide animation starts');
+    });
+
+    test('it executes `onHide` action if closed manually', async function(assert) {
+      let onHideStub = this.stub();
+      this.set('onHide', onHideStub);
+
+      render(hbs`<BsToast @autohide={{false}} @onHide={{this.onHide}} />`);
+
+      // must await until toast including close button is fully rendered
+      await waitFor('.close');
+
+      click('.close');
+      await waitUntil(() => onHideStub.calledOnce, {
+        timeoutMessage: 'onHide stub was not executed before timeout',
+      });
+
+      assert.dom('.toast')
+        .doesNotHaveClass('.hide', 'onHide action is executed before hide animation starts');
+    });
+
+    test('it executes `onHidden` action if closed by autohide', async function(assert) {
+      let onHiddenStub = this.stub();
+      this.set('onHidden', onHiddenStub);
+
+      await render(hbs`<BsToast @onHidden={{this.onHidden}} />`);
+
+      assert.ok(onHiddenStub.calledOnce);
+    });
+
+    test('it executes `onHidden` action if closed manually', async function(assert) {
+      let onHiddenStub = this.stub();
+      this.set('onHidden', onHiddenStub);
+
+      await render(hbs`<BsToast @autohide={{false}} @onHidden={{this.onHidden}} />`);
+      await click('button.close');
+
+      assert.ok(onHiddenStub.calledOnce);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,14 @@
     silent-error "^1.1.0"
     util.promisify "^1.0.0"
 
+"@ember/render-modifiers@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.1.tgz#a85e746e4bb9fd51302cc43e726e2c641261a7c2"
+  integrity sha512-HHZwL84jCVAaIDFtPZHAnM41aB8XgvDiutD1tKnll43fw7/rhejGj/LDWdB1jrPF+vryFSSQwSJ85gk4J7W86g==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+
 "@ember/test-helpers@^1.5.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.6.0.tgz#e928c0190a19c312bf40dc8a6f4159735af48a7f"
@@ -2939,6 +2947,23 @@ broccoli-babel-transpiler@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.2.0.tgz#5c0d694c4055106abb385e2d3d88936d35b7cb18"
   integrity sha512-lkP9dNFfK810CRHHWsNl9rjyYqcXH3qg0kArnA6tV9Owx3nlZm3Eyr0cGo6sMUQCNLH+2oKrRjOdUGSc6Um6Cw==
+  dependencies:
+    "@babel/core" "^7.3.3"
+    "@babel/polyfill" "^7.0.0"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-persistent-filter "^2.2.1"
+    clone "^2.1.2"
+    hash-for-dep "^1.4.7"
+    heimdalljs-logger "^0.1.9"
+    json-stable-stringify "^1.0.1"
+    rsvp "^4.8.4"
+    workerpool "^3.1.1"
+
+broccoli-babel-transpiler@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.3.0.tgz#a0ad3a37dbf74469664bbca403d652070c2c1317"
+  integrity sha512-tsXNvDf3gp6g8rGkz234AhbaIRUsCdd6CM3ikfkJVB0EpC8ZAczGsFKTjENLy1etx4s7FkruW/QjI7Wfdhx6Ng==
   dependencies:
     "@babel/core" "^7.3.3"
     "@babel/polyfill" "^7.0.0"
@@ -5105,6 +5130,33 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
+ember-cli-babel@^7.10.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.12.0.tgz#064997d199384be8c88d251f30ef67953d3bddc5"
+  integrity sha512-+EGQsbPvh19nNXHCm6rVBx2CdlxQlzxMyhey5hsGViDPriDI4PFYXYaFWdGizDrmZoDcG/Ywpeph3hl0NxGQTg==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.3.4"
+    "@babel/plugin-proposal-decorators" "^7.3.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.12.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.3.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.0"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
 ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz#e596500eca0f5a7c9aaee755f803d1542f578acf"
@@ -5797,6 +5849,15 @@ ember-modifier-manager-polyfill@^1.0.1:
   integrity sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==
   dependencies:
     ember-cli-babel "^7.4.2"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
+
+ember-modifier-manager-polyfill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
+  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
+  dependencies:
+    ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5852,7 +5852,7 @@ ember-modifier-manager-polyfill@^1.0.1:
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 
-ember-modifier-manager-polyfill@^1.1.0:
+ember-modifier-manager-polyfill@^1.0.3, ember-modifier-manager-polyfill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
@@ -5868,6 +5868,16 @@ ember-named-arguments-polyfill@^1.0.0:
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.2"
+
+ember-on-modifier@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-on-modifier/-/ember-on-modifier-1.0.0.tgz#fb89c8d8a69df2f19a11160fa0b054395a5b947c"
+  integrity sha512-OPX5QrNiyXXQ//uN4cFj7gz5pt0rBK5c6LPEMP5iSK2I1J+WtiHM5Kg7mVCM7VziMiRUBVe3wp8CAE26m45hsA==
+  dependencies:
+    broccoli-funnel "^2.0.2"
+    ember-cli-babel "^7.8.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-modifier-manager-polyfill "^1.0.3"
 
 ember-popper@^0.10.1:
   version "0.10.1"


### PR DESCRIPTION
This implements toasts. It's only provides very basic features so far. But since it includes some new concepts and was stale on my private computer for more than a month, I would like to ship it even if missing some basic features like customization of header and footer in block mode.

We might consider shipping it as an _experimental feature_. We could highlight that it's not covered by our semver commitments. In that case we would keep some flexibility regarding the API as long as we haven't implemented full feature set. I won't expect a breaking change though but you never know.

I will try to finish the implementation soon but shipping a very basic feature set would make it easier for other to help out with some features.

From a technical perspective I would like to highlight `getTransitionDurationFromElement`. This is an implementation of #839. After we have landed it here, we could and should use it for `<BsAlert>`, `<BsCarousel>`, `<BsModal>` and `<BsTooltip>` as well.

Closes #751 