### PR TITLE
add template linting for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     }
   },
   plugins: [
-    'ember'
+    'ember',
+    'hbs'
   ],
   extends: [
     'eslint:recommended',
@@ -20,7 +21,8 @@ module.exports = {
   },
   rules: {
     'ember/no-jquery': 'error',
-    'ember/no-observers': 'warn'
+    'ember/no-observers': 'warn',
+    'hbs/check-hbs-template-literals': 'error'
   },
   overrides: [
     // node files

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.4.0",
     "eslint-plugin-ember": "^7.7.1",
+    "eslint-plugin-hbs": "^1.0.0",
     "eslint-plugin-node": "^10.0.0",
     "execa": "^2.0.0",
     "glob": "^7.1.1",

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -522,35 +522,36 @@ module('Integration | Component | bs-form/element', function(hooks) {
         return prev;
       }, {});
       this.setProperties(resetProps);
-      await render(hbs`<BsForm::element @formLayout={{this.formLayout}} as |el|>
-        <el.control
-          name={{this.name}}
-          required={{this.required}}
-          readonly={{this.readonly}}
-          placeholder={{this.placeholder}}
-          disabled={{this.disabled}}
-          autofocus={{this.autofocus}}
-          size={{this.size}}
-          tabindex={{this.tabindex}}
-          minlength={{this.minlength}}
-          maxlength={{this.maxlength}}
-          min={{this.min}}
-          max={{this.max}}
-          pattern={{this.pattern}}
-          accept={{this.accept}}
-          autocomplete={{this.autocomplete}}
-          autocapitalize={{this.autocapitalize}}
-          autocorrect={{this.autocorrect}}
-          autosave={{this.autosave}}
-          inputmode={{this.inputmode}}
-          multiple={{this.multiple}}
-          step={{this.step}}
-          form={{this.form}}
-          spellcheck={{this.spellcheck}}
-          title={{this.title}}
-        />
+      await render(hbs`
+        <BsForm::element @formLayout={{this.formLayout}} as |el|>
+          <el.control
+            name={{this.name}}
+            required={{this.required}}
+            readonly={{this.readonly}}
+            placeholder={{this.placeholder}}
+            disabled={{this.disabled}}
+            autofocus={{this.autofocus}}
+            size={{this.size}}
+            tabindex={{this.tabindex}}
+            minlength={{this.minlength}}
+            maxlength={{this.maxlength}}
+            min={{this.min}}
+            max={{this.max}}
+            pattern={{this.pattern}}
+            accept={{this.accept}}
+            autocomplete={{this.autocomplete}}
+            autocapitalize={{this.autocapitalize}}
+            autocorrect={{this.autocorrect}}
+            autosave={{this.autosave}}
+            inputmode={{this.inputmode}}
+            multiple={{this.multiple}}
+            step={{this.step}}
+            form={{this.form}}
+            spellcheck={{this.spellcheck}}
+            title={{this.title}}
+          />
         </BsForm::element>
-      />`);
+      `);
 
       for (let attribute in supportedInputAttributes) {
         assert.equal(this.element.querySelector('input').getAttribute(attribute), undefined, `input attribute ${attribute} is undefined [${formLayout}]`);
@@ -613,29 +614,30 @@ module('Integration | Component | bs-form/element', function(hooks) {
         return prev;
       }, {});
       this.setProperties(resetProps);
-      await render(hbs`<BsForm::element @formLayout={{this.formLayout}} @controlType="textarea" as |el|>
-        <el.control
-          name={{this.name}}
-          rows={{this.rows}}
-          cols={{this.cols}}
-          required={{this.required}}
-          readonly={{this.readonly}}
-          placeholder={{this.placeholder}}
-          disabled={{this.disabled}}
-          autofocus={{this.autofocus}}
-          tabindex={{this.tabindex}}
-          minlength={{this.minlength}}
-          maxlength={{this.maxlength}}
-          autocomplete={{this.autocomplete}}
-          autocapitalize={{this.autocapitalize}}
-          autocorrect={{this.autocorrect}}
-          form={{this.form}}
-          spellcheck={{this.spellcheck}}
-          wrap={{this.wrap}}
-          title={{this.title}}
-         />
-       </BsForm::element>
-      />`);
+      await render(hbs`
+        <BsForm::element @formLayout={{this.formLayout}} @controlType="textarea" as |el|>
+          <el.control
+            name={{this.name}}
+            rows={{this.rows}}
+            cols={{this.cols}}
+            required={{this.required}}
+            readonly={{this.readonly}}
+            placeholder={{this.placeholder}}
+            disabled={{this.disabled}}
+            autofocus={{this.autofocus}}
+            tabindex={{this.tabindex}}
+            minlength={{this.minlength}}
+            maxlength={{this.maxlength}}
+            autocomplete={{this.autocomplete}}
+            autocapitalize={{this.autocapitalize}}
+            autocorrect={{this.autocorrect}}
+            form={{this.form}}
+            spellcheck={{this.spellcheck}}
+            wrap={{this.wrap}}
+            title={{this.title}}
+          />
+        </BsForm::element>
+      `);
 
       for (let attribute in supportedTextareaAttributes) {
         assert.equal(this.element.querySelector('textarea').getAttribute(attribute), undefined, `textarea attribute ${attribute} is undefined [${formLayout}]`);
@@ -690,18 +692,19 @@ module('Integration | Component | bs-form/element', function(hooks) {
         return prev;
       }, {});
       this.setProperties(resetProps);
-      await render(hbs`<BsForm::element @controlType="checkbox" @formLayout={{this.formLayout}} as |el|>
-        <el.control
-          name={{this.name}}
-          required={{this.required}}
-          disabled={{this.disabled}}
-          autofocus={{this.autofocus}}
-          tabindex={{this.tabindex}}
-          form={{this.form}}
-          title={{this.title}}
-         />
-       </BsForm::element>
-      />`);
+      await render(hbs`
+        <BsForm::element @controlType="checkbox" @formLayout={{this.formLayout}} as |el|>
+          <el.control
+            name={{this.name}}
+            required={{this.required}}
+            disabled={{this.disabled}}
+            autofocus={{this.autofocus}}
+            tabindex={{this.tabindex}}
+            form={{this.form}}
+            title={{this.title}}
+          />
+        </BsForm::element>
+      `);
 
       for (let attribute in supportedCheckboxAttributes) {
         assert.equal(this.element.querySelector('input').getAttribute(attribute), undefined, `checkbox attribute ${attribute} is undefined [${formLayout}]`);
@@ -755,18 +758,19 @@ module('Integration | Component | bs-form/element', function(hooks) {
         return prev;
       }, {});
       this.setProperties(resetProps);
-      await render(hbs`<BsForm::element @controlType="radio" @formLayout={{this.formLayout}} @options={{this.options}} as |el|>
-        <el.control
-          name={{this.name}}
-          required={{this.required}}
-          disabled={{this.disabled}}
-          autofocus={{this.autofocus}}
-          tabindex={{this.tabindex}}
-          form={{this.form}}
-          title={{this.title}}
-        />
+      await render(hbs`
+        <BsForm::element @controlType="radio" @formLayout={{this.formLayout}} @options={{this.options}} as |el|>
+          <el.control
+            name={{this.name}}
+            required={{this.required}}
+            disabled={{this.disabled}}
+            autofocus={{this.autofocus}}
+            tabindex={{this.tabindex}}
+            form={{this.form}}
+            title={{this.title}}
+          />
         </BsForm::element>
-      />`);
+      `);
 
       for (let attribute in supportedCheckboxAttributes) {
         assert.equal(this.element.querySelector('input').getAttribute(attribute), undefined, `checkbox attribute ${attribute} is undefined [${formLayout}]`);

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -124,9 +124,13 @@ module('Integration | Component | bs-popover', function(hooks) {
     this.set('hide', hideAction);
     let hiddenAction = this.spy();
     this.set('hidden', hiddenAction);
-    await render(
-      hbs`<div id="target"><BsPopover @visible={{true}} @onHide={{action hide}} @onHidden={{action hidden}} as |po|><div id="hide" {{action po.close}}>Hide</div></BsPopover></div>`
-    );
+    await render(hbs`
+      <div id="target">
+        <BsPopover @visible={{true}} @onHide={{action hide}} @onHidden={{action hidden}} as |po|>
+          <div id="hide" {{action po.close}} role="button">Hide</div>
+        </BsPopover>
+      </div>
+    `);
     await click('#hide');
     assert.ok(hideAction.calledOnce, 'hide action has been called');
     assert.ok(hiddenAction.calledOnce, 'hidden action was called');
@@ -134,9 +138,13 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   test('click-initiated close action does not interfere with click-to-open', async function(assert) {
-    await render(
-      hbs`<div id="target"><BsPopover as |po|><div id="hide" onclick={{action po.close}}>Hide</div></BsPopover></div>`
-    );
+    await render(hbs`
+      <div id="target">
+        <BsPopover as |po|>
+          <div id="hide" onclick={{action po.close}} role="button">Hide</div>
+        </BsPopover>
+      </div>
+    `);
     await click('#target');
     assert.dom('.popover').exists('popover is visible');
     await click('#hide');
@@ -146,9 +154,12 @@ module('Integration | Component | bs-popover', function(hooks) {
   });
 
   test('click-initiated close action does not interfere with click-to-open when wormholed', async function(assert) {
-    await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="target"><BsPopover as |po|><div id="hide" onclick={{action po.close}}>Hide</div></BsPopover></div>`
-    );
+    await render(hbs`
+      <div id="ember-bootstrap-wormhole"></div>
+      <div id="target">
+        <BsPopover as |po|><div id="hide" onclick={{action po.close}} role="button">Hide</div></BsPopover>
+      </div>
+    `);
     await click('#target');
     assert.dom('.popover').exists('popover is visible');
     await click('#hide');
@@ -231,7 +242,8 @@ module('Integration | Component | bs-popover', function(hooks) {
 
   test('it passes accessibility checks', async function (assert) {
     await render(hbs`
-      <button>Test
+      <button>
+        Test
         <BsPopover @title="dummy title" @visible={{true}}>
           template block text
         </BsPopover>

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -24,16 +24,16 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('it yields expected values', async function(assert) {
     await render(hbs`
-      {{#bs-tab fade=false as |tab|}}
-        {{#tab.pane id="pane1" title="Tab 1"}}
+      <BsTab @fade={{false}} as |tab|>
+        <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @id="pane2" @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
+        </tab.pane>
         <div id="activeId">{{tab.activeId}}</div>
-        <div id="switch" {{action tab.select "pane2"}}></div>
-      {{/bs-tab}}
+        <div id="switch" {{action tab.select "pane2"}} role="button"></div>
+      </BsTab>
     `);
 
     assert.dom('.tab-pane').exists({ count: 2 }, 'yields tab pane component');
@@ -47,18 +47,18 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('it yields expected values [customTabs=true]', async function(assert) {
     await render(hbs`
-      {{#bs-tab fade=false customTabs=true as |tab|}}
+      <BsTab @fade={{false}} @customTabs={{true}} as |tab|>
         <div class="tab-content">
-        {{#tab.pane id="pane1" title="Tab 1"}}
-          tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
-          tabcontent 2
-        {{/tab.pane}}
-        <div id="activeId">{{tab.activeId}}</div>
-        <div id="switch" {{action tab.select "pane2"}}></div>
+          <tab.pane @id="pane1" @title="Tab 1">
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id="pane2" @title="Tab 2">
+            tabcontent 2
+          </tab.pane>
+          <div id="activeId">{{tab.activeId}}</div>
+          <div id="switch" {{action tab.select "pane2"}} role="button"></div>
         </div>
-      {{/bs-tab}}
+      </BsTab>
     `);
 
     assert.dom('.tab-pane').exists({ count: 2 }, 'yields tab pane component');
@@ -72,14 +72,14 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('it generates tab navigation', async function(assert) {
     await render(hbs`
-      {{#bs-tab as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assert.dom('ul.nav.nav-tabs').exists({ count: 1 }, 'has tabs navigation');
@@ -90,11 +90,11 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('tabs have proper aria roles', async function(assert) {
     await render(hbs`
-      {{#bs-tab as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assert.dom('ul.nav.nav-tabs').hasAttribute('role', 'tablist');
@@ -107,14 +107,14 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('first tab is active by default', async function(assert) {
     await render(hbs`
-      {{#bs-tab fade=false as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab @fade={{false}} as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assertActiveTab.call(this, assert, 0, true);
@@ -124,14 +124,14 @@ module('Integration | Component | bs-tab', function(hooks) {
   test('activeId activates tabs', async function(assert) {
     this.set('paneId', 'pane1');
     await render(hbs`
-      {{#bs-tab fade=false activeId=paneId as |tab|}}
-        {{#tab.pane id="pane1" title="Tab 1"}}
+      <BsTab @fade={{false}} @activeId={{paneId}} as |tab|>
+        <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @id="pane2" @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assertActiveTab.call(this, assert, 0, true);
@@ -145,20 +145,20 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('tab navigation is groupable', async function(assert) {
     await render(hbs`
-      {{#bs-tab as |tab|}}
-        {{#tab.pane title="Tab 1"}}
-            tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
-            tabcontent 2
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 3" groupTitle="Dropdown"}}
-            tabcontent 3
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 4" groupTitle="Dropdown"}}
-            tabcontent 4
-        {{/tab.pane}}
-      {{/bs-tab}}
+      <BsTab as |tab|>
+        <tab.pane @title="Tab 1">
+          tabcontent 1
+        </tab.pane>
+        <tab.pane @title="Tab 2">
+          tabcontent 2
+        </tab.pane>
+        <tab.pane @title="Tab 3" @groupTitle="Dropdown">
+          tabcontent 3
+        </tab.pane>
+        <tab.pane @title="Tab 4" @groupTitle="Dropdown">
+          tabcontent 4
+        </tab.pane>
+      </BsTab>
     `);
 
     assert.dom('ul.nav.nav-tabs').exists({ count: 1 }, 'has tabs navigation');
@@ -176,14 +176,14 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('customTabs disables tab navigation generation', async function(assert) {
     await render(hbs`
-      {{#bs-tab customTabs=true as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab @customTabs={{true}} as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assert.dom('ul.nav.nav-tabs').doesNotExist('has no tabs navigation');
@@ -191,14 +191,14 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('type sets tab navigation type', async function(assert) {
     await render(hbs`
-      {{#bs-tab type="pills" as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab @type="pills" as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     assert.dom('ul.nav.nav-pills').exists({ count: 1 }, 'has pills navigation');
@@ -210,14 +210,14 @@ module('Integration | Component | bs-tab', function(hooks) {
     this.actions.change = action;
 
     await render(hbs`
-      {{#bs-tab fade=false onChange=(action "change") as |tab|}}
-        {{#tab.pane id="pane1" title="Tab 1"}}
+      <BsTab @fade={{false}} @onChange={{action "change"}} as |tab|>
+        <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @id="pane2" @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     await click('ul.nav.nav-tabs li:nth-child(2) a');
@@ -233,14 +233,14 @@ module('Integration | Component | bs-tab', function(hooks) {
     this.actions.change = action;
 
     await render(hbs`
-      {{#bs-tab fade=false onChange=(action "change") as |tab|}}
-        {{#tab.pane id="pane1" title="Tab 1"}}
+      <BsTab @fade={{false}} @onChange={{action "change"}} as |tab|>
+        <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @id="pane2" @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     await click('ul.nav.nav-tabs li:nth-child(2) a');
@@ -253,14 +253,14 @@ module('Integration | Component | bs-tab', function(hooks) {
   test('changing active tab does not change public activeId property (DDAU)', async function(assert) {
     this.set('paneId', 'pane1');
     await render(hbs`
-      {{#bs-tab fade=false activeId=paneId as |tab|}}
-        {{#tab.pane id="pane1" title="Tab 1"}}
+      <BsTab @fade={{false}} @activeId={{paneId}} as |tab|>
+        <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane id="pane2" title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @id="pane2" @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
     await click('ul.nav.nav-tabs li:nth-child(2) a');
     assert.equal(this.get('paneId'), 'pane1', 'Does not modify public activeId property');
@@ -268,14 +268,14 @@ module('Integration | Component | bs-tab', function(hooks) {
 
   test('it passes accessibility checks', async function (assert) {
     await render(hbs`
-      {{#bs-tab as |tab|}}
-        {{#tab.pane title="Tab 1"}}
+      <BsTab as |tab|>
+        <tab.pane @title="Tab 1">
           tabcontent 1
-        {{/tab.pane}}
-        {{#tab.pane title="Tab 2"}}
+        </tab.pane>
+        <tab.pane @title="Tab 2">
           tabcontent 2
-        {{/tab.pane}}
-      {{/bs-tab}}
+        </tab.pane>
+      </BsTab>
     `);
 
     await a11yAudit({

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -75,9 +75,11 @@ module('Integration | Component | bs-tooltip', function(hooks) {
   });
 
   test('it shows visible tooltip with block content', async function(assert) {
-    await render(hbs`<BsTooltip @visible={{true}}>
-      BLOCK
-      </BsTooltip>`);
+    await render(hbs`
+      <BsTooltip @visible={{true}}>
+        BLOCK
+      </BsTooltip>
+    `);
 
     assert.dom('.tooltip').exists({ count: 1 }, 'tooltip is visible');
     assert.dom('.tooltip .tooltip-inner').hasText('BLOCK');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5738,6 +5738,13 @@ eslint-plugin-es@^2.0.0:
     eslint-utils "^1.4.2"
     regexpp "^3.0.0"
 
+eslint-plugin-hbs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-hbs/-/eslint-plugin-hbs-1.0.0.tgz#4facf1031a8d83d5fba1a3e1bd1dea837fb91248"
+  integrity sha512-UaJYgG1xP6Mr/VuPO9G/tbReiavs8lmTUInwbomQ+FtA7C22AlDZK08FH4aRloKo70GyeJLm+SYSF6QtM/QZhQ==
+  dependencies:
+    requireindex "^1.2.0"
+
 eslint-plugin-node@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6"
@@ -10830,6 +10837,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Also converts a test to angle bracket component invocation which was missed in #966.

Unstable Ember Language Server (UELS) for VSCode reports that template linting errors also if not included in CI. This ensures that template linting is done both in CI as well as VSCode using UELS. Better developer experience. :smile: