### PR TITLE
Deprecate readonly and disabled args of bs form element

### DIFF
--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -391,7 +391,7 @@ const nonDefaultLayouts = A([
   @public
 */
 @templateLayout(layout)
-@classNameBindings('disabled:disabled', 'required:is-required', 'isValidating')
+@classNameBindings('__disabled:disabled', 'required:is-required', 'isValidating')
 export default class FormElement extends FormGroup {
   /**
    * Text to display within a `<label>` tag.
@@ -846,10 +846,10 @@ export default class FormElement extends FormGroup {
     'showValidation',
     'showModelValidation',
     'isValidating',
-    'disabled'
+    '__disabled'
   )
   get validation() {
-    if (!this.get('showValidation') || !this.get('hasValidator') || this.get('isValidating') || this.get('disabled')) {
+    if (!this.get('showValidation') || !this.get('hasValidator') || this.get('isValidating') || this.get('__disabled')) {
       return null;
     } else if (this.get('showModelValidation')) {
       /* The display of model validation messages has been triggered */
@@ -968,6 +968,44 @@ export default class FormElement extends FormGroup {
   }
 
   /**
+   * Interal argument to set disabled class and disabled HTML attribute by
+   * `<BsForm>`, which can not use angle bracket invocation syntax /
+   * splatattributes due to limitations of `{{component}}` helper.
+   *
+   * If both the deprecated public API `@disabled` and private API `@_disabled` are
+   * set, `@disabled` wins.
+   *
+   * @property _disabled
+   * @type {Boolean}
+   * @private
+   */
+  _disabled;
+
+  @computed('disabled', '_disabled')
+  get __disabled() {
+    return this.get('disabled') !== undefined ? this.get('disabled') : this.get('_disabled');
+  }
+
+  /**
+   * Interal argument to set readonly HTML attribute of control by `<BsForm>`,
+   * which can not use angle bracket invocation syntax / splatattributes due to
+   * limitations of `{{component}}` helper.
+   *
+   * If both the deprecated public API `@readonly` and private API `@_readonly`
+   * are set, `@readonly` wins.
+   *
+   * @property _readonly
+   * @type {Boolean}
+   * @private
+   */
+  _readonly;
+
+  @computed('readonly', '_readonly')
+  get __readonly() {
+    return this.get('readonly') !== undefined ? this.get('readonly') : this.get('_readonly');
+  }
+
+  /**
    * @property errorsComponent
    * @type {String}
    * @private
@@ -1083,6 +1121,7 @@ export default class FormElement extends FormGroup {
         ['autosave', 'someuniquevalue'],
         ['cols', '10'],
         ['controlSize:size', '10'],
+        ['disabled', true],
         ['form', 'myform'],
         ['inputmode', 'tel'],
         ['max', '5'],
@@ -1094,6 +1133,7 @@ export default class FormElement extends FormGroup {
         ['pattern', '^[0-9]{5}$'],
         ['placeholder', 'foo'],
         ['required', true],
+        ['readonly', true],
         ['rows', '10'],
         ['spellcheck', true],
         ['step', '2'],

--- a/addon/components/base/bs-form/element.js
+++ b/addon/components/base/bs-form/element.js
@@ -979,6 +979,7 @@ export default class FormElement extends FormGroup {
    * @type {Boolean}
    * @private
    */
+  @defaultValue
   _disabled;
 
   @computed('disabled', '_disabled')
@@ -998,6 +999,7 @@ export default class FormElement extends FormGroup {
    * @type {Boolean}
    * @private
    */
+  @defaultValue
   _readonly;
 
   @computed('readonly', '_readonly')

--- a/addon/templates/components/common/bs-form.hbs
+++ b/addon/templates/components/common/bs-form.hbs
@@ -5,8 +5,8 @@
       formLayout=this.formLayout
       horizontalLabelGridClass=this.horizontalLabelGridClass
       showAllValidations=this.showAllValidations
-      disabled=this.disabled
-      readonly=this.readonly
+      _disabled=this.disabled
+      _readonly=this.readonly
       onChange=this.elementChanged
       _onChange=this.resetSubmissionState
     )

--- a/addon/templates/components/common/bs-form/element.hbs
+++ b/addon/templates/components/common/bs-form/element.hbs
@@ -35,8 +35,8 @@
       label=@label
       placeholder=placeholder
       autofocus=autofocus
-      disabled=disabled
-      readonly=readonly
+      disabled=__disabled
+      readonly=__readonly
       required=required
       controlSize=controlSize
       tabindex=tabindex

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -93,9 +93,7 @@ const deprecatedAttributeBindings = [].concat(
   Object.keys(supportedTextareaAttributes),
   Object.keys(supportedCheckboxAttributes),
   Object.keys(supportedRadioAttributes),
-).filter((attr) => {
-  return !['disabled', 'readonly'].includes(attr);
-});
+);
 
 module('Integration | Component | bs-form/element', function(hooks) {
   setupRenderingTest(hooks);
@@ -833,17 +831,6 @@ module('Integration | Component | bs-form/element', function(hooks) {
         }
       }
     }
-  });
-
-  test('required property propagates', async function(assert) {
-    await render(hbs`{{bs-form/element label="myLabel" required=true}}`);
-    assert.dom('.form-group').hasClass('is-required', 'component has is-required class');
-    assert.deprecationsInclude(`Argument required of <element> component yielded by <BsForm> is deprecated.`);
-  });
-
-  test('disabled property propagates', async function(assert) {
-    await render(hbs`{{bs-form/element label="myLabel" disabled=true}}`);
-    assert.dom('.form-group').hasClass('disabled', 'component has disabled class');
   });
 
   test('if invisibleLabel is true sr-only class is added to label', async function(assert) {


### PR DESCRIPTION
Open questions:

1. If `@disabled` is `true` a `disabled` class is set on the `.form-group`: https://github.com/kaliber5/ember-bootstrap/blob/fd3a1cbd0d9ecf176c26d8de36755d86231ef01d/addon/components/base/bs-form/element.js#L394 This is not mentioned in the deprecation message. But I'm not sure if it should be. I wasn't able to find the reason for setting that class in the first place. I wasn't able to find a `.disabled` class in Boostrap 4 docs at all and in Bootstrap 3 docs I have only seen it for checkboxes and radios - and in that cases it was not set on the same element as the `.form-group`.

2. Should `@disabled` and `@readonly` arguments of `<BsForm>` are deprecated as well? They allow setting the `disabled` / `readonly` HTML attributes for all controls of a form. I'm tending to remove that feature but would like to get another opinion before doing it.