### PR TITLE
wrong warning message if using yarn link

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = {
     let bowerDependencies = this.app.project.bowerDependencies();
 
     if (this.getBootstrapVersion() === 4) {
-      let checker = new VersionChecker(this);
+      let checker = new VersionChecker(this.project);
       let dep = checker.for('bootstrap');
 
       if (!dep.gte(minimumBS4Version)) {


### PR DESCRIPTION
If using `yarn link` and not installing `devDependencies` the warning message was shown cause `VersionChecker(this)` checks versions of the addons dependencies not the ones of the consuming application.

This issue was highlighted by `undefined` in the warning message:

> For Bootstrap 4 support this version of ember-bootstrap requires at least Bootstrap 4.0.0-beta, but you have undefined. Please run `ember generate ember-bootstrap` to update your dependencies!

Rwjblue explained me that difference some time ago: https://github.com/rwjblue/ember-cli-content-security-policy/pull/121#pullrequestreview-335292964