### PR TITLE
Deprecate arguments whose only purpose is supporting HTML attributes

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -93,7 +93,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 @tagName('button')
 @classNames('btn')
 @classNameBindings('active', 'block:btn-block', 'sizeClass', 'typeClass')
-@attributeBindings('_disabled:disabled', 'buttonType:type', 'title')
+@attributeBindings('__disabled:disabled', 'buttonType:type', 'title')
 export default class Button extends Component {
   /**
    * Default label of the button. Not need if used as a block component
@@ -149,15 +149,31 @@ export default class Button extends Component {
    * @property disabled
    * @type ?boolean
    * @default null
+   * @deprecated
    * @public
    */
   @defaultValue
   disabled = null;
 
-  @computed('disabled', 'isPending', 'preventConcurrency')
-  get _disabled() {
+  /**
+   * Pproperty to disable the button only used in internal communication
+   * between Ember Boostrap components.
+   *
+   * @property _disabled
+   * @type ?boolean
+   * @default null
+   * @private
+   */
+  _disabled = null;
+
+  @computed('disabled', '_disabled', 'isPending', 'preventConcurrency')
+  get __disabled() {
     if (this.get('disabled') !== null) {
       return this.get('disabled');
+    }
+
+    if (this.get('_disabled') !== null) {
+      return this.get('_disabled');
     }
 
     return this.get('isPending') && this.get('preventConcurrency');
@@ -460,6 +476,7 @@ export default class Button extends Component {
     runInDebug(() => {
       [
         ['buttonType:type', 'submit'],
+        ['disabled', true],
         ['title', 'foo'],
       ].forEach(([mapping, value]) => {
         let argument = mapping.split(':')[0];
@@ -469,10 +486,10 @@ export default class Button extends Component {
           `was setting the HTML attribute ${attribute} of the control element. You should use ` +
           `angle bracket  component invocation syntax instead:\n` +
           `Before:\n` +
-          `  {{bs-button ${attribute}="${value}"}}\n` +
-          `  <BsButton @${attribute}="${value}" />\n` +
+          `  {{bs-button ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
+          `  <BsButton @${attribute}=${typeof value === 'string' ? `"${value}"`: `{{${value}}}`} />\n` +
           `After:\n` +
-          `  <BsButton ${attribute}="${value}" />`;
+          `  <BsButton ${typeof value === 'boolean' ? attribute : `${attribute}="${value}"`} />`;
 
         deprecate(
           deprecationMessage,

--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -149,7 +149,6 @@ export default class Button extends Component {
    * @property disabled
    * @type ?boolean
    * @default null
-   * @deprecated
    * @public
    */
   @defaultValue
@@ -461,7 +460,6 @@ export default class Button extends Component {
     [
       ['buttonType:type', 'submit'],
       ['title', 'foo'],
-      ['disabled', true],
     ].forEach(([mapping, value]) => {
       let argument = mapping.split(':')[0];
       let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
@@ -470,10 +468,10 @@ export default class Button extends Component {
         `was setting the HTML attribute ${attribute} of the control element. You should use ` +
         `angle bracket  component invocation syntax instead:\n` +
         `Before:\n` +
-        `  {{bs-button ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
-        `  <BsButton @${attribute}=${typeof value === 'string' ? `"${value}"`: `{{${value}}}`} />\n` +
+        `  {{bs-button ${attribute}="${value}"}}\n` +
+        `  <BsButton @${attribute}="${value}" />\n` +
         `After:\n` +
-        `  <BsButton ${typeof value === 'boolean' ? ( value ? attribute : '' ) : `${attribute}="${value}"`} />`;
+        `  <BsButton ${attribute}="${value}" />`;
 
       deprecate(
         deprecationMessage,

--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -164,6 +164,7 @@ export default class Button extends Component {
    * @default null
    * @private
    */
+  @defaultValue
   _disabled = null;
 
   @computed('disabled', '_disabled', 'isPending', 'preventConcurrency')

--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -10,7 +10,7 @@ import { observes } from '@ember-decorators/object';
 import { computed } from '@ember/object';
 import { equal, or } from '@ember/object/computed';
 import { scheduleOnce } from '@ember/runloop';
-import { deprecate } from '@ember/debug';
+import { deprecate, runInDebug } from '@ember/debug';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-button';
 import sizeClass from 'ember-bootstrap/utils/cp/size-class';
@@ -457,31 +457,33 @@ export default class Button extends Component {
     super.init(...arguments);
 
     // deprecate arguments used for attribute bindings only
-    [
-      ['buttonType:type', 'submit'],
-      ['title', 'foo'],
-    ].forEach(([mapping, value]) => {
-      let argument = mapping.split(':')[0];
-      let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
-      let deprecationMessage =
-        `Argument ${argument} of <BsButton> component is deprecated. It's only purpose ` +
-        `was setting the HTML attribute ${attribute} of the control element. You should use ` +
-        `angle bracket  component invocation syntax instead:\n` +
-        `Before:\n` +
-        `  {{bs-button ${attribute}="${value}"}}\n` +
-        `  <BsButton @${attribute}="${value}" />\n` +
-        `After:\n` +
-        `  <BsButton ${attribute}="${value}" />`;
+    runInDebug(() => {
+      [
+        ['buttonType:type', 'submit'],
+        ['title', 'foo'],
+      ].forEach(([mapping, value]) => {
+        let argument = mapping.split(':')[0];
+        let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
+        let deprecationMessage =
+          `Argument ${argument} of <BsButton> component is deprecated. It's only purpose ` +
+          `was setting the HTML attribute ${attribute} of the control element. You should use ` +
+          `angle bracket  component invocation syntax instead:\n` +
+          `Before:\n` +
+          `  {{bs-button ${attribute}="${value}"}}\n` +
+          `  <BsButton @${attribute}="${value}" />\n` +
+          `After:\n` +
+          `  <BsButton ${attribute}="${value}" />`;
 
-      deprecate(
-        deprecationMessage,
-        // eslint-disable-next-line ember/no-attrs-in-components
-        !Object.keys(this.attrs).includes(argument),
-        {
-          id: `ember-bootstrap.deprecated-argument.button#${argument}`,
-          until: '4.0.0',
-        }
-      );
+        deprecate(
+          deprecationMessage,
+          // eslint-disable-next-line ember/no-attrs-in-components
+          !Object.keys(this.attrs).includes(argument),
+          {
+            id: `ember-bootstrap.deprecated-argument.button#${argument}`,
+            until: '4.0.0',
+          }
+        );
+      });
     });
   }
 }

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -1092,8 +1092,6 @@ export default class FormElement extends FormGroup {
       ['name', 'foo'],
       ['pattern', '^[0-9]{5}$'],
       ['placeholder', 'foo'],
-      ['readonly', true],
-      ['required', true],
       ['rows', '10'],
       ['spellcheck', true],
       ['step', '2'],

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -3,7 +3,7 @@ import { observes } from '@ember-decorators/object';
 import { alias, and, equal, gt, notEmpty, or } from '@ember/object/computed';
 import { action, computed, defineProperty } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
-import { assert, deprecate } from '@ember/debug';
+import { assert, deprecate, runInDebug } from '@ember/debug';
 import { isBlank, typeOf } from '@ember/utils';
 import { A, isArray } from '@ember/array';
 import { getOwner } from '@ember/application';
@@ -1073,63 +1073,65 @@ export default class FormElement extends FormGroup {
     }
 
     // deprecate arguments used for attribute bindings only
-    [
-      ['accept', 'image/png'],
-      ['autocapitalize', 'words'],
-      ['autocomplete', 'on'],
-      ['autocorrect', 'off'],
-      ['autofocus', false],
-      ['autosave', 'someuniquevalue'],
-      ['cols', '10'],
-      ['controlSize:size', '10'],
-      ['form', 'myform'],
-      ['inputmode', 'tel'],
-      ['max', '5'],
-      ['maxlength', '5'],
-      ['min', '5'],
-      ['minlength', '5'],
-      ['multiple', true],
-      ['name', 'foo'],
-      ['pattern', '^[0-9]{5}$'],
-      ['placeholder', 'foo'],
-      ['rows', '10'],
-      ['spellcheck', true],
-      ['step', '2'],
-      ['tabindex', '-1'],
-      ['title', 'foo'],
-      ['wrap', 'hard'],
-    ].forEach(([mapping, value]) => {
-      let argument = mapping.split(':')[0];
-      let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
-      let deprecationMessage =
-        `Argument ${argument} of <element> component yielded by <BsForm> is deprecated. ` +
-        `It's only purpose was setting the HTML attribute ${attribute} of the control element. ` +
-        `You should use  angle bracket  component invocation syntax instead:\n` +
-        `Before:n` +
-        `  {{#bs-form as |form|}}\n` +
-        `    {{form.element ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
-        `  {{/bs-form}}\n` +
-        `  <BsForm as |form|>\n` +
-        `    <form.element as |el|>\n` +
-        `      <el.control @${attribute}=${typeof value === 'string' ? `"${value}"`: `{{${value}}}`} />\n` +
-        `    </form.element>\n` +
-        `  </BsForm>\n` +
-        `After:\n` +
-        `  <BsForm as |form|>\n` +
-        `    <form.element as |el|>\n` +
-        `      <el.control ${typeof value === 'boolean' ? ( value ? attribute : '' ) : `${attribute}="${value}"`} />\n` +
-        `    </form.element>\n` +
-        `  </BsForm>`;
+    runInDebug(() => {
+      [
+        ['accept', 'image/png'],
+        ['autocapitalize', 'words'],
+        ['autocomplete', 'on'],
+        ['autocorrect', 'off'],
+        ['autofocus', false],
+        ['autosave', 'someuniquevalue'],
+        ['cols', '10'],
+        ['controlSize:size', '10'],
+        ['form', 'myform'],
+        ['inputmode', 'tel'],
+        ['max', '5'],
+        ['maxlength', '5'],
+        ['min', '5'],
+        ['minlength', '5'],
+        ['multiple', true],
+        ['name', 'foo'],
+        ['pattern', '^[0-9]{5}$'],
+        ['placeholder', 'foo'],
+        ['rows', '10'],
+        ['spellcheck', true],
+        ['step', '2'],
+        ['tabindex', '-1'],
+        ['title', 'foo'],
+        ['wrap', 'hard'],
+      ].forEach(([mapping, value]) => {
+        let argument = mapping.split(':')[0];
+        let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
+        let deprecationMessage =
+          `Argument ${argument} of <element> component yielded by <BsForm> is deprecated. ` +
+          `It's only purpose was setting the HTML attribute ${attribute} of the control element. ` +
+          `You should use  angle bracket  component invocation syntax instead:\n` +
+          `Before:n` +
+          `  {{#bs-form as |form|}}\n` +
+          `    {{form.element ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
+          `  {{/bs-form}}\n` +
+          `  <BsForm as |form|>\n` +
+          `    <form.element as |el|>\n` +
+          `      <el.control @${attribute}=${typeof value === 'string' ? `"${value}"`: `{{${value}}}`} />\n` +
+          `    </form.element>\n` +
+          `  </BsForm>\n` +
+          `After:\n` +
+          `  <BsForm as |form|>\n` +
+          `    <form.element as |el|>\n` +
+          `      <el.control ${typeof value === 'boolean' ? ( value ? attribute : '' ) : `${attribute}="${value}"`} />\n` +
+          `    </form.element>\n` +
+          `  </BsForm>`;
 
-      deprecate(
-        deprecationMessage,
-        // eslint-disable-next-line ember/no-attrs-in-components
-        !Object.keys(this.attrs).includes(argument),
-        {
-          id: `ember-bootstrap.deprecated-argument.form-element#${argument}`,
-          until: '4.0.0',
-        }
-      );
+        deprecate(
+          deprecationMessage,
+          // eslint-disable-next-line ember/no-attrs-in-components
+          !Object.keys(this.attrs).includes(argument),
+          {
+            id: `ember-bootstrap.deprecated-argument.form-element#${argument}`,
+            until: '4.0.0',
+          }
+        );
+      });
     });
   }
 

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -3,7 +3,7 @@ import { observes } from '@ember-decorators/object';
 import { alias, and, equal, gt, notEmpty, or } from '@ember/object/computed';
 import { action, computed, defineProperty } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { isBlank, typeOf } from '@ember/utils';
 import { A, isArray } from '@ember/array';
 import { getOwner } from '@ember/application';
@@ -25,10 +25,10 @@ const nonDefaultLayouts = A([
 
   ```handlebars
   <BsForm @formLayout="horizontal" @model={{this}} @onSubmit={{action "submit"}} as |form|>
-    <form.element @controlType="email" @label="Email" @placeholder="Email" @value={{this.email}}" />
-    <form.element @controlType="password" @label="Password" @placeholder="Password" @value={{this.password}} />
+    <form.element @controlType="email" @label="Email" @value={{this.email}}" />
+    <form.element @controlType="password" @label="Password" @value={{this.password}} />
     <form.element @controlType="checkbox" @label="Remember me" @value={{this.rememberMe}} />
-    <BsButton @defaultText="Submit" @type="primary" @buttonType="submit" />
+    <BsButton @defaultText="Submit" @type="primary" type="submit" />
   </BsForm>
   ```
 
@@ -93,8 +93,8 @@ const nonDefaultLayouts = A([
 
   ```hbs
   <BsForm @model={{this}} @onSubmit={{action "submit"}} as |form|>
-    <form.element @label="Email" @placeholder="Email" @property="email" as |el|>
-      <el.control class="input-lg" />
+    <form.element @label="Email" @property="email" as |el|>
+      <el.control class="input-lg" placeholder="Email" />
     </form.element>
   </BsForm>
   ```
@@ -111,8 +111,8 @@ const nonDefaultLayouts = A([
 
   ```handlebars
   <BsForm @formLayout="horizontal" @model={{this}} @onSubmit={{action "submit"}} as |form|>
-    <form.element @controlType="email" @label="Email" @placeholder="Email" @property="email" />
-    <form.element @controlType="password" @label="Password" @placeholder="Password" @property="password" />
+    <form.element @controlType="email" @label="Email" @property="email" />
+    <form.element @controlType="password" @label="Password" @property="password" />
     <form.element @controlType="checkbox" @label="Remember me" @property="rememberMe" />
     <BsButton @defaultText="Submit" @type="primary" @buttonType="submit" />
   </BsForm>
@@ -183,9 +183,9 @@ const nonDefaultLayouts = A([
   <form.element @controlType="email" @label="Email" @property="email" as |el|>
     <el.control
       placeholder="Email"
-      required={{true}}
-      multiple={{true}}
       tabIndex={{5}}
+      multiple
+      required
     />
   </form.element>
   ...
@@ -205,6 +205,8 @@ const nonDefaultLayouts = A([
   ...
   {{/bs-form}}
   ```
+
+  But be aware that this is deprecated and will be removed in Ember Bootstrap v4.
 
   The following attributes are supported depending on the `controlType`:
 
@@ -449,7 +451,7 @@ export default class FormElement extends FormGroup {
    * get/set the control element's value:
    *
    * ```hbs
-   * {{form.element controlType="email" label="Email" placeholder="Email" value=email}}
+   * <form.element controlType="email" label="Email" value={{email}} />
    * ```
    *
    * Note: you lose the ability to validate this form element by directly binding to its value. It is recommended
@@ -1069,6 +1071,68 @@ export default class FormElement extends FormGroup {
       defineProperty(this, 'value', alias(`model.${this.get('property')}`));
       this.setupValidations();
     }
+
+    // deprecate arguments used for attribute bindings only
+    [
+      ['accept', 'image/png'],
+      ['autocapitalize', 'words'],
+      ['autocomplete', 'on'],
+      ['autocorrect', 'off'],
+      ['autofocus', false],
+      ['autosave', 'someuniquevalue'],
+      ['cols', '10'],
+      ['controlSize:size', '10'],
+      ['form', 'myform'],
+      ['inputmode', 'tel'],
+      ['max', '5'],
+      ['maxlength', '5'],
+      ['min', '5'],
+      ['minlength', '5'],
+      ['multiple', true],
+      ['name', 'foo'],
+      ['pattern', '^[0-9]{5}$'],
+      ['placeholder', 'foo'],
+      ['readonly', true],
+      ['required', true],
+      ['rows', '10'],
+      ['spellcheck', true],
+      ['step', '2'],
+      ['tabindex', '-1'],
+      ['title', 'foo'],
+      ['wrap', 'hard'],
+    ].forEach(([mapping, value]) => {
+      let argument = mapping.split(':')[0];
+      let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
+      let deprecationMessage =
+        `Argument ${argument} of <element> component yielded by <BsForm> is deprecated. ` +
+        `It's only purpose was setting the HTML attribute ${attribute} of the control element. ` +
+        `You should use  angle bracket  component invocation syntax instead:\n` +
+        `Before:n` +
+        `  {{#bs-form as |form|}}\n` +
+        `    {{form.element ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
+        `  {{/bs-form}}\n` +
+        `  <BsForm as |form|>\n` +
+        `    <form.element as |el|>\n` +
+        `      <el.control @${attribute}=${typeof value === 'string' ? `"${value}"`: `{{${value}}}`} />\n` +
+        `    </form.element>\n` +
+        `  </BsForm>\n` +
+        `After:\n` +
+        `  <BsForm as |form|>\n` +
+        `    <form.element as |el|>\n` +
+        `      <el.control ${typeof value === 'boolean' ? ( value ? attribute : '' ) : `${attribute}="${value}"`} />\n` +
+        `    </form.element>\n` +
+        `  </BsForm>`;
+
+      deprecate(
+        deprecationMessage,
+        // eslint-disable-next-line ember/no-attrs-in-components
+        !Object.keys(this.attrs).includes(argument),
+        {
+          id: `ember-bootstrap.deprecated-argument.form-element#${argument}`,
+          until: '4.0.0',
+        }
+      );
+    });
   }
 
   /*

--- a/addon/templates/components/common/bs-modal/footer.hbs
+++ b/addon/templates/components/common/bs-modal/footer.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{#if this.hasSubmitButton}}
     {{#component this.buttonComponent onClick=@onClose}}{{this.closeTitle}}{{/component}}
-    {{#component this.buttonComponent type=this.submitButtonType onClick=@onSubmit disabled=this.submitDisabled}}{{@submitTitle}}{{/component}}
+    {{#component this.buttonComponent type=this.submitButtonType onClick=@onSubmit _disabled=this.submitDisabled}}{{@submitTitle}}{{/component}}
   {{else}}
     {{#component this.buttonComponent type="primary" onClick=@onClose}}{{this.closeTitle}}{{/component}}
   {{/if}}

--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -36,14 +36,16 @@ export default function setupNoDeprecations({ beforeEach, afterEach }) {
   };
 
   QUnit.assert.deprecationsInclude = function(expected) {
-    let foundIndex = deprecations.indexOf(expected);
+    let found = deprecations.find((deprecation) => deprecation.includes(expected));
     this.pushResult({
-      result: foundIndex > -1,
+      result: !!found,
       actual: deprecations,
       message: `expected to find \`${expected}\` deprecation. Found ${deprecations.map(d => `!${d}`).join(', ')}`,
     });
 
-    deprecations.splice(foundIndex, 1);
+    if (found) {
+      deprecations.splice(deprecations.indexOf(found), 1);
+    }
   };
 }
 

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -60,7 +60,6 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.equal(this.element.querySelector('button').getAttribute('title'), 'title');
 
     assert.deprecationsInclude('Argument title of <BsButton> component is deprecated.');
-    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
   });
 
   test('button has default label', async function(assert) {
@@ -244,22 +243,6 @@ module('Integration | Component | bs-button', function(hooks) {
     });
 
     await render(hbs`<BsButton @disabled={{false}} @onClick={{clickAction}} />`);
-    await click('button');
-    assert.dom('button').isNotDisabled();
-
-    deferredClickAction.resolve();
-    await settled();
-
-    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
-  });
-
-  test('setting disabled attribute to false prevents button from being disabled while in pending state', async function(assert) {
-    let deferredClickAction = defer();
-    this.set('clickAction', () => {
-      return deferredClickAction.promise;
-    });
-
-    await render(hbs`<BsButton @onClick={{clickAction}} disabled={{false}} />`);
     await click('button');
     assert.dom('button').isNotDisabled();
 

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -59,6 +59,7 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.equal(this.element.querySelector('button').getAttribute('disabled'), '');
     assert.equal(this.element.querySelector('button').getAttribute('title'), 'title');
 
+    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
     assert.deprecationsInclude('Argument title of <BsButton> component is deprecated.');
   });
 
@@ -245,6 +246,8 @@ module('Integration | Component | bs-button', function(hooks) {
     await render(hbs`<BsButton @disabled={{false}} @onClick={{clickAction}} />`);
     await click('button');
     assert.dom('button').isNotDisabled();
+
+    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
 
     deferredClickAction.resolve();
     await settled();

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -249,6 +249,22 @@ module('Integration | Component | bs-button', function(hooks) {
 
     deferredClickAction.resolve();
     await settled();
+
+    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
+  });
+
+  test('setting disabled attribute to false prevents button from being disabled while in pending state', async function(assert) {
+    let deferredClickAction = defer();
+    this.set('clickAction', () => {
+      return deferredClickAction.promise;
+    });
+
+    await render(hbs`<BsButton @onClick={{clickAction}} disabled={{false}} />`);
+    await click('button');
+    assert.dom('button').isNotDisabled();
+
+    deferredClickAction.resolve();
+    await settled();
   });
 
   (gte('3.4.0') ? test : skip)('setting disabled HTML attribute to false prevents button from being disabled while in pending state', async function(assert) {

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -58,6 +58,9 @@ module('Integration | Component | bs-button', function(hooks) {
     assert.equal(this.element.querySelector('button').getAttribute('id'), 'test');
     assert.equal(this.element.querySelector('button').getAttribute('disabled'), '');
     assert.equal(this.element.querySelector('button').getAttribute('title'), 'title');
+
+    assert.deprecationsInclude('Argument title of <BsButton> component is deprecated.');
+    assert.deprecationsInclude('Argument disabled of <BsButton> component is deprecated.');
   });
 
   test('button has default label', async function(assert) {
@@ -72,7 +75,9 @@ module('Integration | Component | bs-button', function(hooks) {
 
   test('buttonType property allows changing button type', async function(assert) {
     await render(hbs`{{bs-button buttonType="submit"}}`);
-    assert.equal(this.element.querySelector('button').type, 'submit');
+
+    assert.dom('button').hasAttribute('type', 'submit');
+    assert.deprecationsInclude('Argument buttonType of <BsButton> component is deprecated.');
   });
 
   test('button with icon property shows icon', async function(assert) {

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -104,6 +104,7 @@ module('Integration | Component | bs-form', function(hooks) {
 
     await click('button');
     assert.ok(submit.calledOnce, 'onSubmit action has been called');
+    assert.deprecations(1);
   });
 
   test('Submit event bubbles', async function(assert) {

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -88,8 +88,13 @@ const supportedRadioAttributes = {
   form: 'dummy',
   title: 'dummy'
 };
-const deprecatedAttributeBindings = Object.keys(supportedInputAttributes).filter((attr) => {
-  return !['disabled'].includes(attr);
+const deprecatedAttributeBindings = [].concat(
+  Object.keys(supportedInputAttributes),
+  Object.keys(supportedTextareaAttributes),
+  Object.keys(supportedCheckboxAttributes),
+  Object.keys(supportedRadioAttributes),
+).filter((attr) => {
+  return !['disabled', 'readonly', 'required'].includes(attr);
 });
 
 module('Integration | Component | bs-form/element', function(hooks) {
@@ -410,6 +415,10 @@ module('Integration | Component | bs-form/element', function(hooks) {
             assert.ok(this.element.querySelector('input[type=radio]').hasAttribute(attribute), `input has attribute ${attribute} [${formLayout}]`);
           } else {
             assert.equal(this.element.querySelector('input[type=radio]').getAttribute(attribute), value, `input attribute ${attribute} is ${value} [${formLayout}]`);
+          }
+
+          if (deprecatedAttributeBindings.includes(attribute)) {
+            assert.deprecationsInclude(`Argument ${attribute} of <element> component yielded by <BsForm> is deprecated.`);
           }
         }
         await render(hbs``); // hack to prevent browser exception when setting size to undefined

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -88,6 +88,9 @@ const supportedRadioAttributes = {
   form: 'dummy',
   title: 'dummy'
 };
+const deprecatedAttributeBindings = Object.keys(supportedInputAttributes).filter((attr) => {
+  return !['disabled'].includes(attr);
+});
 
 module('Integration | Component | bs-form/element', function(hooks) {
   setupRenderingTest(hooks);
@@ -517,6 +520,11 @@ module('Integration | Component | bs-form/element', function(hooks) {
         } else {
           assert.equal(this.element.querySelector('input').getAttribute(attribute), value, `input attribute ${attribute} is ${value} [${formLayout}]`);
         }
+
+        if (deprecatedAttributeBindings.includes(attribute)) {
+          let argument = attribute === 'size' ? 'controlSize' : attribute;
+          assert.deprecationsInclude(`Argument ${argument} of <element> component yielded by <BsForm> is deprecated.`);
+        }
       }
       await render(hbs``); // hack to prevent browser exception when setting size to undefined
     }
@@ -614,6 +622,10 @@ module('Integration | Component | bs-form/element', function(hooks) {
         } else {
           assert.equal(this.element.querySelector('textarea').getAttribute(attribute), value, `textarea attribute ${attribute} is ${value} [${formLayout}]`);
         }
+
+        if (deprecatedAttributeBindings.includes(attribute)) {
+          assert.deprecationsInclude(`Argument ${attribute} of <element> component yielded by <BsForm> is deprecated.`);
+        }
       }
 
       // Without this MSEdge will fail with an invalid argument exception in Glimmer!??
@@ -698,6 +710,10 @@ module('Integration | Component | bs-form/element', function(hooks) {
         } else {
           assert.equal(this.element.querySelector('input').getAttribute(attribute), value, `input attribute ${attribute} is ${value} [${formLayout}]`);
         }
+
+        if (deprecatedAttributeBindings.includes(attribute)) {
+          assert.deprecationsInclude(`Argument ${attribute} of <element> component yielded by <BsForm> is deprecated.`);
+        }
       }
     }
   });
@@ -765,6 +781,10 @@ module('Integration | Component | bs-form/element', function(hooks) {
           assert.ok(this.element.querySelector('input').hasAttribute(attribute), `input has attribute ${attribute} [${formLayout}]`);
         } else {
           assert.equal(this.element.querySelector('input').getAttribute(attribute), value, `input attribute ${attribute} is ${value} [${formLayout}]`);
+        }
+
+        if (deprecatedAttributeBindings.includes(attribute)) {
+          assert.deprecationsInclude(`Argument ${attribute} of <element> component yielded by <BsForm> is deprecated.`);
         }
       }
     }


### PR DESCRIPTION
This should deprecate all properties whose only purpose is supporting HTML attributes _and_ which are not forwarded internally.

Can not deprecate the arguments on `FormElementControl` yet cause they are set by Ember Boostrap itself (`FormElement` component) and `{{component}}` helper does not support HTML attributes yet. Seems like we need to delay that _after_ the next major.

Actually I had expected that more arguments are affected. Seems like the pattern was only used on `FormElement`,  `FormElementControl` and `BsButton`.

Part of #826 