### PR TITLE
Modals ignore clicking backdrop to close, if mousedown happened on dialog element, reflecting original bootstrap.js behaviour

### DIFF
--- a/addon/components/base/bs-modal/dialog.js
+++ b/addon/components/base/bs-modal/dialog.js
@@ -163,8 +163,28 @@ export default class ModalDialog extends Component {
         }
       }
     }
-    this.set('titleId', nodeId)
+    this.set('titleId', nodeId);
   }
+
+  /**
+   * If true clicking on the backdrop will be ignored and will not close modal.
+   *
+   * @property ignoreBackdropClick
+   * @type boolean
+   * @default false
+   * @private
+   */
+  ignoreBackdropClick = false;
+
+  /**
+   * The target DOM element of mouse down event.
+   *
+   * @property mouseDownElement
+   * @type object
+   * @default null
+   * @private
+   */
+  mouseDownElement = null;
 
   /**
    * Update the elements styles using CSSOM.
@@ -204,10 +224,24 @@ export default class ModalDialog extends Component {
   }
 
   _click(e) {
+    if (this.ignoreBackdropClick) {
+      this.set('ignoreBackdropClick', false);
+      return;
+    }
     if (e.target !== this.element || !this.get('backdropClose')) {
       return;
     }
     this.get('onClose')();
+  }
+
+  _mouseDown(e) {
+    this.set('mouseDownElement', e.target);
+  }
+
+  _mouseUp(e) {
+    if (this.mouseDownElement !== this.element && e.target === this.element) {
+      this.set('ignoreBackdropClick', true);
+    }
   }
 
   didInsertElement() {
@@ -216,6 +250,8 @@ export default class ModalDialog extends Component {
     // iOS to allow clicking the div. So a `click(){}` method here won't work, we need to attach an event listener
     // directly to the element
     this.element.onclick = bind(this, this._click);
+    this.element.onmousedown = bind(this, this._mouseDown);
+    this.element.onmouseup = bind(this, this._mouseUp);
     this.getOrSetTitleId();
     this.updateStyles();
   }

--- a/addon/components/base/bs-modal/dialog.js
+++ b/addon/components/base/bs-modal/dialog.js
@@ -234,11 +234,11 @@ export default class ModalDialog extends Component {
     this.get('onClose')();
   }
 
-  _mouseDown(e) {
+  mouseDown(e) {
     this.set('mouseDownElement', e.target);
   }
 
-  _mouseUp(e) {
+  mouseUp(e) {
     if (this.mouseDownElement !== this.element && e.target === this.element) {
       this.set('ignoreBackdropClick', true);
     }
@@ -250,8 +250,6 @@ export default class ModalDialog extends Component {
     // iOS to allow clicking the div. So a `click(){}` method here won't work, we need to attach an event listener
     // directly to the element
     this.element.onclick = bind(this, this._click);
-    this.element.onmousedown = bind(this, this._mouseDown);
-    this.element.onmouseup = bind(this, this._mouseUp);
     this.getOrSetTitleId();
     this.updateStyles();
   }

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, triggerEvent } from '@ember/test-helpers';
 import { test } from '../../helpers/bootstrap-test';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -150,5 +150,29 @@ module('Integration | Component | bs-modal', function(hooks) {
     assert.dom('.modal').hasClass('custom');
     assert.dom('.modal').hasAttribute('role', 'alert');
     assert.dom('.modal').hasAttribute('data-test');
+  });
+
+  test('it keeps itself visible when mouse click is started from inside of the modal \
+    and dragged outside of the modal', async function(assert) {
+    await render(hbs`
+      <BsModal>
+        template block text
+      </BsModal>
+    `);
+    await triggerEvent('.modal-content', 'mousedown');
+    await triggerEvent('.modal', 'mouseup');
+
+    assert.dom('.modal').exists('Modal should be still visible');
+  });
+
+  test('it closes itself when backdrop is clicked', async function(assert) {
+    await render(hbs`
+      <BsModal>
+        template block text
+      </BsModal>
+    `);
+    await click('.modal');
+
+    assert.dom('.modal').doesNotExist('Modal closes itself as normal');
   });
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -161,6 +161,7 @@ module('Integration | Component | bs-modal', function(hooks) {
     `);
     await triggerEvent('.modal-content', 'mousedown');
     await triggerEvent('.modal', 'mouseup');
+    await triggerEvent('.modal', 'click');
 
     assert.dom('.modal').exists('Modal should be still visible');
   });


### PR DESCRIPTION
In bootstrap's source code, it tries to not close the modals if the
mouse down event was inside of the modal and mouse up event was outside
of the modal. With these changes we are copying the same behaviour from
it. We are also using similar variables to reflect it's source code.

Here is the click event of bootstrap: https://github.com/twbs/bootstrap/blob/master/js/src/modal.js#L361
Here is the handlers for mouse down and up events: https://github.com/twbs/bootstrap/blob/master/js/src/modal.js#L154