### PR TITLE
deprecate required arg of <BsForm::Element>

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -1093,6 +1093,7 @@ export default class FormElement extends FormGroup {
         ['name', 'foo'],
         ['pattern', '^[0-9]{5}$'],
         ['placeholder', 'foo'],
+        ['required', true],
         ['rows', '10'],
         ['spellcheck', true],
         ['step', '2'],

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -94,7 +94,7 @@ const deprecatedAttributeBindings = [].concat(
   Object.keys(supportedCheckboxAttributes),
   Object.keys(supportedRadioAttributes),
 ).filter((attr) => {
-  return !['disabled', 'readonly', 'required'].includes(attr);
+  return !['disabled', 'readonly'].includes(attr);
 });
 
 module('Integration | Component | bs-form/element', function(hooks) {
@@ -838,6 +838,7 @@ module('Integration | Component | bs-form/element', function(hooks) {
   test('required property propagates', async function(assert) {
     await render(hbs`{{bs-form/element label="myLabel" required=true}}`);
     assert.dom('.form-group').hasClass('is-required', 'component has is-required class');
+    assert.deprecationsInclude(`Argument required of <element> component yielded by <BsForm> is deprecated.`);
   });
 
   test('disabled property propagates', async function(assert) {


### PR DESCRIPTION
The `required` argument also adds an `.is-required` class: https://github.com/kaliber5/ember-bootstrap/blob/fd3a1cbd0d9ecf176c26d8de36755d86231ef01d/addon/components/base/bs-form/element.js#L394

To be honest I have no idea why this was added. Wasn't able to find that class in Bootstrap docs. The class name binding is their since nearly ever. It was added in March 2016 by this commit https://github.com/kaliber5/ember-bootstrap/commit/1199dd639aac24e71b123189776f75447160642a, which was part of #775. Not sure if we should mention this behavior explicitly in the deprecation message...