### PR TITLE
Add ember-a11y-testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.0.0",
     "chai-things": "^0.2.0",
+    "ember-a11y-testing": "^1.1.1",
     "ember-bootstrap-power-select": "^1.1.0",
     "ember-cli": "~3.11.0",
     "ember-cli-app-version": "^3.0.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -59,7 +59,20 @@ module.exports = function(environment) {
     },
 
     bootstrapVersion: process.env.BOOTSTRAPVERSION || 4,
-    failOnDeprecation: !!process.env.FAIL_ON_DEPRECATION
+    failOnDeprecation: !!process.env.FAIL_ON_DEPRECATION,
+
+    'ember-a11y-testing': {
+      componentOptions: {
+        turnAuditOff: true,
+        axeOptions: {
+          checks: {
+            // color checks unfortunately fail for custom colors defined in dummy app, but are controlled at the end by
+            // the user, so not a primary concern of the addon
+            'color-contrast': { enabled: false }
+          }
+        }
+      }
+    }
   };
 
   if (environment === 'development') {

--- a/tests/integration/components/bs-accordion-test.js
+++ b/tests/integration/components/bs-accordion-test.js
@@ -13,6 +13,7 @@ import {
   visibilityClass
 } from '../../helpers/bootstrap-test';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-accordion', function(hooks) {
   setupRenderingTest(hooks);
@@ -191,5 +192,15 @@ module('Integration | Component | bs-accordion', function(hooks) {
     assert.dom(`.${accordionClassFor()}:first-child .${accordionItemHeadClass()}`).hasClass('collapsed', `${accordionItemHeadClass()} has collapsed class`);
     assert.dom(`.${accordionClassFor()}:first-child [role="tabpanel"]`).hasClass('collapse', 'tabpanel has collapse class');
     assert.dom(`.${accordionClassFor()}:first-child [role="tabpanel"]`).hasNoClass(visibilityClass(), 'tabpanel is hidden');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`{{#bs-accordion as |acc|}}
+      {{#acc.item value=1 title="TITLE1"}}CONTENT1{{/acc.item}}
+      {{#acc.item value=2 title="TITLE2"}}CONTENT2{{/acc.item}}
+    {{/bs-accordion}}`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-alert-test.js
+++ b/tests/integration/components/bs-alert-test.js
@@ -4,6 +4,7 @@ import { render, click, waitFor } from '@ember/test-helpers';
 import { test, testRequiringTransitions } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-alert', function(hooks) {
   setupRenderingTest(hooks);
@@ -109,5 +110,12 @@ module('Integration | Component | bs-alert', function(hooks) {
     await click('button.close');
 
     assert.equal(this.get('visible'), true, 'Does not modify visible property');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`{{#bs-alert type="success"}}Test{{/bs-alert}}`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-button-group-test.js
+++ b/tests/integration/components/bs-button-group-test.js
@@ -6,6 +6,7 @@ import test from 'ember-sinon-qunit/test-support/test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { testBS3 } from '../../helpers/bootstrap-test';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-button-group', function(hooks) {
   setupRenderingTest(hooks);
@@ -165,5 +166,14 @@ module('Integration | Component | bs-button-group', function(hooks) {
 
     await click('button:nth-child(3)');
     assert.equal(this.get('value'), value, 'Does not change value property');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(
+      hbs`{{#bs-button-group as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+    );
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -8,6 +8,7 @@ import { gte } from 'ember-compatibility-helpers';
 
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-button', function(hooks) {
   setupRenderingTest(hooks);
@@ -402,5 +403,12 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.equal(clickActionExecutionCount, 2);
 
     deferredClickAction.resolve();
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`{{#bs-button}}Test{{/bs-button}}`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -5,6 +5,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { test, testBS3, testBS4, delay } from '../../helpers/bootstrap-test';
 import { skip } from 'qunit';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 const TRANSITION_DURATION = 50;
 
@@ -238,5 +239,15 @@ module('Integration | Component | bs-carousel', function(hooks) {
     await clickIndicator(2);
     assert.dom('.carousel-indicators > li:nth-child(2).active').exists('indicators changes indicator index');
     assert.ok(getActivatedSlide(2), 'indicators changes slide index');
+  });
+
+  // Default carousel markup has a11y issues (buttons w/o content)
+  // Quote from https://getbootstrap.com/docs/4.0/components/carousel/:
+  // carousels are generally not compliant with accessibility standards.
+  skip('it passes accessibility checks', async function (assert) {
+    await render(hbs`{{#bs-carousel interval=0 as |car|}}{{car.slide}}{{car.slide}}{{/bs-carousel}}`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-collapse-test.js
+++ b/tests/integration/components/bs-collapse-test.js
@@ -6,6 +6,7 @@ import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { test, visibilityClass } from '../../helpers/bootstrap-test';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-collapse', function(hooks) {
   setupRenderingTest(hooks);
@@ -71,5 +72,12 @@ module('Integration | Component | bs-collapse', function(hooks) {
     assert.ok(hiddenAction.calledOnce, 'onHidden action has been called');
     assert.dom('.collapse').exists('collapse has collapse class');
     assert.dom('.collapse').hasNoClass('in', 'collapse does not have in class');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`<button>Test</button>{{#bs-collapse}}<p>Just some content</p>{{/bs-collapse}}`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -11,6 +11,7 @@ import {
 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-dropdown', function(hooks) {
   setupRenderingTest(hooks);
@@ -504,5 +505,20 @@ module('Integration | Component | bs-dropdown', function(hooks) {
       await triggerKeyEvent(document.activeElement, 'keydown', 40); // down
       assert.dom('#item1').isFocused();
     });
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(
+      hbs`
+        <BsDropdown as |dd|>
+          <dd.toggle>Dropdown</dd.toggle>
+          <dd.menu as |menu|>
+            <menu.item><a class="dropdown-item" href="#">Something</a></menu.item>
+          </dd.menu>
+        </BsDropdown>
+      `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -19,6 +19,7 @@ import { defer } from 'rsvp';
 import { next, run } from '@ember/runloop';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import RSVP from 'rsvp';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 /* global Ember */
 
 const nextRunloop = function() {
@@ -899,5 +900,17 @@ module('Integration | Component | bs-form', function(hooks) {
     );
 
     assert.dom('.form-group input').hasAttribute('readonly');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(
+      hbs`
+        {{#bs-form model=this as |form|}}
+          {{form.element property="dummy" label="Dummy"}}
+        {{/bs-form}}`
+    );
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-modal-simple-test.js
+++ b/tests/integration/components/bs-modal-simple-test.js
@@ -12,6 +12,7 @@ import {
 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-modal-simple', function(hooks) {
   setupRenderingTest(hooks);
@@ -590,5 +591,16 @@ module('Integration | Component | bs-modal-simple', function(hooks) {
   testBS4('modal can be set to scrollable', async function(assert) {
     await render(hbs`{{#bs-modal-simple title="Simple Dialog" fade=false scrollable=true}}Hello world!{{/bs-modal-simple}}`);
     assert.dom('.modal-dialog').hasClass('modal-dialog-scrollable');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      <BsModalSimple @title="Some Title">
+        template block text
+      </BsModalSimple>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-nav-test.js
+++ b/tests/integration/components/bs-nav-test.js
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-nav', function(hooks) {
   setupRenderingTest(hooks);
@@ -68,5 +69,27 @@ module('Integration | Component | bs-nav', function(hooks) {
     assert.dom('.nav > li').exists({ count: 3 }, 'it has the nav item');
     assert.dom('.nav > li > a[href="/"]').exists({ count: 2 }, 'it has the nav link');
     assert.dom('.nav > li.dropdown').exists({ count: 1 }, 'it has a dropdown as a nav item');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      {{#bs-nav as |nav|}}
+        {{#nav.item}}
+          {{#nav.link-to "application"}}Dummy{{/nav.link-to}}
+        {{/nav.item}}
+        {{#nav.item}}
+          {{#nav.linkTo "application"}}Dummy{{/nav.linkTo}}
+        {{/nav.item}}
+        {{#nav.dropdown as |dd|}}
+          {{#dd.toggle}}Dropdown <span class="caret"></span>{{/dd.toggle}}
+          {{#dd.menu as |ddm|}}
+            {{#ddm.item}}{{#ddm.link-to "index"}}Home{{/ddm.link-to}}{{/ddm.item}}
+          {{/dd.menu}}
+        {{/nav.dropdown}}
+      {{/bs-nav}}
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-navbar-test.js
+++ b/tests/integration/components/bs-navbar-test.js
@@ -11,6 +11,7 @@ import {
 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-navbar', function(hooks) {
   setupRenderingTest(hooks);
@@ -415,5 +416,24 @@ module('Integration | Component | bs-navbar', function(hooks) {
     await click('#link');
 
     assert.ok(collapseAction.calledOnce, 'onCollapse action has been called');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      {{#bs-navbar as |navbar|}}
+        <div class="navbar-header">
+          {{navbar.toggle}}
+          <a class="navbar-brand" href="#">Brand</a>
+        </div>
+        {{#navbar.content}}
+          {{#navbar.nav as |nav|}}
+            {{#nav.item}}{{#nav.link-to "index"}}Home{{/nav.link-to}}{{/nav.item}}
+          {{/navbar.nav}}
+        {{/navbar.content}}
+      {{/bs-navbar}}
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -11,6 +11,7 @@ import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
 import { isFirefox } from '../../helpers/user-agent';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-popover', function(hooks) {
   setupRenderingTest(hooks);
@@ -233,5 +234,18 @@ module('Integration | Component | bs-popover', function(hooks) {
     await settled();
 
     assert.dom('#wrapper .popover').exists({ count: 1 }, 'Popover exists in place.');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      <button>Test
+        <BsPopover @title="dummy title" @visible={{true}}>
+          template block text
+        </BsPopover>
+      </button>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-progress-test.js
+++ b/tests/integration/components/bs-progress-test.js
@@ -5,6 +5,7 @@ import { test, testBS3, testBS4 } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-progress', function(hooks) {
   setupRenderingTest(hooks);
@@ -184,5 +185,17 @@ module('Integration | Component | bs-progress', function(hooks) {
 
     assert.dom('.progress-bar').exists({ count: 2 }, 'Progress bar has two bars');
 
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      <BsProgress as |p|>
+        <p.bar @value={{5}} @maxValue={{10}} />
+      </BsProgress>
+      <button>Test</button>
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -278,7 +278,15 @@ module('Integration | Component | bs-tab', function(hooks) {
       {{/bs-tab}}
     `);
 
-    await a11yAudit();
+    await a11yAudit({
+      rules: {
+        // the component generates the markup as seen in the Bootstrap example: https://getbootstrap.com/docs/4.3/components/navs/#javascript-behavior
+        // however aXe seems to not like having <li>s in a <ul> with a role of tablist
+        // disabling the rule for now, but may be revisited!
+        listitem: { enabled: false },
+        'color-contrast': { enabled: false }
+      }
+    });
     assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -4,6 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import test from 'ember-sinon-qunit/test-support/test';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-tab', function(hooks) {
   setupRenderingTest(hooks);
@@ -263,5 +264,21 @@ module('Integration | Component | bs-tab', function(hooks) {
     `);
     await click('ul.nav.nav-tabs li:nth-child(2) a');
     assert.equal(this.get('paneId'), 'pane1', 'Does not modify public activeId property');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`
+      {{#bs-tab as |tab|}}
+        {{#tab.pane title="Tab 1"}}
+          tabcontent 1
+        {{/tab.pane}}
+        {{#tab.pane title="Tab 2"}}
+          tabcontent 2
+        {{/tab.pane}}
+      {{/bs-tab}}
+    `);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -20,6 +20,7 @@ import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
 import { isFirefox } from '../../helpers/user-agent';
+import a11yAudit from 'ember-a11y-testing/test-support/audit'
 
 module('Integration | Component | bs-tooltip', function(hooks) {
   setupRenderingTest(hooks);
@@ -470,5 +471,12 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     assert.dom('.tooltip').hasClass('wide');
     assert.dom('.tooltip').hasAttribute('role', 'foo');
     assert.dom('.tooltip').hasAttribute('data-test');
+  });
+
+  test('it passes accessibility checks', async function (assert) {
+    await render(hbs`<button>Test<BsTooltip @title="Dummy" @visible={{true}}/></button>`);
+
+    await a11yAudit();
+    assert.ok(true, 'A11y audit passed');
   });
 });

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -474,7 +474,11 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('it passes accessibility checks', async function (assert) {
-    await render(hbs`<button>Test<BsTooltip @title="Dummy" @visible={{true}}/></button>`);
+    await render(hbs`
+    <button>
+      Test
+      <BsTooltip @title="Dummy" @visible={{true}} />
+    </button>`);
 
     await a11yAudit();
     assert.ok(true, 'A11y audit passed');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,6 +1795,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axe-core@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.0.tgz#a57ee620c182d5389aff229586aaae06bc541abe"
+  integrity sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2804,6 +2809,14 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.3, broccoli-debug@^0.6.4, broccoli-de
     heimdalljs-logger "^0.1.7"
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
+
+broccoli-file-creator@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
+  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
 
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
@@ -4676,6 +4689,17 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+ember-a11y-testing@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-1.1.1.tgz#2fd3d9a8343e0e1dd107fb819d4878b4a31f1dcb"
+  integrity sha512-4WPcznYO6jD6bi+och92lMUd6EdZTHIAFN4XTJ3DkTlIpXW2jH5GExX2/pZmz0QcTTfWry0VVjM5cq9xcFjeEA==
+  dependencies:
+    axe-core "^3.3.2"
+    broccoli-funnel "^2.0.2"
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^3.1.3"
+    ember-get-config "^0.2.4"
+
 ember-angle-bracket-invocation-polyfill@^2.0.1, ember-angle-bracket-invocation-polyfill@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
@@ -4796,7 +4820,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5403,6 +5427,14 @@ ember-focus-trap@^0.3.2:
     ember-cli-babel "^7.11.0"
     ember-modifier-manager-polyfill "^1.1.0"
     focus-trap "^5.0.1"
+
+ember-get-config@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
 
 ember-getowner-polyfill@^2.0.1:
   version "2.2.0"


### PR DESCRIPTION
This does not replace specific tests for a11y features (e.g. testing for ARIA roles), but serves at least as a sanity check in case something has been forgotten. (in fact it uncovered #926)

Similar check should be added to any new component tests we introduce (hint: toasts). /cc @jelhan  

Closes #224 