### PR TITLE
radio group should have a legend not a label

### DIFF
--- a/addon/components/bs4/bs-form/element.js
+++ b/addon/components/bs4/bs-form/element.js
@@ -1,5 +1,6 @@
 import BaseFormGroup from 'ember-bootstrap/components/base/bs-form/element';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import { computed } from '@ember/object';
 
 export default class FormElement extends BaseFormGroup {
   @defaultValue
@@ -7,4 +8,9 @@ export default class FormElement extends BaseFormGroup {
     '.input-group-append',
     '.input-group-prepend',
   ];
+
+  @computed('controlType')
+  get labelComponent() {
+    return this.get('controlType') === 'radio' ? 'bs-form/element/legend' : 'bs-form/element/label';
+  }
 }

--- a/addon/components/bs4/bs-form/element/label.js
+++ b/addon/components/bs4/bs-form/element/label.js
@@ -1,5 +1,6 @@
 import { attributeBindings, classNameBindings, tagName } from '@ember-decorators/component';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import BaseFormElementLabel from 'ember-bootstrap/components/base/bs-form/element/label';
 import { isBlank } from '@ember/utils';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
@@ -12,7 +13,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   'labelClass',
   'sizeClass'
 )
-@attributeBindings('formElementId:for')
+@attributeBindings('forAttribute:for')
 export default class FormElementLabel extends BaseFormElementLabel {
   @computed('isHorizontal', 'isCheckbox')
   get isHorizontalAndNotCheckbox() {
@@ -27,6 +28,8 @@ export default class FormElementLabel extends BaseFormElementLabel {
     let size = this.get('size');
     return isBlank(size) ? null : `col-form-label-${size}`;
   }
+
+  @readOnly('formElementId') forAttribute;
 
   /**
    * Property for size styling, set to 'lg', 'sm'

--- a/addon/components/bs4/bs-form/element/legend.js
+++ b/addon/components/bs4/bs-form/element/legend.js
@@ -1,0 +1,12 @@
+import { tagName } from '@ember-decorators/component';
+import FormElementLabel from 'ember-bootstrap/components/bs-form/element/label';
+import defaultValue from 'ember-bootstrap/utils/default-decorator';
+
+@tagName('legend')
+export default class FormElementLegend extends FormElementLabel {
+  // FormElementLabel has an attribute binding `formElementId:for`. `attributeBindings` is a
+  // concenated property. Therefor we can't remove the attribute binding but we can prevent
+  // rendering it, by setting it to `null`.
+  @defaultValue
+  forAttribute = null;
+}

--- a/app/components/bs-form/element/legend.js
+++ b/app/components/bs-form/element/legend.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/components/bs-form/element/legend';

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -343,11 +343,27 @@ module('Integration | Component | bs-form/element', function(hooks) {
     });
 
     testBS4('has correct markup', async function(assert) {
-      await render(hbs`<BsForm::Element @controlType="radio" @options={{simpleOptions}} />`);
+      await render(hbs`<BsForm::Element @controlType="radio" @label="my radio group" @options={{simpleOptions}} />`);
+
+      assert.dom('legend').exists({ count: 1 }, 'renders a <legend> instead of a <label> for radio group');
+      assert.dom('legend').hasText('my radio group', 'renders value of label argument as text of <legend>');
+      assert.dom('legend').doesNotHaveAttribute('for', '<legend> does not have a for attribute');
 
       assert.dom('.form-check').exists({ count: 2 });
       assert.dom('.form-check input[type=radio]').hasClass('form-check-input');
       assert.dom('.form-check label').hasClass('form-check-label');
+    });
+
+    testBS4('supports horizontal from layout', async function(assert) {
+      await render(hbs`
+        <BsForm @formLayout="horizontal" as |form|>
+          <form.element @controlType="radio" @label="my radio group" @options={{simpleOptions}} />
+        </BsForm>
+      `);
+
+      assert.dom('legend').hasClass('col-form-label');
+      assert.dom('legend').hasClass('col-md-4');
+      assert.dom('.row > :not(legend)').hasClass('col-md-8');
     });
 
     testBS4('supports inline', async function(assert) {


### PR DESCRIPTION
This changes the elements used for the label of a radio group from `<label>` to `<legend>`.
A `<label>` should only be used for the label of each option.

Simplified markup before this change:

```html
  <label>label of radio group</label>
  <div class="form-check">
    <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
    <label class="form-check-label" for="gridRadios1">
      First radio
    </label>
  </div>
  <div class="form-check">
    <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
    <label class="form-check-label" for="gridRadios2">
      Second radio
    </label>
  </div>
```

After this change it looks like:

```html
  <legend>label of radio group</legend>
  <div class="form-check">
    <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
    <label class="form-check-label" for="gridRadios1">
      First radio
    </label>
  </div>
  <div class="form-check">
    <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
    <label class="form-check-label" for="gridRadios2">
      Second radio
    </label>
  </div>
```

I would treat this as a bug fix even so it might break custom CSS styles. I think releasing as part of a minor version should be fine.

Belongs to #931 