### PR TITLE
test scenario expects closeButton to be false

### DIFF
--- a/tests/integration/components/bs-modal/header-test.js
+++ b/tests/integration/components/bs-modal/header-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | bs-modal/header', function(hooks) {
   });
 
   test('close button can be removed in yield block form', async function(assert) {
-    await render(hbs`{{#bs-modal/header as |header|}}<div id="custom">Test</div>{{/bs-modal/header}}`);
+    await render(hbs`{{#bs-modal/header closeButton=false as |header|}}<div id="custom">Test</div>{{/bs-modal/header}}`);
 
     assert.dom('.modal-header div#custom').exists({ count: 1 }, 'Modal header custom block.');
     assert.equal(this.element.querySelector('.modal-header #custom').innerHTML.trim(), 'Test', 'Block content is shown.');


### PR DESCRIPTION
`closeButton` defaults to `true` and isn't different for block mode or not. Test scenario for inline mode, which is just one test above, passes `closebutton=false` as it should be. I don't have any idea why the test was passing without `closeButton=false` but it was failing after refactoring to angle bracket invocation: https://github.com/kaliber5/ember-bootstrap/pull/966#discussion_r365409274