### PR TITLE
onSlideChange action added for bs-carousel

### DIFF
--- a/addon/components/base/bs-carousel.js
+++ b/addon/components/base/bs-carousel.js
@@ -447,13 +447,13 @@ export default class Carousel extends Component.extend(ComponentParent) {
   transition = 'slide';
 
   /**
-   * Action called when the slide has changed.
+   * Action called after the slide has changed.
    *
-   * @event onIndexChange
+   * @event onSlideChanged
    * @param toIndex
    * @public
    */
-  onIndexChange(toIndex) {} // eslint-disable-line no-unused-vars
+  onSlideChanged(toIndex) {} // eslint-disable-line no-unused-vars
 
   /**
    * Do a presentation and calls itself to perform a cycle.
@@ -507,15 +507,15 @@ export default class Carousel extends Component.extend(ComponentParent) {
     if (this.get('currentIndex') === toIndex || this.get('shouldNotDoPresentation')) {
       return;
     }
-    if (this.get('onIndexChange')) {
-      this.get('onIndexChange')(toIndex);
-    }
     this.assignClassNameControls(toIndex);
     this.setFollowingIndex(toIndex);
     if (this.get('shouldRunAutomatically') === false || this.get('isMouseHovering')) {
       this.get('transitioner').perform();
     } else {
       this.get('cycle').perform();
+    }
+    if (this.get('onSlideChanged')) {
+      this.get('onSlideChanged')(toIndex);
     }
   }
 

--- a/addon/components/base/bs-carousel.js
+++ b/addon/components/base/bs-carousel.js
@@ -514,9 +514,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
     } else {
       this.get('cycle').perform();
     }
-    if (this.get('onSlideChanged')) {
-      this.get('onSlideChanged')(toIndex);
-    }
+    this.get('onSlideChanged')(toIndex);
   }
 
   @action

--- a/addon/components/base/bs-carousel.js
+++ b/addon/components/base/bs-carousel.js
@@ -447,6 +447,15 @@ export default class Carousel extends Component.extend(ComponentParent) {
   transition = 'slide';
 
   /**
+   * Action called when the slide has changed.
+   *
+   * @event onIndexChange
+   * @param toIndex
+   * @public
+   */
+  onIndexChange(toIndex) {} // eslint-disable-line no-unused-vars
+
+  /**
    * Do a presentation and calls itself to perform a cycle.
    *
    * @method cycle
@@ -497,6 +506,9 @@ export default class Carousel extends Component.extend(ComponentParent) {
   toSlide(toIndex) {
     if (this.get('currentIndex') === toIndex || this.get('shouldNotDoPresentation')) {
       return;
+    }
+    if (this.get('onIndexChange')) {
+      this.get('onIndexChange')(toIndex);
     }
     this.assignClassNameControls(toIndex);
     this.setFollowingIndex(toIndex);

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -126,13 +126,14 @@ module('Integration | Component | bs-carousel', function(hooks) {
     this.stopCarousel();
   });
 
-  test('carousel calls onIndexChange when slide changes', async function(assert) {
+  test('carousel calls onSlideChanged when slide changes', async function(assert) {
     let action = this.spy();
-    this.actions = { indexChange: action }
-    await render(hbs`{{#bs-carousel onIndexChange=(action "indexChange") wrap=false transitionDuration=transitionDuration as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
+    this.set('action', action);
+    await render(hbs`{{#bs-carousel onSlideChanged=this.action wrap=false transitionDuration=transitionDuration as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
+    assert.ok(action.notCalled, 'onSlideChanged action has not been called.');
     clickToNextSlide();
     await waitTransitionTime();
-    assert.ok(action.calledWith(1), 'onIndexChange action has been called.');
+    assert.ok(action.calledWith(1), 'onSlideChanged action has been called.');
   });
 
   test('carousel wrap=false must not cross lower bound', async function(assert) {

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -47,7 +47,7 @@ function waitTransitionTime(interval = 450) {
   return delay(TRANSITION_DURATION + interval);
 }
 
-module('Integration | Component | bs-carousel', function(hooks) {
+module.only('Integration | Component | bs-carousel', function(hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 
@@ -124,6 +124,15 @@ module('Integration | Component | bs-carousel', function(hooks) {
     await waitTransitionTime();
     assert.ok(getActivatedSlide(2), 'autoPlay has correct behavior');
     this.stopCarousel();
+  });
+
+  test('carousel calls onIndexChange when slide changes', async function(assert) {
+    let action = this.spy();
+    this.actions = { indexChange: action }
+    await render(hbs`{{#bs-carousel onIndexChange=(action "indexChange") wrap=false transitionDuration=transitionDuration as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
+    clickToNextSlide();
+    await waitTransitionTime();
+    assert.ok(action.calledWith(1), 'onIndexChange action has been called.');
   });
 
   test('carousel wrap=false must not cross lower bound', async function(assert) {

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -47,7 +47,7 @@ function waitTransitionTime(interval = 450) {
   return delay(TRANSITION_DURATION + interval);
 }
 
-module.only('Integration | Component | bs-carousel', function(hooks) {
+module('Integration | Component | bs-carousel', function(hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -130,8 +130,8 @@ module('Integration | Component | bs-carousel', function(hooks) {
     let action = this.spy();
     this.set('action', action);
     await render(hbs`{{#bs-carousel onSlideChanged=this.action wrap=false transitionDuration=transitionDuration as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
-    assert.ok(action.notCalled, 'onSlideChanged action has not been called.');
     clickToNextSlide();
+    assert.ok(action.notCalled, 'onSlideChanged action has not been called.');
     await waitTransitionTime();
     assert.ok(action.calledWith(1), 'onSlideChanged action has been called.');
   });


### PR DESCRIPTION
Closes https://github.com/kaliber5/ember-bootstrap/issues/760

~Decided to use `onIndexChange` as the name (rather than `onIndexChanged`), to be consistent with other actions in this repo, eg `onChange`~
Now using `onSlideChanged` as per feedback below.