### PR TITLE
Run CI w/ node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
Although support for node 8 will only be dropped in v4, there is a problem with some transitive dependency not properly following SemVer, having dropped node support in a minor release. Not going to fix this, as v4 is coming soon, but need a way to make CI green again...