### PR TITLE
support optional feature default-async-observers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,12 @@ jobs:
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
   - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+  - env: EMBER_TRY_SCENARIO=ember-classic
   - env: EMBER_TRY_SCENARIO=ember-lts-2.18 BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=ember-lts-3.4 BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=ember-release BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=ember-beta BOOTSTRAPVERSION=3
+  - env: EMBER_TRY_SCENARIO=ember-classic BOOTSTRAPVERSION=3
   - env: EMBER_TRY_SCENARIO=fastboot-tests
   - env: EMBER_TRY_SCENARIO=node-tests
   - env: EMBER_TRY_SCENARIO=ember-default TEST_COMMAND="ember test --launch Firefox"

--- a/addon/components/base/bs-alert.js
+++ b/addon/components/base/bs-alert.js
@@ -1,7 +1,7 @@
 import { classNameBindings, layout as templateLayout } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
 import { action } from '@ember/object';
 import { and, not } from '@ember/object/computed';
+import { addObserver } from '@ember/object/observers';
 import Component from '@ember/component';
 import { later } from '@ember/runloop';
 import layout from 'ember-bootstrap/templates/components/bs-alert';
@@ -205,12 +205,17 @@ export default class Alert extends Component {
     }
   }
 
-  @observes('_visible')
   _observeIsVisible() {
     if (this.get('_visible')) {
       this.show();
     } else {
       this.hide();
     }
+  }
+
+  init() {
+    super.init(...arguments);
+
+    addObserver(this, '_visible', null, this._observeIsVisible, true);
   }
 }

--- a/addon/components/base/bs-collapse.js
+++ b/addon/components/base/bs-collapse.js
@@ -1,6 +1,6 @@
 import { classNameBindings } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
 import { alias, and, not } from '@ember/object/computed';
+import { addObserver } from '@ember/object/observers';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
 import '@ember/object';
@@ -250,7 +250,6 @@ export default class Collapse extends Component {
     });
   }
 
-  @observes('collapsed')
   _onCollapsedChange() {
     let collapsed = this.get('collapsed');
     let active = this.get('active');
@@ -264,17 +263,23 @@ export default class Collapse extends Component {
     }
   }
 
-  @observes('collapsedSize')
   _updateCollapsedSize() {
     if (!this.get('resetSizeWhenNotCollapsing') && this.get('collapsed') && !this.get('collapsing')) {
       this.setCollapseSize(this.get('collapsedSize'));
     }
   }
 
-  @observes('expandedSize')
   _updateExpandedSize() {
     if (!this.get('resetSizeWhenNotCollapsing') && !this.get('collapsed') && !this.get('collapsing')) {
       this.setCollapseSize(this.get('expandedSize'));
     }
+  }
+
+  init() {
+    super.init(...arguments);
+
+    addObserver(this, 'collapsed', null, this._onCollapsedChange, true);
+    addObserver(this, 'collapsedSize', null, this._updateCollapsedSize, true);
+    addObserver(this, 'expandedSize', null, this._updateExpandedSize, true);
   }
 }

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -1,7 +1,7 @@
 import { classNameBindings, layout as templateLayout } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
 import { alias, and, equal, gt, notEmpty, or } from '@ember/object/computed';
 import { action, computed, defineProperty } from '@ember/object';
+import { addObserver } from '@ember/object/observers';
 import { scheduleOnce } from '@ember/runloop';
 import { assert, deprecate, runInDebug } from '@ember/debug';
 import { isBlank, typeOf } from '@ember/utils';
@@ -1133,6 +1133,9 @@ export default class FormElement extends FormGroup {
         );
       });
     });
+
+    addObserver(this, 'hasFeedback', null, this.adjustFeedbackIcons, true);
+    addObserver(this, 'formLayout', null, this.adjustFeedbackIcons, true);
   }
 
   /*
@@ -1143,7 +1146,6 @@ export default class FormElement extends FormGroup {
    *  with an add-on on the right. [...] For input groups, adjust the right
    *  value to an appropriate pixel value depending on the width of your addon.
    */
-  @observes('hasFeedback', 'formLayout')
   adjustFeedbackIcons() {
     scheduleOnce('afterRender', this, this._adjustFeedbackIcons);
   }

--- a/addon/components/base/bs-modal.js
+++ b/addon/components/base/bs-modal.js
@@ -1,7 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
 import { action, computed } from '@ember/object';
 import { not } from '@ember/object/computed';
+import { addObserver } from '@ember/object/observers';
 import { assert } from '@ember/debug';
 import Component from '@ember/component';
 import { bind, next, schedule } from '@ember/runloop';
@@ -701,7 +701,6 @@ export default class Modal extends Component {
     this.resetScrollbar();
   }
 
-  @observes('isOpen')
   _observeOpen() {
     if (this.get('isOpen')) {
       this.show();
@@ -724,5 +723,7 @@ export default class Modal extends Component {
       fade,
       destinationElement: getDestinationElement(this)
     });
+
+    addObserver(this, 'isOpen', null, this._observeOpen, true);
   }
 }

--- a/addon/components/base/bs-tab/pane.js
+++ b/addon/components/base/bs-tab/pane.js
@@ -1,6 +1,6 @@
 import { classNameBindings, classNames, layout as templateLayout } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
 import { computed } from '@ember/object';
+import { addObserver } from '@ember/object/observers';
 import Component from '@ember/component';
 import { scheduleOnce } from '@ember/runloop';
 import layout from 'ember-bootstrap/templates/components/bs-tab/pane';
@@ -167,7 +167,6 @@ export default class TabPane extends Component.extend(ComponentChild) {
     }
   }
 
-  @observes('isActive')
   _showHide() {
     if (this.get('isActive')) {
       this.show();
@@ -183,7 +182,10 @@ export default class TabPane extends Component.extend(ComponentChild) {
 
   init() {
     super.init(...arguments);
+
     // isActive comes from parent component, so only available after render...
     scheduleOnce('afterRender', this, this._setActive);
+
+    addObserver(this, 'isActive', null, this._showHide, true);
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -95,6 +95,16 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-classic',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'application-template-wrapper': true,
+              'default-async-observers': false,
+              'template-only-glimmer-components': false
+            })
+          }
+        },
+        {
           name: 'fastboot-tests',
           command: 'ember test --filter FastBoot',
           npm: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -76,7 +76,7 @@ module.exports = function() {
           name: 'ember-default',
           npm: {
             devDependencies: {
-            'bootstrap': bootstrapVersion
+              'bootstrap': bootstrapVersion
             }
           }
         },
@@ -98,10 +98,16 @@ module.exports = function() {
           name: 'ember-classic',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'application-template-wrapper': true,
+              // TODO: tests fail if optional feature application-template-wrapper is enabled
+              // 'application-template-wrapper': true,
               'default-async-observers': false,
               'template-only-glimmer-components': false
             })
+          },
+          npm: {
+            devDependencies: {
+              'bootstrap': bootstrapVersion
+            }
           }
         },
         {

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,4 +1,6 @@
 {
+  "application-template-wrapper": false,
+  "default-async-observers": true,
   "jquery-integration": false,
-  "application-template-wrapper": false
+  "template-only-glimmer-components": true
 }


### PR DESCRIPTION
Adds support for optional feature `default-async-observers: true` by explicitly setting all observers to sync, which must not be run async.

It also enables optional feature `template-only-glimmer-components` for testing. It was already supported. Only changed it to prevent a regression.

Adds an additional ember try scenario that ensures it's working for the opposite optional feature configuration. This is similar to the ember-classic scenario, which is part of Ember CLI's blueprints since 3.15.

Closes #939
Superseds #945