### PR TITLE
Refactor Button and ButtonGroup to Glimmer components

### DIFF
--- a/addon/components/bs-button-group.hbs
+++ b/addon/components/bs-button-group.hbs
@@ -1,8 +1,0 @@
-<div class="{{if this.vertical "btn-group-vertical" "btn-group"}} {{this.sizeClass}} {{if this.justified (if (macroCondition (macroGetOwnConfig "isBS3")) "btn-group-justified")}}" ...attributes>
-  {{yield
-    (hash
-      button=(component this.buttonComponent buttonGroupType=@type groupValue=@value onClick=this.buttonPressed)
-    )
-  }}
-
-</div>

--- a/addon/components/bs-button-group.hbs
+++ b/addon/components/bs-button-group.hbs
@@ -1,0 +1,7 @@
+<div class="{{if @vertical "btn-group-vertical" "btn-group"}} {{bs-size-class "btn-group" @size}} {{if @justified (if (macroCondition (macroGetOwnConfig "isBS3")) "btn-group-justified")}}" role="group" ...attributes>
+  {{yield
+    (hash
+      button=(component this.buttonComponent buttonGroupType=@type groupValue=@value onClick=this.buttonPressed)
+    )
+  }}
+</div>

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { isArray } from '@ember/array';
 import arg from 'ember-bootstrap/utils/decorators/arg';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Bootstrap-style button group, that visually groups buttons, and optionally adds radio/checkbox like behaviour.
@@ -61,6 +62,7 @@ import arg from 'ember-bootstrap/utils/decorators/arg';
   @extends Glimmer.Component
   @public
 */
+@deprecateSubclassing
 export default class ButtonGroup extends Component {
   /**
    * @property buttonComponent

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -1,11 +1,7 @@
 import { action } from '@ember/object';
-import { tagName } from '@ember-decorators/component';
-import { equal } from '@ember/object/computed';
-import Component from '@ember/component';
-import { A, isArray } from '@ember/array';
-import sizeClass from 'ember-bootstrap/utils/cp/size-class';
-import defaultValue from 'ember-bootstrap/utils/default-decorator';
-import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
+import Component from '@glimmer/component';
+import { isArray } from '@ember/array';
+import arg from 'ember-bootstrap/utils/decorators/arg';
 
 /**
   Bootstrap-style button group, that visually groups buttons, and optionally adds radio/checkbox like behaviour.
@@ -62,20 +58,16 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   @class ButtonGroup
   @namespace Components
-  @extends Ember.Component
+  @extends Glimmer.Component
   @public
 */
-@tagName('')
-@deprecateSubclassing
 export default class ButtonGroup extends Component {
-  ariaRole = 'group';
-
   /**
    * @property buttonComponent
    * @type {String}
    * @private
    */
-  @defaultValue
+  @arg
   buttonComponent = 'bs-button-group/button';
 
   /**
@@ -86,8 +78,6 @@ export default class ButtonGroup extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  vertical = false;
 
   /**
    * Set to true for the buttons to stretch at equal sizes to span the entire width of its parent. (BS3 only!)
@@ -107,8 +97,6 @@ export default class ButtonGroup extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  justified = false;
 
   /**
    * The type of the button group specifies how child buttons behave and how the `value` property will be computed:
@@ -146,14 +134,6 @@ export default class ButtonGroup extends Component {
    */
 
   /**
-   * @property isRadio
-   * @type boolean
-   * @private
-   */
-  @(equal('type', 'radio').readOnly())
-  isRadio;
-
-  /**
    * Property for size styling, set to 'lg', 'sm' or 'xs'
    *
    * Also see the [Bootstrap docs](https://getbootstrap.com/docs/4.3/components/button-group/#sizing)
@@ -162,11 +142,6 @@ export default class ButtonGroup extends Component {
    * @type String
    * @public
    */
-  @defaultValue
-  size = null;
-
-  @sizeClass('btn-group', 'size')
-  sizeClass;
 
   /**
    * This action is called whenever the button group's value should be changed because the user clicked a button.
@@ -177,27 +152,28 @@ export default class ButtonGroup extends Component {
    * @param {*} value
    * @public
    */
-  onChange() {}
 
   @action
   buttonPressed(pressedValue) {
+    if (!this.args.onChange) {
+      return;
+    }
     let newValue;
 
-    if (this.isRadio) {
+    if (this.args.type === 'radio') {
       newValue = pressedValue;
     } else {
-      if (!isArray(this.value)) {
-        newValue = A([pressedValue]);
+      if (!isArray(this.args.value)) {
+        newValue = [pressedValue];
       } else {
-        newValue = A(this.value.slice());
-        if (newValue.includes(pressedValue)) {
-          newValue.removeObject(pressedValue);
+        if (this.args.value.includes(pressedValue)) {
+          newValue = this.args.value.filter((v) => v !== pressedValue);
         } else {
-          newValue.pushObject(pressedValue);
+          newValue = [...this.args.value, pressedValue];
         }
       }
     }
 
-    this.onChange(newValue);
+    this.args.onChange(newValue);
   }
 }

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { isArray } from '@ember/array';
+import { A, isArray } from '@ember/array';
 import arg from 'ember-bootstrap/utils/decorators/arg';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
@@ -174,6 +174,10 @@ export default class ButtonGroup extends Component {
           newValue = [...this.args.value, pressedValue];
         }
       }
+
+      // For compatibility we continue to return an EmberArray instance for now
+      // @todo this should be changed for the next major release!
+      newValue = A(newValue);
     }
 
     this.args.onChange(newValue);

--- a/addon/components/bs-button-group/button.hbs
+++ b/addon/components/bs-button-group/button.hbs
@@ -1,0 +1,17 @@
+<button
+  disabled={{this.__disabled}}
+  type={{this.buttonType}}
+  class="btn {{if this.active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
+  ...attributes
+  {{on "click" this.handleClick}}
+  {{did-update this.resetState @reset}}
+>
+  {{#if this.icon}}<i class={{this.icon}}></i> {{/if}}{{this.text}}{{yield
+    (hash
+      isFulfilled=this.isFulfilled
+      isPending=this.isPending
+      isRejected=this.isRejected
+      isSettled=this.isSettled
+    )
+  }}
+</button>

--- a/addon/components/bs-button-group/button.js
+++ b/addon/components/bs-button-group/button.js
@@ -10,6 +10,8 @@ import Button from 'ember-bootstrap/components/bs-button';
  @private
  */
 export default class ButtonGroupButton extends Button {
+  '__ember-bootstrap_subclass' = true;
+
   /**
    * @property groupValue
    * @private

--- a/addon/components/bs-button-group/button.js
+++ b/addon/components/bs-button-group/button.js
@@ -1,7 +1,5 @@
-import { computed } from '@ember/object';
 import { isArray } from '@ember/array';
 import Button from 'ember-bootstrap/components/bs-button';
-import defaultValue from 'ember-bootstrap/utils/default-decorator';
 
 /**
  Internal component for button-group buttons
@@ -12,22 +10,16 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  @private
  */
 export default class ButtonGroupButton extends Button {
-  '__ember-bootstrap_subclass' = true;
-
   /**
    * @property groupValue
    * @private
    */
-  @defaultValue
-  groupValue = null;
 
   /**
    * @property buttonGroupType
    * @type string
    * @private
    */
-  @defaultValue
-  buttonGroupType = false;
 
   /**
    * @property active
@@ -35,10 +27,9 @@ export default class ButtonGroupButton extends Button {
    * @readonly
    * @private
    */
-  @(computed('buttonGroupType', 'groupValue.[]', 'value').readOnly())
   get active() {
-    let { value, groupValue } = this;
-    if (this.buttonGroupType === 'radio') {
+    let { value, groupValue } = this.args;
+    if (this.args.buttonGroupType === 'radio') {
       return value === groupValue;
     } else {
       if (isArray(groupValue)) {

--- a/addon/components/bs-button.hbs
+++ b/addon/components/bs-button.hbs
@@ -1,9 +1,10 @@
 <button
   disabled={{this.__disabled}}
   type={{this.buttonType}}
-  class="btn {{if this.active "active"}} {{if this.block "btn-block"}} {{this.sizeClass}} {{this.typeClass}}"
+  class="btn {{if @active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
   ...attributes
   {{on "click" this.handleClick}}
+  {{did-update this.resetState @reset}}
 >
   {{#if this.icon}}<i class={{this.icon}}></i> {{/if}}{{this.text}}{{yield
     (hash
@@ -13,5 +14,4 @@
       isSettled=this.isSettled
     )
   }}
-
 </button>

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -1,8 +1,11 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { equal, or } from '@ember/object/computed';
+import { warn } from '@ember/debug';
 import Component from '@glimmer/component';
 import arg from 'ember-bootstrap/utils/decorators/arg';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
+import { DEBUG } from '@glimmer/env';
 
 /**
   Implements a HTML button element, with support for all [Bootstrap button CSS styles](http://getbootstrap.com/css/#buttons)
@@ -96,6 +99,7 @@ import arg from 'ember-bootstrap/utils/decorators/arg';
   @extends Glimmer.Component
   @public
 */
+@deprecateSubclassing
 export default class Button extends Component {
   /**
    * Default label of the button. Not need if used as a block component
@@ -400,6 +404,41 @@ export default class Button extends Component {
 
     if (!this.args.bubble) {
       e.stopPropagation();
+    }
+  }
+
+  constructor() {
+    super(...arguments);
+
+    // deprecate arguments used for attribute bindings only
+    if (DEBUG) {
+      [
+        // ['buttonType:type', 'submit'],
+        ['disabled', true],
+        ['title', 'foo'],
+      ].forEach(([mapping, value]) => {
+        let argument = mapping.split(':')[0];
+        let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
+        let warningMessage =
+          `Argument ${argument} of <BsButton> component has been removed. Its only purpose ` +
+          `was setting the HTML attribute ${attribute} of the control element. You should use ` +
+          `angle bracket component invocation syntax instead:\n` +
+          `Before:\n` +
+          `  {{bs-button ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
+          `  <BsButton @${attribute}=${typeof value === 'string' ? `"${value}"` : `{{${value}}}`} />\n` +
+          `After:\n` +
+          `  <BsButton ${typeof value === 'boolean' ? attribute : `${attribute}="${value}"`} />\n` +
+          `A codemod is available to help with the required migration. See https://github.com/kaliber5/ember-bootstrap-codemods/blob/master/transforms/deprecated-attribute-arguments/README.md`;
+
+        warn(
+          warningMessage,
+          // eslint-disable-next-line ember/no-attrs-in-components
+          !Object.keys(this.args).includes(argument),
+          {
+            id: `ember-bootstrap.removed-argument.button#${argument}`,
+          }
+        );
+      });
     }
   }
 }

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -379,7 +379,7 @@ export default class Button extends Component {
     let onClick = this.args.onClick;
     let preventConcurrency = this.args.preventConcurrency;
 
-    if (!onClick) {
+    if (typeof onClick !== 'function') {
       return;
     }
 
@@ -428,16 +428,11 @@ export default class Button extends Component {
           `  <BsButton @${attribute}=${typeof value === 'string' ? `"${value}"` : `{{${value}}}`} />\n` +
           `After:\n` +
           `  <BsButton ${typeof value === 'boolean' ? attribute : `${attribute}="${value}"`} />\n` +
-          `A codemod is available to help with the required migration. See https://github.com/kaliber5/ember-bootstrap-codemods/blob/master/transforms/deprecated-attribute-arguments/README.md`;
+          `A codemod is available to help withFi the required migration. See https://github.com/kaliber5/ember-bootstrap-codemods/blob/master/transforms/deprecated-attribute-arguments/README.md`;
 
-        warn(
-          warningMessage,
-          // eslint-disable-next-line ember/no-attrs-in-components
-          !Object.keys(this.args).includes(argument),
-          {
-            id: `ember-bootstrap.removed-argument.button#${argument}`,
-          }
-        );
+        warn(warningMessage, !Object.keys(this.args).includes(argument), {
+          id: `ember-bootstrap.removed-argument.button#${argument}`,
+        });
       });
     }
   }

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -1,17 +1,8 @@
-import { tagName } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
-import { computed, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { equal, or } from '@ember/object/computed';
-import { scheduleOnce } from '@ember/runloop';
-import { warn } from '@ember/debug';
-import { DEBUG } from '@glimmer/env';
-import Component from '@ember/component';
-import sizeClass from 'ember-bootstrap/utils/cp/size-class';
-import typeClass from 'ember-bootstrap/utils/cp/type-class';
-import overrideableCP from 'ember-bootstrap/utils/cp/overrideable';
-import defaultValue from 'ember-bootstrap/utils/default-decorator';
-import { macroCondition, getOwnConfig } from '@embroider/macros';
-import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
+import Component from '@glimmer/component';
+import arg from 'ember-bootstrap/utils/decorators/arg';
 
 /**
   Implements a HTML button element, with support for all [Bootstrap button CSS styles](http://getbootstrap.com/css/#buttons)
@@ -102,11 +93,9 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   @class Button
   @namespace Components
-  @extends Ember.Component
+  @extends Glimmer.Component
   @public
 */
-@tagName('')
-@deprecateSubclassing
 export default class Button extends Component {
   /**
    * Default label of the button. Not need if used as a block component
@@ -115,8 +104,6 @@ export default class Button extends Component {
    * @type string
    * @public
    */
-  @defaultValue
-  defaultText = null;
 
   /**
    * Label of the button used if `onClick` event has returned a Promise which is pending.
@@ -126,8 +113,6 @@ export default class Button extends Component {
    * @type string
    * @public
    */
-  @defaultValue
-  pendingText = undefined;
 
   /**
    * Label of the button used if `onClick` event has returned a Promise which succeeded.
@@ -137,8 +122,6 @@ export default class Button extends Component {
    * @type string
    * @public
    */
-  @defaultValue
-  fulfilledText = undefined;
 
   /**
    * Label of the button used if `onClick` event has returned a Promise which failed.
@@ -148,8 +131,6 @@ export default class Button extends Component {
    * @type string
    * @public
    */
-  @defaultValue
-  rejectedText = undefined;
 
   /**
    * Property to disable the button only used in internal communication
@@ -160,16 +141,13 @@ export default class Button extends Component {
    * @default null
    * @private
    */
-  @defaultValue
-  _disabled = null;
 
-  @computed('_disabled', 'isPending', 'preventConcurrency')
   get __disabled() {
-    if (this._disabled !== null) {
-      return this._disabled;
+    if (this.args._disabled !== undefined) {
+      return this.args._disabled;
     }
 
-    return this.isPending && this.preventConcurrency;
+    return this.isPending && this.args.preventConcurrency !== false;
   }
 
   /**
@@ -181,8 +159,7 @@ export default class Button extends Component {
    * @deprecated
    * @public
    */
-  @defaultValue
-  buttonType = 'button';
+  @arg buttonType = 'button';
 
   /**
    * Set the 'active' class to apply active/pressed CSS styling
@@ -192,8 +169,6 @@ export default class Button extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  active = false;
 
   /**
    * Property for block level buttons
@@ -204,8 +179,7 @@ export default class Button extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  block = false;
+  @arg block = false;
 
   /**
    * A click event on a button will not bubble up the DOM tree if it has an `onClick` action handler. Set to true to
@@ -216,8 +190,6 @@ export default class Button extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  bubble = false;
 
   /**
    * If button is active and this is set, the icon property will match this property
@@ -226,8 +198,6 @@ export default class Button extends Component {
    * @type String
    * @public
    */
-  @defaultValue
-  iconActive = null;
 
   /**
    * If button is inactive and this is set, the icon property will match this property
@@ -236,8 +206,6 @@ export default class Button extends Component {
    * @type String
    * @public
    */
-  @defaultValue
-  iconInactive = null;
 
   /**
    * Class(es) (e.g. glyphicons or font awesome) to use as a button icon
@@ -245,13 +213,11 @@ export default class Button extends Component {
    *
    * @property icon
    * @type String
-   * @readonly
    * @public
    */
-  @overrideableCP('active', function () {
-    return this.active ? this.iconActive : this.iconInactive;
-  })
-  icon;
+  get icon() {
+    return this.args.icon || (this.args.active ? this.args.iconActive : this.args.iconInactive);
+  }
 
   /**
    * Supply a value that will be associated with this button. This will be send
@@ -261,8 +227,6 @@ export default class Button extends Component {
    * @type any
    * @public
    */
-  @defaultValue
-  value = null;
 
   /**
    * Controls if `onClick` action is fired concurrently. If `true` clicking button multiple times will not trigger
@@ -275,8 +239,6 @@ export default class Button extends Component {
    * @default true
    * @public
    */
-  @defaultValue
-  preventConcurrency = true;
 
   /**
    * State of the button. The button's label (if not used as a block component) will be set to the
@@ -290,8 +252,7 @@ export default class Button extends Component {
    * @default 'default'
    * @private
    */
-  @defaultValue
-  state = 'default';
+  @tracked state = 'default';
 
   /**
    * Promise returned by `onClick` event is pending.
@@ -344,8 +305,6 @@ export default class Button extends Component {
    * @type boolean
    * @public
    */
-  @defaultValue
-  reset = null;
 
   /**
    * Property for size styling, set to 'lg', 'sm' or 'xs'
@@ -356,11 +315,6 @@ export default class Button extends Component {
    * @type String
    * @public
    */
-  @defaultValue
-  size = null;
-
-  @sizeClass('btn', 'size')
-  sizeClass;
 
   /**
    * Property for type styling
@@ -372,8 +326,6 @@ export default class Button extends Component {
    * @default 'secondary'
    * @public
    */
-  @defaultValue
-  type = macroCondition(getOwnConfig().isBS4) ? 'secondary' : 'default';
 
   /**
    * Property to create outline buttons (BS4+ only)
@@ -383,11 +335,6 @@ export default class Button extends Component {
    * @default false
    * @public
    */
-  @defaultValue
-  outline = false;
-
-  @typeClass('btn', 'type')
-  typeClass;
 
   /**
    * When clicking the button this action is called with the value of the button (that is the value of the "value" property).
@@ -403,8 +350,6 @@ export default class Button extends Component {
    * @param {*} value
    * @public
    */
-  @defaultValue
-  onClick = null;
 
   /**
    * This will reset the state property to 'default', and with that the button's label to defaultText
@@ -412,20 +357,13 @@ export default class Button extends Component {
    * @method resetState
    * @private
    */
+  @action
   resetState() {
-    this.set('state', 'default');
+    this.state = 'default';
   }
 
-  @observes('reset')
-  resetObserver() {
-    if (this.reset) {
-      scheduleOnce('actions', this, 'resetState');
-    }
-  }
-
-  @computed('state', 'defaultText', 'pendingText', 'fulfilledText', 'rejectedText')
   get text() {
-    return this[`${this.state}Text`] || this.defaultText;
+    return this.args[`${this.state}Text`] || this.args.defaultText;
   }
 
   /**
@@ -434,69 +372,34 @@ export default class Button extends Component {
    */
   @action
   handleClick(e) {
-    let onClick = this.onClick;
-    let preventConcurrency = this.preventConcurrency;
+    let onClick = this.args.onClick;
+    let preventConcurrency = this.args.preventConcurrency;
 
-    if (onClick === null || onClick === undefined) {
+    if (!onClick) {
       return;
     }
 
     if (!preventConcurrency || !this.isPending) {
-      let promise = onClick(this.value);
+      let promise = onClick(this.args.value);
       if (promise && typeof promise.then === 'function' && !this.isDestroyed) {
-        this.set('state', 'pending');
+        this.state = 'pending';
         promise.then(
           () => {
             if (!this.isDestroyed) {
-              this.set('state', 'fulfilled');
+              this.state = 'fulfilled';
             }
           },
           () => {
             if (!this.isDestroyed) {
-              this.set('state', 'rejected');
+              this.state = 'rejected';
             }
           }
         );
       }
     }
 
-    if (!this.bubble) {
+    if (!this.args.bubble) {
       e.stopPropagation();
-    }
-  }
-
-  init() {
-    super.init(...arguments);
-
-    // deprecate arguments used for attribute bindings only
-    if (DEBUG) {
-      [
-        // ['buttonType:type', 'submit'],
-        ['disabled', true],
-        ['title', 'foo'],
-      ].forEach(([mapping, value]) => {
-        let argument = mapping.split(':')[0];
-        let attribute = mapping.includes(':') ? mapping.split(':')[1] : argument;
-        let warningMessage =
-          `Argument ${argument} of <BsButton> component has been removed. Its only purpose ` +
-          `was setting the HTML attribute ${attribute} of the control element. You should use ` +
-          `angle bracket component invocation syntax instead:\n` +
-          `Before:\n` +
-          `  {{bs-button ${attribute}=${typeof value === 'string' ? `"${value}"` : value}}}\n` +
-          `  <BsButton @${attribute}=${typeof value === 'string' ? `"${value}"` : `{{${value}}}`} />\n` +
-          `After:\n` +
-          `  <BsButton ${typeof value === 'boolean' ? attribute : `${attribute}="${value}"`} />\n` +
-          `A codemod is available to help with the required migration. See https://github.com/kaliber5/ember-bootstrap-codemods/blob/master/transforms/deprecated-attribute-arguments/README.md`;
-
-        warn(
-          warningMessage,
-          // eslint-disable-next-line ember/no-attrs-in-components
-          !Object.keys(this.attrs).includes(argument),
-          {
-            id: `ember-bootstrap.removed-argument.button#${argument}`,
-          }
-        );
-      });
     }
   }
 }

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { equal, or } from '@ember/object/computed';
+import { equal, or } from 'macro-decorators';
 import { warn } from '@ember/debug';
 import Component from '@glimmer/component';
 import arg from 'ember-bootstrap/utils/decorators/arg';

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -256,7 +256,13 @@ export default class Button extends Component {
    * @default 'default'
    * @private
    */
-  @tracked state = 'default';
+  @tracked _state = 'default';
+  get state() {
+    return this.args.state ?? this._state;
+  }
+  set state(state) {
+    this._state = state;
+  }
 
   /**
    * Promise returned by `onClick` event is pending.

--- a/addon/components/bs-dropdown/button.hbs
+++ b/addon/components/bs-dropdown/button.hbs
@@ -1,12 +1,11 @@
 <button
   disabled={{this.__disabled}}
   type={{this.buttonType}}
-  title={{this.title}}
-  aria-expanded={{this.ariaExpanded}}
-  class="btn dropdown-toggle {{if this.active "active"}} {{if this.block "btn-block"}} {{this.sizeClass}} {{this.typeClass}}"
+  aria-expanded={{if @isOpen "true" "false"}}
+  class="btn dropdown-toggle {{if @active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
   ...attributes
   {{on "click" this.handleClick}}
-  {{on "keydown" this.handleKeyDown}}
+  {{on "keydown" @onKeyDown}}
   {{did-insert @registerChildElement "toggle"}}
   {{will-destroy @unregisterChildElement "toggle"}}
 >
@@ -18,5 +17,4 @@
       isSettled=this.isSettled
     )
   }}
-
 </button>

--- a/addon/components/bs-dropdown/button.js
+++ b/addon/components/bs-dropdown/button.js
@@ -1,5 +1,4 @@
 import Button from 'ember-bootstrap/components/bs-button';
-import { computed, action } from '@ember/object';
 
 /**
  Button component with that can act as a dropdown toggler.
@@ -11,16 +10,4 @@ import { computed, action } from '@ember/object';
  @extends Components.Button
  @public
  */
-export default class DropdownButton extends Button {
-  '__ember-bootstrap_subclass' = true;
-
-  @action
-  handleKeyDown(e) {
-    this.onKeyDown(e);
-  }
-
-  @computed('isOpen')
-  get ariaExpanded() {
-    return this.isOpen ? 'true' : 'false';
-  }
-}
+export default class DropdownButton extends Button {}

--- a/addon/helpers/bs-size-class.js
+++ b/addon/helpers/bs-size-class.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+import { isBlank } from '@ember/utils';
+
+export function sizeClassHelper([prefix, size], { default: defaultValue }) {
+  size = size ?? defaultValue;
+  return isBlank(size) ? null : `${prefix}-${size}`;
+}
+
+export default helper(sizeClassHelper);

--- a/addon/helpers/bs-type-class.js
+++ b/addon/helpers/bs-type-class.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+export function typeClassHelper([prefix, type], { default: defaultValue, outline = false }) {
+  type = type ?? defaultValue;
+  if (outline) {
+    return `${prefix}-outline-${type}`;
+  }
+  return `${prefix}-${type}`;
+}
+
+export default helper(typeClassHelper);

--- a/addon/utils/cp/size-class.js
+++ b/addon/utils/cp/size-class.js
@@ -7,7 +7,7 @@ export default function sizeClass(prefix, sizeProperty) {
   assert('You have to provide a sizeProperty for sizeClass', typeof sizeProperty === 'string');
 
   return computed('size', function () {
-    let size = this.get(sizeProperty);
+    let size = this[sizeProperty];
     assert('The value of `size` must be a string', !size || (typeof size === 'string' && size !== ''));
 
     return isBlank(size) ? null : `${prefix}-${size}`;

--- a/addon/utils/cp/type-class.js
+++ b/addon/utils/cp/type-class.js
@@ -6,7 +6,7 @@ export default function typeClass(prefix, typeProperty) {
   assert('You have to provide a typeProperty for typeClass', typeof typeProperty === 'string');
 
   return computed('outline', 'type', function () {
-    let type = this.get(typeProperty) || 'default';
+    let type = this[typeProperty] || 'default';
     assert('The value of `type` must be a string', typeof type === 'string' && type !== '');
 
     if (this.outline) {

--- a/addon/utils/decorators/arg.js
+++ b/addon/utils/decorators/arg.js
@@ -1,0 +1,10 @@
+export default function arg(target, key, descriptor) {
+  let defaultValue = descriptor.initializer ? descriptor.initializer() : undefined;
+
+  return {
+    get() {
+      const argValue = this.args[key];
+      return argValue !== undefined ? argValue : defaultValue;
+    },
+  };
+}

--- a/addon/utils/deprecate-subclassing.js
+++ b/addon/utils/deprecate-subclassing.js
@@ -1,21 +1,24 @@
 import { DEBUG } from '@glimmer/env';
 import { deprecate } from '@ember/debug';
+import { next } from '@ember/runloop';
 
 export default function deprecateSubclassing(target) {
   if (DEBUG) {
     const wrapperClass = class extends target {
-      init() {
-        deprecate(
-          `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
-          // the `__ember-bootstrap_subclass` flag is an escape hatch for "privileged" addons like validations addons that currently still have to rely on subclassing
-          wrapperClass === this.constructor || this['__ember-bootstrap_subclass'] === true,
-          {
-            id: `ember-bootstrap.subclassing#${target.name}`,
-            until: '5.0.0',
-          }
-        );
-
-        return super.init(...arguments);
+      constructor() {
+        super(...arguments);
+        // we need to delay the deprecation check, as the __ember-bootstrap_subclass class field will only be set *after* the constructor
+        next(() => {
+          deprecate(
+            `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
+            // the `__ember-bootstrap_subclass` flag is an escape hatch for "privileged" addons like validations addons that currently still have to rely on subclassing
+            wrapperClass === this.constructor || this['__ember-bootstrap_subclass'] === true,
+            {
+              id: `ember-bootstrap.subclassing#${target.name}`,
+              until: '5.0.0',
+            }
+          );
+        });
       }
     };
 

--- a/app/helpers/bs-size-class.js
+++ b/app/helpers/bs-size-class.js
@@ -1,0 +1,1 @@
+export { default, eq } from 'ember-bootstrap/helpers/bs-size-class';

--- a/app/helpers/bs-type-class.js
+++ b/app/helpers/bs-type-class.js
@@ -1,0 +1,1 @@
+export { default, eq } from 'ember-bootstrap/helpers/bs-type-class';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
     "@embroider/macros": "^0.21.0",
+    "@glimmer/component": "^1.0.1",
+    "@glimmer/tracking": "^1.0.1",
     "broccoli-debug": "^0.6.3",
     "broccoli-funnel": "^3.0.2",
     "broccoli-merge-trees": "^4.2.0",
@@ -69,8 +71,6 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@glimmer/component": "^1.0.1",
-    "@glimmer/tracking": "^1.0.1",
     "babel-eslint": "^10.1.0",
     "bootstrap": "^4.5.2",
     "bootstrap-sass": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",
     "chalk": "^4.1.0",
+    "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-build-config-editor": "0.5.1",
     "ember-cli-htmlbars": "^5.1.2",
@@ -65,6 +66,7 @@
     "ember-style-modifier": "^0.6.0",
     "findup-sync": "^4.0.0",
     "fs-extra": "^9.0.1",
+    "macro-decorators": "^0.1.2",
     "resolve": "^1.17.0",
     "rsvp": "^4.0.1",
     "silent-error": "^1.0.1"

--- a/tests/integration/components/subclassing-test.js
+++ b/tests/integration/components/subclassing-test.js
@@ -6,7 +6,6 @@ import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import BsAccordion from 'ember-bootstrap/components/bs-accordion';
 import BsAlert from 'ember-bootstrap/components/bs-alert';
-import BsButtonGroup from 'ember-bootstrap/components/bs-button-group';
 import BsCarousel from 'ember-bootstrap/components/bs-carousel';
 import BsCollapse from 'ember-bootstrap/components/bs-collapse';
 import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
@@ -28,10 +27,6 @@ const tests = [
   {
     name: 'BsAlert',
     clazz: BsAlert,
-  },
-  {
-    name: 'BsButtonGroup',
-    clazz: BsButtonGroup,
   },
   {
     name: 'BsCarousel',

--- a/tests/integration/components/subclassing-test.js
+++ b/tests/integration/components/subclassing-test.js
@@ -6,6 +6,8 @@ import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import BsAccordion from 'ember-bootstrap/components/bs-accordion';
 import BsAlert from 'ember-bootstrap/components/bs-alert';
+import BsButton from 'ember-bootstrap/components/bs-button';
+import BsButtonGroup from 'ember-bootstrap/components/bs-button-group';
 import BsCarousel from 'ember-bootstrap/components/bs-carousel';
 import BsCollapse from 'ember-bootstrap/components/bs-collapse';
 import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
@@ -27,6 +29,14 @@ const tests = [
   {
     name: 'BsAlert',
     clazz: BsAlert,
+  },
+  {
+    name: 'BsButton',
+    clazz: BsButton,
+  },
+  {
+    name: 'BsButtonGroup',
+    clazz: BsButtonGroup,
   },
   {
     name: 'BsCarousel',

--- a/tests/integration/components/subclassing-test.js
+++ b/tests/integration/components/subclassing-test.js
@@ -6,7 +6,6 @@ import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import BsAccordion from 'ember-bootstrap/components/bs-accordion';
 import BsAlert from 'ember-bootstrap/components/bs-alert';
-import BsButton from 'ember-bootstrap/components/bs-button';
 import BsButtonGroup from 'ember-bootstrap/components/bs-button-group';
 import BsCarousel from 'ember-bootstrap/components/bs-carousel';
 import BsCollapse from 'ember-bootstrap/components/bs-collapse';
@@ -29,10 +28,6 @@ const tests = [
   {
     name: 'BsAlert',
     clazz: BsAlert,
-  },
-  {
-    name: 'BsButton',
-    clazz: BsButton,
   },
   {
     name: 'BsButtonGroup',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5557,6 +5557,40 @@ ember-auto-import@^1.2.15, ember-auto-import@^1.5.3:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
+ember-auto-import@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.6.0.tgz#00a498172b04f7084a5d2a327f76f577038ed403"
+  integrity sha512-BRBrmbDXRuXG/WYbn/2DXM7bFNyQuT80du1scUrrX0+xFVkDOU08s46ZPCvzYprzSg2htgrztQ/nVdnfbIBV+Q==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/preset-env" "^7.10.2"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    "@embroider/core" "^0.4.3"
+    babel-core "^6.26.3"
+    babel-loader "^8.0.6"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^1.0.0"
+    handlebars "^4.3.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^0.3.3"
+    webpack "~4.28"
+
 ember-cli-app-version@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-app-version/-/ember-cli-app-version-3.2.0.tgz#7b9ad0e1b63ae0518648356ee24c703e922bc26e"
@@ -10278,6 +10312,11 @@ macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
+
+macro-decorators@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/macro-decorators/-/macro-decorators-0.1.2.tgz#1d5cf1276d343371040af192901947f2a0af03c1"
+  integrity sha512-BV5XPmCm9kPSMtgfZiv0vTjOooe5pTIPIVkdoqbC49H1B7z22KB39H50R2ZNclZDQlmVyviLozRatKnOYZkwzg==
 
 make-dir@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Proof of concept of how easy/difficult it would be to refactor components:
* https://github.com/ember-codemods/ember-tracked-properties-codemod helped a bit
* used https://github.com/jkusa/ember-arg-types at first, but later decided to move most usages into the template (named args, custom helpers instead of CPs), and a custom, very simple `@args` decorator
* took a few hours, but was ok
* ~tests for `<BsButtonGroup> ` and `<BsDropdown>` are *expectedly* failing, as they access private properties of the button, which does not work anymore~
* tests for `<BsButton>` should be passing, without any changes. Does that make us confident enough that we can refactor component by component in minor version updates, without breaking changes? Or should we do a single major version release with all component refactored? 🤔 