### PR TITLE
add test coverages for optional feature: async-observers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
   - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+  - env: EMBER_TRY_SCENARIO=ember-default-with-async-observers
   - env: EMBER_TRY_SCENARIO=ember-lts-2.18 BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=ember-lts-3.4 BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=ember-release BOOTSTRAPVERSION=3

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -86,6 +86,14 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-default-with-async-observers',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'default-async-observers': true
+            })
+          },
+        },
+        {
           name: 'fastboot-tests',
           command: 'ember test --filter FastBoot'
         },


### PR DESCRIPTION
As reported in #939 Ember Bootstrap does not work with optional feature *async-observers*. This adds another ember try scenario running our test suite with that optional feature enabled to see how worse it is (and provide a starting point to fix it).

We might want to remove scenario as soon as we remove the last observer from our code base. We might want to ensure before removing that all of our dependencies don't use observers anymore or have a similar scenario in their CI pipeline.