### PR TITLE
docs for FormElement should use a supported addon as example

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -68,13 +68,13 @@ const nonDefaultLayouts = A([
   #### Custom controls
 
   Apart from the standard built-in browser controls (see the `controlType` property), you can use any custom control simply
-  by invoking the component with a block template. Use whatever control you might want, for example a select-2 component
-  (from the [ember-select-2 addon](https://istefo.github.io/ember-select-2)):
+  by invoking the component with a block template. Use whatever control you might want, for example a `<PickadayInput>`
+  component (from the [ember-pikaday addon](https://github.com/adopted-ember-addons/ember-pikaday)):
 
   ```hbs
   <BsForm @model={{this}} @onSubmit={{action "submit"}} as |form|>
     <form.element @label="Select-2" @property="gender" @useIcons={{false}} as |el|>
-      {{select-2 id=el.id content=genderChoices optionLabelPath="label" value=el.value searchEnabled=false}}
+      <PickadayInput @value={{el.value}} @onSelection={{action (mut el.value)}} id={{el.id}} />
     </form.element>
   </BsForm>
   ```


### PR DESCRIPTION
The custom controls example was using `ember-select-2` addon, which is deprecated. Rewritten to use `ember-pikaday`, which is a commonly used addon. The example now also includes how to set the value. This was missed by the old example as `ember-select-2` uses two-way bindings for value.