### PR TITLE
Fix `calling set on destroyed object` for tooltips when tooltip is disposed before being shown

### DIFF
--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -512,6 +512,9 @@ export default class ContextualHelp extends Component {
   }
 
   _show(skipTransition = false) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
     this.set('showHelp', true);
 
     // If this is a touch-enabled device we add extra

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -473,6 +473,15 @@ module('Integration | Component | bs-tooltip', function(hooks) {
     assert.dom('.tooltip').hasAttribute('data-test');
   });
 
+  test('can be shown and disposed in same loop', async function(assert) {
+    this.set('show', true);
+    await render(hbs`{{#if this.show}}<div id="target">{{bs-tooltip title="Dummy" class="wide"}}</div>{{/if}}`);
+    triggerEvent('#target', 'mouseenter');
+    this.set('show', false);
+    await settled();
+    assert.dom('.tooltip').doesNotExist();
+  });
+
   test('it passes accessibility checks', async function (assert) {
     await render(hbs`
     <button>


### PR DESCRIPTION
Backport of #1014 for `v4`