### PR TITLE
WIP: transpile object spread syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,5 +343,11 @@ module.exports = {
 
     whitelist.forEach(_addToWhitelist);
     return list;
+  },
+
+  options: {
+    babel: {
+      plugins: ['transform-object-rest-spread']
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "broccoli-debug": "^0.6.3",
     "broccoli-funnel": "^2.0.0",
     "broccoli-merge-trees": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,6 +2879,11 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
   integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -3091,6 +3096,14 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
I faced an issue that an app was throwing a syntax error in Microsoft Edge after I removed IE11 from build list. Adding the babel transform for it to the addon fixed it.

Object spread syntax is at least used here: https://github.com/kaliber5/ember-bootstrap/blob/44c393a2cd991060a4dab7e55afe5220cf493f54/addon/utils/default-decorator.js#L13

For some reason I was not able to reproduce the issue if doing `yarn link` or using `file:` or `link:` protocol. That wasn't helpful for debugging...