### PR TITLE
Remove usage of `this.get()`

### DIFF
--- a/addon/components/bs-accordion.js
+++ b/addon/components/bs-accordion.js
@@ -83,11 +83,11 @@ export default class Accordion extends Component {
 
   @action
   doChange(newValue) {
-    let oldValue = this.get('isSelected');
+    let oldValue = this.isSelected;
     if (oldValue === newValue) {
       newValue = null;
     }
-    if (this.get('onChange')(newValue, oldValue) !== false) {
+    if (this.onChange(newValue, oldValue) !== false) {
       this.set('isSelected', newValue);
     }
   }

--- a/addon/components/bs-accordion/item.js
+++ b/addon/components/bs-accordion/item.js
@@ -70,7 +70,7 @@ export default class AccordionItem extends Component {
    */
   @(computed('value', 'selected').readOnly())
   get collapsed() {
-    return this.get('value') !== this.get('selected');
+    return this.value !== this.selected;
   }
 
   /**

--- a/addon/components/bs-accordion/item/title.js
+++ b/addon/components/bs-accordion/item/title.js
@@ -38,8 +38,8 @@ export default class AccordionItemTitle extends Component {
   @action
   handleClick(e) {
     e.preventDefault();
-    if (!this.get('disabled')) {
-      this.get('onClick')();
+    if (!this.disabled) {
+      this.onClick();
     }
   }
 }

--- a/addon/components/bs-alert.js
+++ b/addon/components/bs-alert.js
@@ -54,7 +54,7 @@ export default class Alert extends Component {
    * @private
    */
   @defaultValue
-  hidden = !this.get('_visible');
+  hidden = !this._visible;
 
   /**
    * This property controls if the alert should be visible. If false it might still be in the DOM until the fade animation
@@ -169,7 +169,7 @@ export default class Alert extends Component {
 
   @action
   dismiss() {
-    if (this.get('onDismiss')() !== false) {
+    if (this.onDismiss() !== false) {
       this.set('_visible', false);
     }
   }
@@ -192,21 +192,21 @@ export default class Alert extends Component {
    * @private
    */
   hide() {
-    if (this.get('usesTransition')) {
+    if (this.usesTransition) {
       later(this, function() {
-        if (!this.get('isDestroyed')) {
+        if (!this.isDestroyed) {
           this.set('hidden', true);
-          this.get('onDismissed')();
+          this.onDismissed();
         }
-      }, this.get('fadeDuration'));
+      }, this.fadeDuration);
     } else {
       this.set('hidden', true);
-      this.get('onDismissed')();
+      this.onDismissed();
     }
   }
 
   _observeIsVisible() {
-    if (this.get('_visible')) {
+    if (this._visible) {
       this.show();
     } else {
       this.hide();

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -181,13 +181,13 @@ export default class ButtonGroup extends Component {
   buttonPressed(pressedValue) {
     let newValue;
 
-    if (this.get('isRadio')) {
+    if (this.isRadio) {
       newValue = pressedValue;
     } else {
-      if (!isArray(this.get('value'))) {
+      if (!isArray(this.value)) {
         newValue = A([pressedValue]);
       } else {
-        newValue = A(this.get('value').slice());
+        newValue = A(this.value.slice());
         if (newValue.includes(pressedValue)) {
           newValue.removeObject(pressedValue);
         } else {
@@ -196,6 +196,6 @@ export default class ButtonGroup extends Component {
       }
     }
 
-    this.get('onChange')(newValue);
+    this.onChange(newValue);
   }
 }

--- a/addon/components/bs-button-group/button.js
+++ b/addon/components/bs-button-group/button.js
@@ -35,8 +35,8 @@ export default class ButtonGroupButton extends Button {
    */
   @(computed('buttonGroupType', 'groupValue.[]', 'value').readOnly())
   get active() {
-    let { value, groupValue } = this.getProperties('value', 'groupValue');
-    if (this.get('buttonGroupType') === 'radio') {
+    let { value, groupValue } = this;
+    if (this.buttonGroupType === 'radio') {
       return value === groupValue;
     } else {
       if (isArray(groupValue)) {

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -162,11 +162,11 @@ export default class Button extends Component {
 
   @computed('_disabled', 'isPending', 'preventConcurrency')
   get __disabled() {
-    if (this.get('_disabled') !== null) {
-      return this.get('_disabled');
+    if (this._disabled !== null) {
+      return this._disabled;
     }
 
-    return this.get('isPending') && this.get('preventConcurrency');
+    return this.isPending && this.preventConcurrency;
   }
 
   /**
@@ -420,14 +420,14 @@ export default class Button extends Component {
 
   @observes('reset')
   resetObserver() {
-    if (this.get('reset')) {
+    if (this.reset) {
       scheduleOnce('actions', this, 'resetState');
     }
   }
 
   @computed('state', 'defaultText', 'pendingText', 'fulfilledText', 'rejectedText')
   get text() {
-    return this.getWithDefault(`${this.get('state')}Text`, this.get('defaultText'));
+    return this.getWithDefault(`${this.state}Text`, this.defaultText);
   }
 
   /**
@@ -436,23 +436,23 @@ export default class Button extends Component {
    */
   @action
   handleClick(e) {
-    let onClick = this.get('onClick');
-    let preventConcurrency = this.get('preventConcurrency');
+    let onClick = this.onClick;
+    let preventConcurrency = this.preventConcurrency;
 
     if (onClick === null || onClick === undefined) {
       return;
     }
 
-    if (!preventConcurrency || !this.get('isPending')) {
-      let promise = (onClick)(this.get('value'));
-      if (promise && typeof promise.then === 'function' && !this.get('isDestroyed')) {
+    if (!preventConcurrency || !this.isPending) {
+      let promise = (onClick)(this.value);
+      if (promise && typeof promise.then === 'function' && !this.isDestroyed) {
         this.set('state', 'pending');
         promise.then(() => {
-          if (!this.get('isDestroyed')) {
+          if (!this.isDestroyed) {
             this.set('state', 'fulfilled');
           }
         }, () => {
-          if (!this.get('isDestroyed')) {
+          if (!this.isDestroyed) {
             this.set('state', 'rejected');
           }
         }
@@ -460,7 +460,7 @@ export default class Button extends Component {
       }
     }
 
-    if (!this.get('bubble')) {
+    if (!this.bubble) {
       e.stopPropagation();
     }
   }

--- a/addon/components/bs-carousel.js
+++ b/addon/components/bs-carousel.js
@@ -81,7 +81,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    */
   @computed('wrap', 'currentIndex')
   get canTurnToLeft() {
-    return this.get('wrap') || this.get('currentIndex') > 0;
+    return this.wrap || this.currentIndex > 0;
   }
 
   /**
@@ -92,7 +92,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    */
   @computed('childSlides.length', 'wrap', 'currentIndex')
   get canTurnToRight() {
-    return this.get('wrap') || this.get('currentIndex') < this.get('childSlides.length') - 1;
+    return this.wrap || this.currentIndex < this.get('childSlides.length') - 1;
   }
 
   /**
@@ -120,19 +120,19 @@ export default class Carousel extends Component.extend(ComponentParent) {
   }
 
   _childSlidesObserver() {
-    let childSlides = this.get('childSlides');
+    let childSlides = this.childSlides;
     if (childSlides.length === 0) {
       return;
     }
     // Sets new current index
-    let currentIndex = this.get('currentIndex');
+    let currentIndex = this.currentIndex;
     if (currentIndex >= childSlides.length) {
       currentIndex = childSlides.length - 1;
       this.set('currentIndex', currentIndex);
     }
     // Automatic sliding
-    if (this.get('autoPlay')) {
-      this.get('waitIntervalToInitCycle').perform();
+    if (this.autoPlay) {
+      this.waitIntervalToInitCycle.perform();
     }
     // Initial slide state
     this.set('presentationState', null);
@@ -145,7 +145,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    * @private
    */
   @defaultValue
-  currentIndex = this.get('index');
+  currentIndex = this.index;
 
   /**
    * The current slide object that is going to be used by the nested slides components.
@@ -156,7 +156,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    */
   @(computed('childSlides', 'currentIndex').readOnly())
   get currentSlide() {
-    return this.get('childSlides').objectAt(this.get('currentIndex'));
+    return this.childSlides.objectAt(this.currentIndex);
   }
 
   /**
@@ -187,7 +187,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    */
   @(computed('childSlides', 'followingIndex').readOnly())
   get followingSlide() {
-    return this.get('childSlides').objectAt(this.get('followingIndex'));
+    return this.childSlides.objectAt(this.followingIndex);
   }
 
   /**
@@ -206,7 +206,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    */
   @observes('index')
   indexObserver() {
-    this.send('toSlide', this.get('index'));
+    this.send('toSlide', this.index);
   }
 
   /**
@@ -509,30 +509,30 @@ export default class Carousel extends Component.extend(ComponentParent) {
 
   @action
   toSlide(toIndex) {
-    if (this.get('currentIndex') === toIndex || this.get('shouldNotDoPresentation')) {
+    if (this.currentIndex === toIndex || this.shouldNotDoPresentation) {
       return;
     }
     this.assignClassNameControls(toIndex);
     this.setFollowingIndex(toIndex);
-    if (this.get('shouldRunAutomatically') === false || this.get('isMouseHovering')) {
-      this.get('transitioner').perform();
+    if (this.shouldRunAutomatically === false || this.isMouseHovering) {
+      this.transitioner.perform();
     } else {
-      this.get('cycle').perform();
+      this.cycle.perform();
     }
-    this.get('onSlideChanged')(toIndex);
+    this.onSlideChanged(toIndex);
   }
 
   @action
   toNextSlide() {
-    if (this.get('canTurnToRight')) {
-      this.send('toSlide', this.get('currentIndex') + 1);
+    if (this.canTurnToRight) {
+      this.send('toSlide', this.currentIndex + 1);
     }
   }
 
   @action
   toPrevSlide() {
-    if (this.get('canTurnToLeft')) {
-      this.send('toSlide', this.get('currentIndex') - 1);
+    if (this.canTurnToLeft) {
+      this.send('toSlide', this.currentIndex - 1);
     }
   }
 
@@ -543,7 +543,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    * @private
    */
   assignClassNameControls(toIndex) {
-    if (toIndex < this.get('currentIndex')) {
+    if (toIndex < this.currentIndex) {
       this.set('directionalClassName', 'right');
       this.set('orderClassName', 'prev');
     } else {
@@ -563,24 +563,24 @@ export default class Carousel extends Component.extend(ComponentParent) {
 
   @action
   handleMouseEnter() {
-    if (this.get('pauseOnMouseEnter')) {
+    if (this.pauseOnMouseEnter) {
       this.set('isMouseHovering', true);
-      this.get('cycle').cancelAll();
-      this.get('waitIntervalToInitCycle').cancelAll();
+      this.cycle.cancelAll();
+      this.waitIntervalToInitCycle.cancelAll();
     }
   }
 
   @action
   handleMouseLeave() {
     if (
-      this.get('pauseOnMouseEnter')
+      this.pauseOnMouseEnter
       && (
         this.get('transitioner.last') !== null
         || this.get('waitIntervalToInitCycle.last') !== null
       )
     ) {
       this.set('isMouseHovering', false);
-      this.get('waitIntervalToInitCycle').perform();
+      this.waitIntervalToInitCycle.perform();
     }
   }
 
@@ -588,7 +588,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
   handleKeyDown(e) {
     let code = e.keyCode || e.which;
     if (
-      this.get('keyboard') === false
+      this.keyboard === false
       || /input|textarea/i.test(e.target.tagName)
     ) {
       return;
@@ -611,7 +611,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    * @private
    */
   setFollowingIndex(toIndex) {
-    let slidesLengthMinusOne = this.get('childSlides').length - 1;
+    let slidesLengthMinusOne = this.childSlides.length - 1;
     if (toIndex > slidesLengthMinusOne) {
       this.set('followingIndex', 0);
     } else if (toIndex < 0) {
@@ -628,7 +628,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
    * @private
    */
   toAppropriateSlide() {
-    if (this.get('ltr')) {
+    if (this.ltr) {
       this.send('toNextSlide');
     } else {
       this.send('toPrevSlide');
@@ -640,6 +640,6 @@ export default class Carousel extends Component.extend(ComponentParent) {
    * @private
    */
   triggerChildSlidesObserver() {
-    this.get('childSlides');
+    this.childSlides;
   }
 }

--- a/addon/components/bs-carousel/slide.js
+++ b/addon/components/bs-carousel/slide.js
@@ -39,7 +39,7 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    */
   @(computed('currentSlide').readOnly())
   get isCurrentSlide() {
-    return this.get('currentSlide') === this;
+    return this.currentSlide === this;
   }
 
   /**
@@ -49,7 +49,7 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    */
   @(computed('followingSlide').readOnly())
   get isFollowingSlide() {
-    return this.get('followingSlide') === this;
+    return this.followingSlide === this;
   }
 
   /**
@@ -96,8 +96,8 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    */
   @observes('presentationState')
   presentationStateObserver() {
-    let presentationState = this.get('presentationState');
-    if (this.get('isCurrentSlide')) {
+    let presentationState = this.presentationState;
+    if (this.isCurrentSlide) {
       switch (presentationState) {
         case 'didTransition':
           this.currentSlideDidTransition();
@@ -107,7 +107,7 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
           break;
       }
     }
-    if (this.get('isFollowingSlide')) {
+    if (this.isFollowingSlide) {
       switch (presentationState) {
         case 'didTransition':
           this.followingSlideDidTransition();
@@ -124,7 +124,7 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    * @private
    */
   currentSlideDidTransition() {
-    this.set(this.get('directionalClassName'), false);
+    this.set(this.directionalClassName, false);
     this.set('active', false);
   }
 
@@ -135,7 +135,7 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
   currentSlideWillTransit() {
     this.set('active', true);
     next(this, function() {
-      this.set(this.get('directionalClassName'), true);
+      this.set(this.directionalClassName, true);
     });
   }
 
@@ -145,8 +145,8 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    */
   followingSlideDidTransition() {
     this.set('active', true);
-    this.set(this.get('directionalClassName'), false);
-    this.set(this.get('orderClassName'), false);
+    this.set(this.directionalClassName, false);
+    this.set(this.orderClassName, false);
   }
 
   /**
@@ -154,10 +154,10 @@ export default class CarouselSlide extends Component.extend(ComponentChild) {
    * @private
    */
   followingSlideWillTransit() {
-    this.set(this.get('orderClassName'), true);
+    this.set(this.orderClassName, true);
     next(this, function() {
       this.reflow();
-      this.set(this.get('directionalClassName'), true);
+      this.set(this.directionalClassName, true);
     });
   }
 

--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -50,7 +50,7 @@ export default class Collapse extends Component {
    * @private
    */
   @defaultValue
-  active = !this.get('collapsed');
+  active = !this.collapsed;
 
   @not('transitioning')
   collapse;
@@ -127,7 +127,7 @@ export default class Collapse extends Component {
   collapseSize = null;
 
   setCollapseSize(size) {
-    let dimension = this.get('collapseDimension');
+    let dimension = this.collapseDimension;
 
     assert(`collapseDimension must be either "width" or "height". ${dimension} given.`, ["width", "height"].indexOf(dimension) !== -1);
 
@@ -173,27 +173,27 @@ export default class Collapse extends Component {
    * @protected
    */
   show() {
-    this.get('onShow')();
+    this.onShow();
 
     this.setProperties({
       transitioning: true,
       active: true
     });
-    this.setCollapseSize(this.get('collapsedSize'));
+    this.setCollapseSize(this.collapsedSize);
 
-    transitionEnd(this._element, this.get('transitionDuration')).then(() => {
-      if (this.get('isDestroyed')) {
+    transitionEnd(this._element, this.transitionDuration).then(() => {
+      if (this.isDestroyed) {
         return;
       }
       this.set('transitioning', false);
-      if (this.get('resetSizeWhenNotCollapsing')) {
+      if (this.resetSizeWhenNotCollapsing) {
         this.setCollapseSize(null);
       }
-      this.get('onShown')();
+      this.onShown();
     });
 
     next(this, function() {
-      if (!this.get('isDestroyed')) {
+      if (!this.isDestroyed) {
         this.setCollapseSize(this.getExpandedSize('show'));
       }
     });
@@ -208,14 +208,14 @@ export default class Collapse extends Component {
    * @private
    */
   getExpandedSize(action) {
-    let expandedSize = this.get('expandedSize');
+    let expandedSize = this.expandedSize;
     if (isPresent(expandedSize)) {
       return expandedSize;
     }
 
     let collapseElement = this._element;
     let prefix = action === 'show' ? 'scroll' : 'offset';
-    let measureProperty = camelize(`${prefix}-${this.get('collapseDimension')}`);
+    let measureProperty = camelize(`${prefix}-${this.collapseDimension}`);
     return collapseElement[measureProperty];
   }
 
@@ -226,7 +226,7 @@ export default class Collapse extends Component {
    * @protected
    */
   hide() {
-    this.get('onHide')();
+    this.onHide();
 
     this.setProperties({
       transitioning: true,
@@ -234,27 +234,27 @@ export default class Collapse extends Component {
     });
     this.setCollapseSize(this.getExpandedSize('hide'));
 
-    transitionEnd(this._element, this.get('transitionDuration')).then(() => {
-      if (this.get('isDestroyed')) {
+    transitionEnd(this._element, this.transitionDuration).then(() => {
+      if (this.isDestroyed) {
         return;
       }
       this.set('transitioning', false);
-      if (this.get('resetSizeWhenNotCollapsing')) {
+      if (this.resetSizeWhenNotCollapsing) {
         this.setCollapseSize(null);
       }
-      this.get('onHidden')();
+      this.onHidden();
     });
 
     next(this, function() {
-      if (!this.get('isDestroyed')) {
-        this.setCollapseSize(this.get('collapsedSize'));
+      if (!this.isDestroyed) {
+        this.setCollapseSize(this.collapsedSize);
       }
     });
   }
 
   _onCollapsedChange() {
-    let collapsed = this.get('collapsed');
-    let active = this.get('active');
+    let collapsed = this.collapsed;
+    let active = this.active;
     if (collapsed !== active) {
       return;
     }
@@ -266,14 +266,14 @@ export default class Collapse extends Component {
   }
 
   _updateCollapsedSize() {
-    if (!this.get('resetSizeWhenNotCollapsing') && this.get('collapsed') && !this.get('collapsing')) {
-      this.setCollapseSize(this.get('collapsedSize'));
+    if (!this.resetSizeWhenNotCollapsing && this.collapsed && !this.collapsing) {
+      this.setCollapseSize(this.collapsedSize);
     }
   }
 
   _updateExpandedSize() {
-    if (!this.get('resetSizeWhenNotCollapsing') && !this.get('collapsed') && !this.get('collapsing')) {
-      this.setCollapseSize(this.get('expandedSize'));
+    if (!this.resetSizeWhenNotCollapsing && !this.collapsed && !this.collapsing) {
+      this.setCollapseSize(this.expandedSize);
     }
   }
 

--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -77,7 +77,7 @@ export default class ContextualHelp extends Component {
    * @private
    */
   @defaultValue
-  inDom = this.get('visible') && this.get('triggerTargetElement');
+  inDom = this.visible && this.triggerTargetElement;
 
   /**
    * Set to false to disable fade animations.
@@ -225,7 +225,7 @@ export default class ContextualHelp extends Component {
    */
   @computed('viewportSelector')
   get viewportElement() {
-    return document.querySelector(this.get('viewportSelector'));
+    return document.querySelector(this.viewportSelector);
   }
 
   /**
@@ -245,7 +245,7 @@ export default class ContextualHelp extends Component {
    * @private
    */
   getTriggerTargetElement() {
-    let triggerElement = this.get('triggerElement');
+    let triggerElement = this.triggerElement;
 
     if (!triggerElement) {
       return this._parent;
@@ -270,7 +270,7 @@ export default class ContextualHelp extends Component {
 
   @computed('triggerEvents')
   get _triggerEvents() {
-    let events = this.get('triggerEvents');
+    let events = this.triggerEvents;
     if (!isArray(events)) {
       events = events.split(' ');
     }
@@ -305,7 +305,7 @@ export default class ContextualHelp extends Component {
    */
   @computed('renderInPlace')
   get _renderInPlace() {
-    return this.get('renderInPlace') || !this.destinationElement;
+    return this.renderInPlace || !this.destinationElement;
   }
 
   /**
@@ -358,7 +358,7 @@ export default class ContextualHelp extends Component {
    * @private
    */
   get overlayElement() {
-    return document.getElementById(this.get('overlayId'));
+    return document.getElementById(this.overlayId);
   }
 
   /**
@@ -407,10 +407,10 @@ export default class ContextualHelp extends Component {
   enter(e) {
     if (e) {
       let eventType = e.type === 'focusin' ? 'focus' : 'hover';
-      this.get('inState').set(eventType, true);
+      this.inState.set(eventType, true);
     }
 
-    if (this.get('showHelp') || this.get('hoverState') === 'in') {
+    if (this.showHelp || this.hoverState === 'in') {
       this.set('hoverState', 'in');
       return;
     }
@@ -419,15 +419,15 @@ export default class ContextualHelp extends Component {
 
     this.set('hoverState', 'in');
 
-    if (!this.get('hasDelayShow')) {
+    if (!this.hasDelayShow) {
       return this.show();
     }
 
     this.timer = later(this, function() {
-      if (this.get('hoverState') === 'in') {
+      if (this.hoverState === 'in') {
         this.show();
       }
-    }, this.get('delayShow'));
+    }, this.delayShow);
   }
 
   /**
@@ -440,7 +440,7 @@ export default class ContextualHelp extends Component {
   leave(e) {
     if (e) {
       let eventType = e.type === 'focusout' ? 'focus' : 'hover';
-      this.get('inState').set(eventType, false);
+      this.inState.set(eventType, false);
     }
 
     if (this.get('inState.showHelp')) {
@@ -451,15 +451,15 @@ export default class ContextualHelp extends Component {
 
     this.set('hoverState', 'out');
 
-    if (!this.get('hasDelayHide')) {
+    if (!this.hasDelayHide) {
       return this.hide();
     }
 
     this.timer = later(this, function() {
-      if (this.get('hoverState') === 'out') {
+      if (this.hoverState === 'out') {
         this.hide();
       }
-    }, this.get('delayHide'));
+    }, this.delayHide);
   }
 
   /**
@@ -471,14 +471,14 @@ export default class ContextualHelp extends Component {
    */
   toggle(e) {
     if (e) {
-      this.get('inState').toggleProperty('click');
+      this.inState.toggleProperty('click');
       if (this.get('inState.showHelp')) {
         this.enter();
       } else {
         this.leave();
       }
     } else {
-      if (this.get('showHelp')) {
+      if (this.showHelp) {
         this.leave();
       } else {
         this.enter();
@@ -493,17 +493,17 @@ export default class ContextualHelp extends Component {
    * @private
    */
   show() {
-    if (this.get('isDestroyed') || this.get('isDestroying')) {
+    if (this.isDestroyed || this.isDestroying) {
       return;
     }
 
-    if (false === this.get('onShow')(this)) {
+    if (false === this.onShow(this)) {
       return;
     }
 
     // this waits for the tooltip/popover element to be created. when animating a wormholed tooltip/popover we need to wait until
     // ember-wormhole has moved things in the DOM for the animation to be correct, so use Ember.run.next in this case
-    let delayFn = !this.get('_renderInPlace') && this.get('fade') ? next : function(target, fn) {
+    let delayFn = !this._renderInPlace && this.fade ? next : function(target, fn) {
       schedule('afterRender', target, fn);
     };
 
@@ -528,12 +528,12 @@ export default class ContextualHelp extends Component {
     }
 
     let tooltipShowComplete = () => {
-      if (this.get('isDestroyed')) {
+      if (this.isDestroyed) {
         return;
       }
-      let prevHoverState = this.get('hoverState');
+      let prevHoverState = this.hoverState;
 
-      this.get('onShown')(this);
+      this.onShown(this);
       this.set('hoverState', null);
 
       if (prevHoverState === 'out') {
@@ -541,8 +541,8 @@ export default class ContextualHelp extends Component {
       }
     };
 
-    if (skipTransition === false && this.get('usesTransition')) {
-      transitionEnd(this.get('overlayElement'), this.get('transitionDuration'))
+    if (skipTransition === false && this.usesTransition) {
+      transitionEnd(this.overlayElement, this.transitionDuration)
         .then(tooltipShowComplete);
     } else {
       tooltipShowComplete();
@@ -559,7 +559,7 @@ export default class ContextualHelp extends Component {
    * @private
    */
   replaceArrow(delta, dimension, isVertical) {
-    let el = this.get('arrowElement');
+    let el = this.arrowElement;
     el.style[isVertical ? 'left' : 'top'] = `${50 * (1 - delta / dimension)}%`;
     el.style[isVertical ? 'top' : 'left'] = null;
   }
@@ -571,22 +571,22 @@ export default class ContextualHelp extends Component {
    * @private
    */
   hide() {
-    if (this.get('isDestroyed')) {
+    if (this.isDestroyed) {
       return;
     }
 
-    if (false === this.get('onHide')(this)) {
+    if (false === this.onHide(this)) {
       return;
     }
 
     let tooltipHideComplete = () => {
-      if (this.get('isDestroyed')) {
+      if (this.isDestroyed) {
         return;
       }
-      if (this.get('hoverState') !== 'in') {
+      if (this.hoverState !== 'in') {
         this.set('inDom', false);
       }
-      this.get('onHidden')(this);
+      this.onHidden(this);
     };
 
     this.set('showHelp', false);
@@ -600,8 +600,8 @@ export default class ContextualHelp extends Component {
       }
     }
 
-    if (this.get('usesTransition')) {
-      transitionEnd(this.get('overlayElement'), this.get('transitionDuration'))
+    if (this.usesTransition) {
+      transitionEnd(this.overlayElement, this.transitionDuration)
         .then(tooltipHideComplete);
     } else {
       tooltipHideComplete();
@@ -615,9 +615,9 @@ export default class ContextualHelp extends Component {
    * @private
    */
   addListeners() {
-    let target = this.get('triggerTargetElement');
+    let target = this.triggerTargetElement;
 
-    this.get('_triggerEvents')
+    this._triggerEvents
       .forEach((event) => {
         if (isArray(event)) {
           let [inEvent, outEvent] = event;
@@ -635,8 +635,8 @@ export default class ContextualHelp extends Component {
    */
   removeListeners() {
     try {
-      let target = this.get('triggerTargetElement');
-      this.get('_triggerEvents')
+      let target = this.triggerTargetElement;
+      this._triggerEvents
         .forEach((event) => {
           if (isArray(event)) {
             let [inEvent, outEvent] = event;
@@ -654,7 +654,7 @@ export default class ContextualHelp extends Component {
    * @private
    */
   handleTriggerEvent(handler, e) {
-    let overlayElement = this.get('overlayElement');
+    let overlayElement = this.overlayElement;
     if (overlayElement && overlayElement.contains(e.target)) {
       return;
     }
@@ -691,7 +691,7 @@ export default class ContextualHelp extends Component {
     this._parent = this._parentFinder.parentNode;
     this.triggerTargetElement = this.getTriggerTargetElement();
     this.addListeners();
-    if (this.get('visible')) {
+    if (this.visible) {
       next(this, this.show, true);
     }
   }
@@ -703,7 +703,7 @@ export default class ContextualHelp extends Component {
 
   @observes('visible')
   _watchVisible() {
-    if (this.get('visible')) {
+    if (this.visible) {
       this.show();
     } else {
       this.hide();

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -120,7 +120,7 @@ export default class ContextualHelpElement extends Component {
     let self = this;
     return {
       arrow: {
-        element: `.${this.get('arrowClass')}`
+        element: `.${this.arrowClass}`
       },
       offset: {
         fn(data) {
@@ -146,26 +146,26 @@ export default class ContextualHelpElement extends Component {
         }
       },
       preventOverflow: {
-        enabled: this.get('autoPlacement'),
-        boundariesElement: this.get('viewportElement'),
-        padding: this.get('viewportPadding')
+        enabled: this.autoPlacement,
+        boundariesElement: this.viewportElement,
+        padding: this.viewportPadding
       },
       hide: {
-        enabled: this.get('autoPlacement')
+        enabled: this.autoPlacement
       },
       flip: {
-        enabled: this.get('autoPlacement')
+        enabled: this.autoPlacement
       }
     };
   }
 
   didReceiveAttrs() {
-    assert('Contextual help element needs id for popper element', this.get('id'));
+    assert('Contextual help element needs id for popper element', this.id);
   }
 
   @action
   updatePlacement(popperDataObject) {
-    if (this.get('actualPlacement') === popperDataObject.placement) {
+    if (this.actualPlacement === popperDataObject.placement) {
       return;
     }
     this.set('actualPlacement', popperDataObject.placement);

--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -240,9 +240,9 @@ export default class Dropdown extends Component {
   @computed('toggleElement', 'direction')
   get containerClass() {
     if (this.hasButton && !this.toggleElement.classList.contains('btn-block')) {
-      return this.get('direction') !== 'down' ? `btn-group drop${this.get('direction')}` : 'btn-group';
+      return this.direction !== 'down' ? `btn-group drop${this.direction}` : 'btn-group';
     } else {
-      return `drop${this.get('direction')}`;
+      return `drop${this.direction}`;
     }
   }
 
@@ -284,7 +284,7 @@ export default class Dropdown extends Component {
 
   @action
   toggleDropdown() {
-    if (this.get('isOpen')) {
+    if (this.isOpen) {
       this.closeDropdown();
     } else {
       this.openDropdown();
@@ -294,13 +294,13 @@ export default class Dropdown extends Component {
   @action
   openDropdown() {
     this.set('isOpen', true);
-    this.get('onShow')();
+    this.onShow();
   }
 
   @action
   closeDropdown() {
     this.set('isOpen', false);
-    this.get('onHide')();
+    this.onHide();
   }
 
   /**
@@ -313,12 +313,12 @@ export default class Dropdown extends Component {
   @action
   closeHandler(e) {
     let { target } = e;
-    let { toggleElement, menuElement } = this.getProperties('toggleElement', 'menuElement');
+    let { toggleElement, menuElement } = this;
 
-    if (!this.get('isDestroyed')
+    if (!this.isDestroyed
       && (
         (e.type === 'keyup' && e.which === TAB_KEYCODE && menuElement && !menuElement.contains(target))
-        || (e.type === 'click' && toggleElement && !toggleElement.contains(target) && ((menuElement && !menuElement.contains(target)) || this.get('closeOnMenuClick')))
+        || (e.type === 'click' && toggleElement && !toggleElement.contains(target) && ((menuElement && !menuElement.contains(target)) || this.closeOnMenuClick))
       )) {
       this.closeDropdown();
     }
@@ -336,7 +336,7 @@ export default class Dropdown extends Component {
     if (['input', 'textarea'].includes(event.target.tagName.toLowerCase())
       ? (
         event.which === SPACE_KEYCODE
-        || event.which !== ESCAPE_KEYCODE && (event.which !== ARROW_DOWN_KEYCODE && event.which !== ARROW_UP_KEYCODE || this.get('menuElement').contains(event.target)))
+        || event.which !== ESCAPE_KEYCODE && (event.which !== ARROW_DOWN_KEYCODE && event.which !== ARROW_UP_KEYCODE || this.menuElement.contains(event.target)))
       : !SUPPORTED_KEYCODES.includes(event.which)) {
       return;
     }
@@ -344,12 +344,12 @@ export default class Dropdown extends Component {
     event.preventDefault();
     event.stopPropagation();
 
-    if (!this.get('isOpen')) {
+    if (!this.isOpen) {
       this.openDropdown();
       return;
     } else if (event.which === ESCAPE_KEYCODE || event.which === SPACE_KEYCODE) {
       this.closeDropdown();
-      this.get('toggleElement').focus();
+      this.toggleElement.focus();
       return;
     }
 

--- a/addon/components/bs-dropdown/button.js
+++ b/addon/components/bs-dropdown/button.js
@@ -17,7 +17,7 @@ import { computed, action } from '@ember/object';
 export default class DropdownButton extends Button {
   @action
   handleKeyDown(e) {
-    this.get('onKeyDown')(e);
+    this.onKeyDown(e);
   }
 
   @computed('isOpen')

--- a/addon/components/bs-dropdown/menu.js
+++ b/addon/components/bs-dropdown/menu.js
@@ -73,10 +73,8 @@ export default class DropdownMenu extends Component {
    */
   @computed('renderInPlace')
   get _renderInPlace() {
-    return (
-      this.get('renderInPlace') ||
-      !this.destinationElement
-    );
+    return this.renderInPlace ||
+    !this.destinationElement;
   }
 
   /**
@@ -94,7 +92,7 @@ export default class DropdownMenu extends Component {
 
   @computed('align')
   get alignClass() {
-    return this.get('align') !== 'left' ? `dropdown-menu-${this.get('align')}` : undefined;
+    return this.align !== 'left' ? `dropdown-menu-${this.align}` : undefined;
   }
 
   @computed
@@ -106,7 +104,7 @@ export default class DropdownMenu extends Component {
     // delay removing the menu from DOM to allow (delegated Ember) event to fire for the menu's children
     // Fixes https://github.com/kaliber5/ember-bootstrap/issues/660
     next(() => {
-      if (this.get('isDestroying') || this.get('isDestroyed')) {
+      if (this.isDestroying || this.isDestroyed) {
         return;
       }
       this.set('_isOpen', value);
@@ -121,7 +119,7 @@ export default class DropdownMenu extends Component {
   @computed('direction', 'align')
   get popperPlacement() {
     let placement = 'bottom-start';
-    let { direction, align } = this.getProperties('direction', 'align');
+    let { direction, align } = this;
 
     if (direction === 'up') {
       placement = 'top-start';
@@ -140,7 +138,7 @@ export default class DropdownMenu extends Component {
 
   @action
   setFocus() {
-    let menuElement = document.getElementById(`${this.get('dropdownElementId')}__menu`);
+    let menuElement = document.getElementById(`${this.dropdownElementId}__menu`);
     if (menuElement) {
       menuElement.focus();
     }
@@ -151,10 +149,10 @@ export default class DropdownMenu extends Component {
     return {
       // @todo add offset config
       applyStyle: {
-        enabled: !this.get('inNav')
+        enabled: !this.inNav
       },
       flip: {
-        enabled: this.get('flip')
+        enabled: this.flip
       }
     };
   }

--- a/addon/components/bs-dropdown/toggle.js
+++ b/addon/components/bs-dropdown/toggle.js
@@ -44,11 +44,11 @@ export default class DropdownToggle extends Component {
   @action
   handleClick(e) {
     e.preventDefault();
-    this.get('onClick')();
+    this.onClick();
   }
 
   @action
   handleKeyDown(e) {
-    this.get('onKeyDown')(e);
+    this.onKeyDown(e);
   }
 }

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -122,7 +122,7 @@ export default class Form extends Component {
    */
   @computed('formLayout')
   get layoutClass() {
-    let layout = this.get('formLayout');
+    let layout = this.formLayout;
     if (hasBootstrapVersion(3)) {
       return layout === 'vertical' ? 'form' : `form-${layout}`;
     } else {
@@ -369,38 +369,38 @@ export default class Form extends Component {
       e.preventDefault();
     }
 
-    if (this.get('preventConcurrency') && this.get('isSubmitting')) {
+    if (this.preventConcurrency && this.isSubmitting) {
       return RSVP.resolve();
     }
 
-    let model = this.get('model');
+    let model = this.model;
 
     this.incrementProperty('pendingSubmissions');
-    this.get('onBefore')(model);
+    this.onBefore(model);
 
     return RSVP.resolve()
       .then(() => {
-        return this.get('hasValidator') ? this.validate(model) : null;
+        return this.hasValidator ? this.validate(model) : null;
       })
       .then(
         (record) => {
-          if (this.get('hideValidationsOnSubmit') === true) {
+          if (this.hideValidationsOnSubmit === true) {
             this.set('showAllValidations', false);
           }
 
           return RSVP.resolve()
             .then(() => {
-              return this.get('onSubmit')(model, record);
+              return this.onSubmit(model, record);
             })
             .then(() => {
-              if (this.get('isDestroyed')) {
+              if (this.isDestroyed) {
                 return;
               }
 
               this.set('isSubmitted', true);
             })
             .catch((error) => {
-              if (this.get('isDestroyed')) {
+              if (this.isDestroyed) {
                 return;
               }
 
@@ -409,14 +409,14 @@ export default class Form extends Component {
               throw error;
             })
             .finally(() => {
-              if (this.get('isDestroyed')) {
+              if (this.isDestroyed) {
                 return;
               }
 
               this.decrementProperty('pendingSubmissions');
 
               // reset forced hiding of validations
-              if (this.get('showAllValidations') === false) {
+              if (this.showAllValidations === false) {
                 schedule('afterRender', () => this.set('showAllValidations', undefined));
               }
             });
@@ -424,17 +424,17 @@ export default class Form extends Component {
         (error) => {
           return RSVP.resolve()
             .then(() => {
-              return this.get('onInvalid')(model, error);
+              return this.onInvalid(model, error);
             })
             .finally(() => {
-              if (this.get('isDestroyed')) {
+              if (this.isDestroyed) {
                 return;
               }
 
               this.setProperties({
                 showAllValidations: true,
                 isRejected: true,
-                pendingSubmissions: this.get('pendingSubmissions') - 1
+                pendingSubmissions: this.pendingSubmissions - 1
               });
 
               if (throwValidationErrors) {
@@ -442,7 +442,7 @@ export default class Form extends Component {
               }
             });
         }
-      )
+      );
   }
 
   @action
@@ -453,7 +453,7 @@ export default class Form extends Component {
   @action
   handleKeyPress(e) {
     let code = e.keyCode || e.which;
-    if (code === 13 && this.get('submitOnEnter')) {
+    if (code === 13 && this.submitOnEnter) {
       this.triggerSubmit();
     }
   }
@@ -467,7 +467,7 @@ export default class Form extends Component {
   init() {
     super.init(...arguments);
 
-    let formLayout = this.get('formLayout');
+    let formLayout = this.formLayout;
     assert(`Invalid formLayout property given: ${formLayout}`, ['vertical', 'horizontal', 'inline'].indexOf(formLayout) >= 0);
 
     warn(

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -461,17 +461,17 @@ export default class FormElement extends FormGroup {
     'showModelValidation'
   )
   get validationMessages() {
-    if (this.get('hasCustomError')) {
-      return A([this.get('customError')]);
+    if (this.hasCustomError) {
+      return A([this.customError]);
     }
-    if (this.get('hasErrors') && this.get('showModelValidation')) {
-      return A(this.get('errors'));
+    if (this.hasErrors && this.showModelValidation) {
+      return A(this.errors);
     }
-    if (this.get('hasCustomWarning')) {
-      return A([this.get('customWarning')]);
+    if (this.hasCustomWarning) {
+      return A([this.customWarning]);
     }
-    if (this.get('hasWarnings') && this.get('showModelValidation')) {
-      return A(this.get('warnings'));
+    if (this.hasWarnings && this.showModelValidation) {
+      return A(this.warnings);
     }
     return null;
   }
@@ -586,7 +586,7 @@ export default class FormElement extends FormGroup {
    */
   @computed('showValidationOn.[]')
   get _showValidationOn() {
-    let showValidationOn = this.get('showValidationOn');
+    let showValidationOn = this.showValidationOn;
 
     assert('showValidationOn must be a String or an Array', isArray(showValidationOn) || typeOf(showValidationOn) === 'string');
     if (isArray(showValidationOn)) {
@@ -611,14 +611,14 @@ export default class FormElement extends FormGroup {
     // Should not do anything if
     if (
       // validations are already shown or
-      this.get('showOwnValidation') ||
+      this.showOwnValidation ||
       // validations should not be shown for this event type or
-      this.get('_showValidationOn').indexOf(type) === -1 ||
+      this._showValidationOn.indexOf(type) === -1 ||
       // validation should not be shown for this event target
       (
-        isArray(this.get('doNotShowValidationForEventTargets')) &&
+        isArray(this.doNotShowValidationForEventTargets) &&
         this.get('doNotShowValidationForEventTargets.length') > 0 &&
-        [...this._element.querySelectorAll(this.get('doNotShowValidationForEventTargets').join(','))]
+        [...this._element.querySelectorAll(this.doNotShowValidationForEventTargets.join(','))]
           .some((el) => el.contains(target))
       )
     ) {
@@ -665,14 +665,14 @@ export default class FormElement extends FormGroup {
     'disabled'
   )
   get validation() {
-    if (!this.get('showValidation') || !this.get('hasValidator') || this.get('isValidating') || this.get('disabled')) {
+    if (!this.showValidation || !this.hasValidator || this.isValidating || this.disabled) {
       return null;
-    } else if (this.get('showModelValidation')) {
+    } else if (this.showModelValidation) {
       /* The display of model validation messages has been triggered */
-      return this.get('hasErrors') || this.get('hasCustomError') ? 'error' : (this.get('hasWarnings') || this.get('hasCustomWarning') ? 'warning' : 'success');
+      return this.hasErrors || this.hasCustomError ? 'error' : (this.hasWarnings || this.hasCustomWarning ? 'warning' : 'success');
     } else {
       /* If there are custom errors or warnings these should always be shown */
-      return this.get('hasCustomError') ? 'error' : 'warning';
+      return this.hasCustomError ? 'error' : 'warning';
     }
   }
 
@@ -754,9 +754,9 @@ export default class FormElement extends FormGroup {
    */
   @computed('formLayout', 'controlType')
   get layoutComponent() {
-    const formComponent = this.get('formComponent');
-    const formLayout = this.get('formLayout');
-    const controlType = this.get('controlType');
+    const formComponent = this.formComponent;
+    const formLayout = this.formLayout;
+    const controlType = this.controlType;
 
     if (nonDefaultLayouts.includes(controlType)) {
       return `${formComponent}/element/layout/${formLayout}/${controlType}`;
@@ -772,8 +772,8 @@ export default class FormElement extends FormGroup {
    */
   @computed('controlType')
   get controlComponent() {
-    const formComponent = this.get('formComponent');
-    const controlType = this.get('controlType');
+    const formComponent = this.formComponent;
+    const controlType = this.controlType;
     const componentName = `${formComponent}/element/control/${controlType}`;
 
     if (getOwner(this).hasRegistration(`component:${componentName}`)) {
@@ -806,7 +806,7 @@ export default class FormElement extends FormGroup {
    */
   @computed('controlType')
   get labelComponent() {
-    return hasBootstrapVersion(3) ? 'bs-form/element/label' : this.get('controlType') === 'radio' ? 'bs-form/element/legend' : 'bs-form/element/label';
+    return hasBootstrapVersion(3) ? 'bs-form/element/label' : this.controlType === 'radio' ? 'bs-form/element/legend' : 'bs-form/element/label';
   }
 
   /**
@@ -848,12 +848,12 @@ export default class FormElement extends FormGroup {
 
   init() {
     super.init(...arguments);
-    if (this.get('showValidationOn') === null) {
+    if (this.showValidationOn === null) {
       this.set('showValidationOn', ['focusOut']);
     }
-    if (!isBlank(this.get('property'))) {
-      assert('You cannot set both property and value on a form element', this.get('value') === null || this.get('value') === undefined);
-      defineProperty(this, 'value', alias(`model.${this.get('property')}`));
+    if (!isBlank(this.property)) {
+      assert('You cannot set both property and value on a form element', this.value === null || this.value === undefined);
+      defineProperty(this, 'value', alias(`model.${this.property}`));
       this.setupValidations();
     }
 
@@ -932,8 +932,8 @@ export default class FormElement extends FormGroup {
     if (hasBootstrapVersion(3)) {
       let feedbackIcon;
       // validation state icons are only shown if form element has feedback
-      if (!this.get('isDestroying')
-        && this.get('hasFeedback')
+      if (!this.isDestroying
+        && this.hasFeedback
         // and form group element has
         // an input-group
         && el.querySelector('.input-group')
@@ -963,7 +963,7 @@ export default class FormElement extends FormGroup {
 
   @action
   doChange(value) {
-    let { onChange, model, property, _onChange } = this.getProperties('onChange', 'model', 'property', '_onChange');
+    let { onChange, model, property, _onChange } = this;
     onChange(value, model, property);
     _onChange();
   }

--- a/addon/components/bs-form/element/control/checkbox.js
+++ b/addon/components/bs-form/element/control/checkbox.js
@@ -15,6 +15,6 @@ import Control from '../control';
 export default class FormElementControlCheckbox extends Control {
   @action
   handleClick(event) {
-    this.get('onChange')(event.target.checked);
+    this.onChange(event.target.checked);
   }
 }

--- a/addon/components/bs-form/element/control/input.js
+++ b/addon/components/bs-form/element/control/input.js
@@ -66,12 +66,12 @@ export default class FormElementControlInput extends Control {
 
   @action
   handleChange(event) {
-    this.get('onChange')(event.target.value);
+    this.onChange(event.target.value);
   }
 
   @action
   handleInput(event) {
-    this.get('onChange')(event.target.value);
+    this.onChange(event.target.value);
   }
 
   /**

--- a/addon/components/bs-form/element/control/textarea.js
+++ b/addon/components/bs-form/element/control/textarea.js
@@ -15,11 +15,11 @@ import Control from '../control';
 export default class FormElementControlTextarea extends Control {
   @action
   handleChange(event) {
-    this.get('onChange')(event.target.value);
+    this.onChange(event.target.value);
   }
 
   @action
   handleInput(event) {
-    this.get('onChange')(event.target.value);
+    this.onChange(event.target.value);
   }
 }

--- a/addon/components/bs-form/element/label.js
+++ b/addon/components/bs-form/element/label.js
@@ -32,15 +32,15 @@ export default class FormElementLabel extends Component {
 
   @computed('isHorizontal', 'isCheckbox')
   get isHorizontalAndNotCheckbox() {
-    return this.get('isHorizontal') && !this.get('isCheckbox');
+    return this.isHorizontal && !this.isCheckbox;
   }
 
   @computed('size', 'isHorizontal')
   get sizeClass() {
-    if (!this.get('isHorizontal')) {
+    if (!this.isHorizontal) {
       return undefined;
     }
-    let size = this.get('size');
+    let size = this.size;
     return isBlank(size) ? null : `col-form-label-${size}`;
   }
 

--- a/addon/components/bs-form/element/layout/horizontal.js
+++ b/addon/components/bs-form/element/layout/horizontal.js
@@ -37,10 +37,10 @@ export default class FormElementLayoutHorizontal extends FormElementLayout {
    */
   @(computed('horizontalLabelGridClass').readOnly())
   get horizontalInputGridClass() {
-    if (isBlank(this.get('horizontalLabelGridClass'))) {
+    if (isBlank(this.horizontalLabelGridClass)) {
       return undefined;
     }
-    let parts = this.get('horizontalLabelGridClass').split('-');
+    let parts = this.horizontalLabelGridClass.split('-');
     assert('horizontalInputGridClass must match format bootstrap grid column class', parts.length === 3);
     parts[2] = 12 - parts[2];
     return parts.join('-');
@@ -57,10 +57,10 @@ export default class FormElementLayoutHorizontal extends FormElementLayout {
    */
   @computed('horizontalLabelGridClass')
   get horizontalInputOffsetGridClass() {
-    if (isBlank(this.get('horizontalLabelGridClass'))) {
+    if (isBlank(this.horizontalLabelGridClass)) {
       return undefined;
     }
-    let parts = this.get('horizontalLabelGridClass').split('-');
+    let parts = this.horizontalLabelGridClass.split('-');
     if (hasBootstrapVersion(3)) {
       parts.splice(2, 0, 'offset');
     } else {

--- a/addon/components/bs-form/group.js
+++ b/addon/components/bs-form/group.js
@@ -210,7 +210,7 @@ export default class FormGroup extends Component {
    */
   @(computed('validation').readOnly())
   get iconName() {
-    let validation = this.get('validation') || 'success';
+    let validation = this.validation || 'success';
     return this.get(`${validation}Icon`);
   }
 
@@ -235,7 +235,7 @@ export default class FormGroup extends Component {
    */
   @(computed('validation').readOnly())
   get validationClass() {
-    let validation = this.get('validation');
+    let validation = this.validation;
     return !isBlank(validation) ? `has-${validation}` : undefined;
   }
 

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -293,7 +293,7 @@ export default class Modal extends Component {
    */
   @computed('renderInPlace', 'destinationElement')
   get _renderInPlace() {
-    return this.get('renderInPlace') || !this.destinationElement;
+    return this.renderInPlace || !this.destinationElement;
   }
 
   /**
@@ -338,7 +338,7 @@ export default class Modal extends Component {
    * @private
    */
   get modalElement() {
-    return document.getElementById(this.get('modalId'));
+    return document.getElementById(this.modalId);
   }
 
   /**
@@ -350,7 +350,7 @@ export default class Modal extends Component {
    * @private
    */
   get backdropElement() {
-    return document.getElementById(this.get('backdropId'));
+    return document.getElementById(this.backdropId);
   }
 
   /**
@@ -419,7 +419,7 @@ export default class Modal extends Component {
 
   @action
   close() {
-    if (this.get('onHide')() !== false) {
+    if (this.onHide() !== false) {
       this.set('isOpen', false);
     }
   }
@@ -427,8 +427,8 @@ export default class Modal extends Component {
   @action
   doSubmit() {
     // replace modalId by :scope selector if supported by all target browsers
-    let modalId = this.get('modalId');
-    let forms = this.get('modalElement').querySelectorAll(`#${modalId} .modal-body form`);
+    let modalId = this.modalId;
+    let forms = this.modalElement.querySelectorAll(`#${modalId} .modal-body form`);
     if (forms.length > 0) {
       // trigger submit event on body forms
       let event = document.createEvent('Events');
@@ -436,7 +436,7 @@ export default class Modal extends Component {
       Array.prototype.slice.call(forms).forEach((form) => form.dispatchEvent(event));
     } else {
       // if we have no form, we send a submit action
-      this.get('onSubmit')();
+      this.onSubmit();
     }
   }
 
@@ -457,7 +457,7 @@ export default class Modal extends Component {
     this.resize();
 
     let callback = () => {
-      if (this.get('isDestroyed')) {
+      if (this.isDestroyed) {
         return;
       }
 
@@ -465,7 +465,7 @@ export default class Modal extends Component {
       this.setScrollbar();
 
       schedule('afterRender', () => {
-        let modalEl = this.get('modalElement');
+        let modalEl = this.modalElement;
         if (!modalEl) {
           return;
         }
@@ -473,19 +473,19 @@ export default class Modal extends Component {
         modalEl.scrollTop = 0;
         this.handleUpdate();
         this.set('showModal', true);
-        this.get('onShow')();
+        this.onShow();
 
-        if (this.get('usesTransition')) {
-          transitionEnd(this.get('modalElement'), this.get('transitionDuration'))
+        if (this.usesTransition) {
+          transitionEnd(this.modalElement, this.transitionDuration)
             .then(() => {
-              this.get('onShown')();
+              this.onShown();
             });
         } else {
-          this.get('onShown')();
+          this.onShown();
         }
       });
     };
-    if (this.get('inDom') !== true) {
+    if (this.inDom !== true) {
       this.set('inDom', true);
     }
     this.handleBackdrop(callback);
@@ -506,8 +506,8 @@ export default class Modal extends Component {
     this.resize();
     this.set('showModal', false);
 
-    if (this.get('usesTransition')) {
-      transitionEnd(this.get('modalElement'), this.get('transitionDuration'))
+    if (this.usesTransition) {
+      transitionEnd(this.modalElement, this.transitionDuration)
         .then(() => this.hideModal());
     } else {
       this.hideModal();
@@ -521,7 +521,7 @@ export default class Modal extends Component {
    * @private
    */
   hideModal() {
-    if (this.get('isDestroyed')) {
+    if (this.isDestroyed) {
       return;
     }
 
@@ -530,7 +530,7 @@ export default class Modal extends Component {
       this.resetAdjustments();
       this.resetScrollbar();
       this.set('inDom', false);
-      this.get('onHidden')();
+      this.onHidden();
     });
   }
 
@@ -542,9 +542,9 @@ export default class Modal extends Component {
    * @private
    */
   handleBackdrop(callback) {
-    let doAnimate = this.get('usesTransition');
+    let doAnimate = this.usesTransition;
 
-    if (this.get('isOpen') && this.get('backdrop')) {
+    if (this.isOpen && this.backdrop) {
       this.set('showBackdrop', true);
 
       if (!callback) {
@@ -552,22 +552,22 @@ export default class Modal extends Component {
       }
 
       schedule('afterRender', this, function() {
-        let backdrop = this.get('backdropElement');
+        let backdrop = this.backdropElement;
         assert('Backdrop element should be in DOM', backdrop);
         if (doAnimate) {
-          transitionEnd(backdrop, this.get('backdropTransitionDuration'))
+          transitionEnd(backdrop, this.backdropTransitionDuration)
             .then(callback);
         } else {
           callback();
         }
       });
 
-    } else if (!this.get('isOpen') && this.get('backdrop')) {
-      let backdrop = this.get('backdropElement');
+    } else if (!this.isOpen && this.backdrop) {
+      let backdrop = this.backdropElement;
       assert('Backdrop element should be in DOM', backdrop);
 
       let callbackRemove = () => {
-        if (this.get('isDestroyed')) {
+        if (this.isDestroyed) {
           return;
         }
         this.set('showBackdrop', false);
@@ -576,7 +576,7 @@ export default class Modal extends Component {
         }
       };
       if (doAnimate) {
-        transitionEnd(backdrop, this.get('backdropTransitionDuration'))
+        transitionEnd(backdrop, this.backdropTransitionDuration)
           .then(callbackRemove);
       } else {
         callbackRemove();
@@ -593,7 +593,7 @@ export default class Modal extends Component {
    * @private
    */
   resize() {
-    if (this.get('isOpen')) {
+    if (this.isOpen) {
       this._handleUpdate = bind(this, this.handleUpdate);
       window.addEventListener('resize', this._handleUpdate, false);
     } else {
@@ -614,10 +614,10 @@ export default class Modal extends Component {
    * @private
    */
   adjustDialog() {
-    let modalIsOverflowing = this.get('modalElement').scrollHeight > document.documentElement.clientHeight;
+    let modalIsOverflowing = this.modalElement.scrollHeight > document.documentElement.clientHeight;
     this.setProperties({
-      paddingLeft: !this.bodyIsOverflowing && modalIsOverflowing ? this.get('scrollbarWidth') : undefined,
-      paddingRight: this.bodyIsOverflowing && !modalIsOverflowing ? this.get('scrollbarWidth') : undefined
+      paddingLeft: !this.bodyIsOverflowing && modalIsOverflowing ? this.scrollbarWidth : undefined,
+      paddingRight: this.bodyIsOverflowing && !modalIsOverflowing ? this.scrollbarWidth : undefined
     });
   }
 
@@ -654,7 +654,7 @@ export default class Modal extends Component {
     let bodyPad = parseInt((document.body.style.paddingRight || 0), 10);
     this._originalBodyPad = document.body.style.paddingRight || '';
     if (this.bodyIsOverflowing) {
-      document.body.style.paddingRight = bodyPad + this.get('scrollbarWidth');
+      document.body.style.paddingRight = bodyPad + this.scrollbarWidth;
     }
   }
 
@@ -676,7 +676,7 @@ export default class Modal extends Component {
   get scrollbarWidth() {
     let scrollDiv = document.createElement('div');
     scrollDiv.className = 'modal-scrollbar-measure';
-    let modalEl = this.get('modalElement');
+    let modalEl = this.modalElement;
     modalEl.parentNode.insertBefore(scrollDiv, modalEl.nextSibling);
     let scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
     scrollDiv.parentNode.removeChild(scrollDiv);
@@ -685,7 +685,7 @@ export default class Modal extends Component {
 
   didInsertElement() {
     super.didInsertElement(...arguments);
-    if (this.get('isOpen')) {
+    if (this.isOpen) {
       this.show();
     }
   }
@@ -698,7 +698,7 @@ export default class Modal extends Component {
   }
 
   _observeOpen() {
-    if (this.get('isOpen')) {
+    if (this.isOpen) {
       this.show();
     } else {
       this.hide();
@@ -707,7 +707,7 @@ export default class Modal extends Component {
 
   init() {
     super.init(...arguments);
-    let { isOpen, backdrop, fade } = this.getProperties('isOpen', 'backdrop', 'fade');
+    let { isOpen, backdrop, fade } = this;
     let isFB = isFastBoot(this);
     if (fade === undefined) {
       fade = !isFB;

--- a/addon/components/bs-modal/dialog.js
+++ b/addon/components/bs-modal/dialog.js
@@ -29,7 +29,7 @@ export default class ModalDialog extends Component {
    */
   @(computed('size').readOnly())
   get sizeClass() {
-    let size = this.get('size');
+    let size = this.size;
     return isBlank(size) ? null : `modal-${size}`;
   }
 
@@ -61,7 +61,7 @@ export default class ModalDialog extends Component {
         nodeId = titleNode.id;
         if (!nodeId) {
           //no title id so we set one
-          nodeId = `${this.get('id')}-title`;
+          nodeId = `${this.id}-title`;
           titleNode.id = nodeId;
         }
       }
@@ -107,8 +107,8 @@ export default class ModalDialog extends Component {
   @action
   handleKeyDown(e) {
     let code = e.keyCode || e.which;
-    if (code === 27 && this.get('keyboard')) {
-      this.get('onClose')();
+    if (code === 27 && this.keyboard) {
+      this.onClose();
     }
   }
 
@@ -118,10 +118,10 @@ export default class ModalDialog extends Component {
       this.set('ignoreBackdropClick', false);
       return;
     }
-    if (e.target !== this._element || !this.get('backdropClose')) {
+    if (e.target !== this._element || !this.backdropClose) {
       return;
     }
-    this.get('onClose')();
+    this.onClose();
   }
 
   @action

--- a/addon/components/bs-modal/footer.js
+++ b/addon/components/bs-modal/footer.js
@@ -88,6 +88,6 @@ export default class ModalFooter extends Component {
   handleSubmit(e) {
     e.preventDefault();
     // send to parent bs-modal component
-    this.get('onSubmit')();
+    this.onSubmit();
   }
 }

--- a/addon/components/bs-modal/header/close.js
+++ b/addon/components/bs-modal/header/close.js
@@ -22,6 +22,6 @@ export default class ModalHeaderClose extends Component {
 
   @action
   handleClick() {
-    this.get('onClick')();
+    this.onClick();
   }
 }

--- a/addon/components/bs-nav.js
+++ b/addon/components/bs-nav.js
@@ -86,7 +86,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 export default class Nav extends Component {
   @computed('type')
   get typeClass() {
-    let type = this.get('type');
+    let type = this.type;
     return type ? `nav-${type}` : undefined;
   }
 

--- a/addon/components/bs-nav/item.js
+++ b/addon/components/bs-nav/item.js
@@ -95,11 +95,11 @@ export default class NavItem extends Component.extend(ComponentParent) {
 
   init() {
     super.init(...arguments);
-    let { model, models } = this.getProperties('model', 'models');
+    let { model, models } = this;
     assert('You cannot pass both `@model` and `@models` to a nav item component!', !model || !models);
 
-    this.get('activeChildLinks');
-    this.get('disabledChildLinks');
+    this.activeChildLinks;
+    this.disabledChildLinks;
   }
 
   @observes('activeChildLinks.[]')
@@ -108,7 +108,7 @@ export default class NavItem extends Component.extend(ComponentParent) {
   }
 
   _updateActive() {
-    this.set('_active', this.get('hasActiveChildLinks'));
+    this.set('_active', this.hasActiveChildLinks);
   }
 
   @observes('disabledChildLinks.[]')
@@ -117,6 +117,6 @@ export default class NavItem extends Component.extend(ComponentParent) {
   }
 
   _updateDisabled() {
-    this.set('_disabled', this.get('hasDisabledChildLinks'));
+    this.set('_disabled', this.hasDisabledChildLinks);
   }
 }

--- a/addon/components/bs-navbar.js
+++ b/addon/components/bs-navbar.js
@@ -149,7 +149,7 @@ export default class Navbar extends Component {
 
   @computed('position')
   get positionClass() {
-    let position = this.get('position');
+    let position = this.position;
     let validPositions = hasBootstrapVersion(3) ? ['fixed-top', 'fixed-bottom', 'static-top'] : ['fixed-top', 'fixed-bottom', 'sticky-top'];
     let positionPrefix = hasBootstrapVersion(3) ? 'navbar-' : '';
 
@@ -227,8 +227,8 @@ export default class Navbar extends Component {
 
   @observes('_collapsed')
   _onCollapsedChange() {
-    let collapsed = this.get('_collapsed');
-    let active = this.get('active');
+    let collapsed = this._collapsed;
+    let active = this.active;
     if (collapsed !== active) {
       return;
     }
@@ -263,7 +263,7 @@ export default class Navbar extends Component {
 
   @action
   toggleNavbar() {
-    if (this.get('_collapsed')) {
+    if (this._collapsed) {
       this.expand();
     } else {
       this.collapse();
@@ -301,7 +301,7 @@ export default class Navbar extends Component {
     if (hasBootstrapVersion(3)) {
       return undefined;
     } else {
-      let toggleBreakpoint = this.get('toggleBreakpoint');
+      let toggleBreakpoint = this.toggleBreakpoint;
 
       if (isBlank(toggleBreakpoint)) {
         return 'navbar-expand';

--- a/addon/components/bs-navbar/link-to.js
+++ b/addon/components/bs-navbar/link-to.js
@@ -27,7 +27,7 @@ export default class NavbarLinkTo extends BsNavLinkToComponent {
   }
 
   click() {
-    if (this.get('collapseNavbar')) {
+    if (this.collapseNavbar) {
       this.onCollapse();
     }
   }

--- a/addon/components/bs-popover.js
+++ b/addon/components/bs-popover.js
@@ -107,6 +107,6 @@ export default class Popover extends ContextualHelp {
    */
   @computed('overlayElement')
   get arrowElement() {
-    return this.get('overlayElement').querySelector('.arrow');
+    return this.overlayElement.querySelector('.arrow');
   }
 }

--- a/addon/components/bs-progress/bar.js
+++ b/addon/components/bs-progress/bar.js
@@ -131,9 +131,9 @@ export default class ProgressBar extends Component {
    */
   @(computed('value', 'minValue', 'maxValue').readOnly())
   get percent() {
-    let value = parseFloat(this.get('value'));
-    let minValue = parseFloat(this.get('minValue'));
-    let maxValue = parseFloat(this.get('maxValue'));
+    let value = parseFloat(this.value);
+    let minValue = parseFloat(this.minValue);
+    let maxValue = parseFloat(this.maxValue);
 
     return Math.min(Math.max((value - minValue) / (maxValue - minValue), 0), 1) * 100;
   }
@@ -148,8 +148,8 @@ export default class ProgressBar extends Component {
    */
   @(computed('percent', 'roundDigits').readOnly())
   get percentRounded() {
-    let roundFactor = Math.pow(10, this.get('roundDigits'));
-    return Math.round(this.get('percent') * roundFactor) / roundFactor;
+    let roundFactor = Math.pow(10, this.roundDigits);
+    return Math.round(this.percent * roundFactor) / roundFactor;
   }
 
   get percentStyleValue() {

--- a/addon/components/bs-tab.js
+++ b/addon/components/bs-tab.js
@@ -243,7 +243,7 @@ export default class Tab extends Component.extend(ComponentParent) {
   @computed('childPanes.@each.{id,title,group}')
   get navItems() {
     let items = A();
-    this.get('childPanes').forEach((pane) => {
+    this.childPanes.forEach((pane) => {
       let groupTitle = pane.get('groupTitle');
       let item = pane.getProperties('id', 'title');
       if (isPresent(groupTitle)) {
@@ -268,8 +268,8 @@ export default class Tab extends Component.extend(ComponentParent) {
 
   @action
   select(id) {
-    let previous = this.get('isActiveId');
-    if (this.get('onChange')(id, previous) !== false) {
+    let previous = this.isActiveId;
+    if (this.onChange(id, previous) !== false) {
       // change active tab when `onChange` does not return false
       this.set('isActiveId', id);
     }

--- a/addon/components/bs-tab/pane.js
+++ b/addon/components/bs-tab/pane.js
@@ -47,7 +47,7 @@ export default class TabPane extends Component.extend(ComponentChild) {
    */
   @(computed('activeId', 'id').readOnly())
   get isActive() {
-    return this.get('activeId') === this.get('id');
+    return this.activeId === this.id;
   }
 
   /**
@@ -137,10 +137,10 @@ export default class TabPane extends Component.extend(ComponentChild) {
    * @protected
    */
   show() {
-    if (this.get('usesTransition')) {
-      transitionEnd(this._element, this.get('fadeDuration'))
+    if (this.usesTransition) {
+      transitionEnd(this._element, this.fadeDuration)
         .then(() => {
-          if (!this.get('isDestroyed')) {
+          if (!this.isDestroyed) {
             this.setProperties({
               active: true,
               showContent: true
@@ -159,10 +159,10 @@ export default class TabPane extends Component.extend(ComponentChild) {
    * @protected
    */
   hide() {
-    if (this.get('usesTransition')) {
-      transitionEnd(this._element, this.get('fadeDuration'))
+    if (this.usesTransition) {
+      transitionEnd(this._element, this.fadeDuration)
         .then(() => {
-          if (!this.get('isDestroyed')) {
+          if (!this.isDestroyed) {
             this.set('active', false);
           }
         });
@@ -173,7 +173,7 @@ export default class TabPane extends Component.extend(ComponentChild) {
   }
 
   _showHide() {
-    if (this.get('isActive')) {
+    if (this.isActive) {
       this.show();
     } else {
       this.hide();
@@ -181,8 +181,8 @@ export default class TabPane extends Component.extend(ComponentChild) {
   }
 
   _setActive() {
-    this.set('active', this.get('isActive'));
-    this.set('showContent', this.get('isActive') && this.get('fade'));
+    this.set('active', this.isActive);
+    this.set('showContent', this.isActive && this.fade);
   }
 
   init() {

--- a/addon/components/bs-tooltip.js
+++ b/addon/components/bs-tooltip.js
@@ -99,6 +99,6 @@ export default class Tooltip extends ContextualHelp {
    */
   @computed('overlayElement')
   get arrowElement() {
-    return this.get('overlayElement').querySelector('.tooltip-arrow');
+    return this.overlayElement.querySelector('.tooltip-arrow');
   }
 }

--- a/addon/mixins/component-child.js
+++ b/addon/mixins/component-child.js
@@ -38,7 +38,7 @@ export default Mixin.create({ // eslint-disable-line ember/no-new-mixins
    */
   _registerWithParent() {
     if (!this._didRegister) {
-      let parent = this.get('_parent');
+      let parent = this._parent;
       if (parent) {
         parent.registerChild(this);
         this._didRegister = true;
@@ -53,7 +53,7 @@ export default Mixin.create({ // eslint-disable-line ember/no-new-mixins
    * @private
    */
   _unregisterFromParent() {
-    let parent = this.get('_parent');
+    let parent = this._parent;
     if (this._didRegister && parent) {
       parent.removeChild(this);
       this._didRegister = false;

--- a/addon/mixins/component-parent.js
+++ b/addon/mixins/component-parent.js
@@ -34,7 +34,7 @@ export default Mixin.create({ // eslint-disable-line ember/no-new-mixins
    */
   registerChild(child) {
     schedule('actions', this, function() {
-      this.get('children').addObject(child);
+      this.children.addObject(child);
     });
   },
 
@@ -47,7 +47,7 @@ export default Mixin.create({ // eslint-disable-line ember/no-new-mixins
    */
   removeChild(child) {
     schedule('actions', this, function() {
-      this.get('children').removeObject(child);
+      this.children.removeObject(child);
     });
   }
 });

--- a/addon/utils/cp/type-class.js
+++ b/addon/utils/cp/type-class.js
@@ -9,7 +9,7 @@ export default function typeClass(prefix, typeProperty) {
     let type = this.get(typeProperty) || 'default';
     assert('The value of `type` must be a string', typeof type === 'string' && type !== '');
 
-    if (this.get('outline')) {
+    if (this.outline) {
       return `${prefix}-outline-${type}`;
     }
     return `${prefix}-${type}`;

--- a/addon/utils/cp/uses-transition.js
+++ b/addon/utils/cp/uses-transition.js
@@ -6,6 +6,6 @@ export default function usesTransition(fadeProperty) {
   assert('You have to provide a fadeProperty for typeClass', typeof fadeProperty === 'string');
 
   return computed(fadeProperty, function() {
-    return !isFastBoot(this) && this.get('fade');
-  })
+    return !isFastBoot(this) && this.fade;
+  });
 }


### PR DESCRIPTION
We can drop that now as we don't support older Ember versions anymore for v4.

Powered by `es5-getter-ember-codemod`.