### PR TITLE
Drop support for Ember 3.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
     - /^v\d+\.\d+\.\d+/
 
 jobs:
-  fail_fast: true
+  fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-canary
 
@@ -50,7 +50,8 @@ jobs:
     - yarn lint:js
     - yarn test
 
-  - name: "Floating Dependencies"
+  - stage: "Additional Tests"
+    name: "Floating Dependencies"
     script:
     - yarn test
 
@@ -67,8 +68,8 @@ jobs:
 
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
-  - stage: "Additional Tests"
-    env: EMBER_TRY_SCENARIO=ember-default BABELPOLYFILL=true BEFORE_SCRIPT="ember browserstack:connect" AFTER_SCRIPT="ember browserstack:disconnect" TEST_COMMAND="ember test --filter !FastBoot --config-file testem.browserstack.js"
+  - env: EMBER_TRY_SCENARIO=ember-default BABELPOLYFILL=true BEFORE_SCRIPT="ember browserstack:connect" AFTER_SCRIPT="ember browserstack:disconnect" TEST_COMMAND="ember test --filter !FastBoot --config-file testem.browserstack.js"
+  - env: EMBER_TRY_SCENARIO=ember-lts-3.16
   - env: EMBER_TRY_SCENARIO=ember-release
   - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To switch Bootstrap version or preprocessor, see the [setup documentation](http:
 
 Ember Bootstrap works and is fully [tested](https://travis-ci.org/kaliber5/ember-bootstrap) with
 
-* Ember.js 3.15+ (including all optional features)
+* Ember.js 3.16+ (including all optional features)
 * Ember CLI 3.15+
 * Bootstrap 3 and 4
 * all modern evergreen browsers (Chrome, Firefox, Safari, Edge) and IE 11 (the latter requires the use of the [Babel polyfill](https://github.com/babel/ember-cli-babel#polyfill)).

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,6 +9,15 @@ module.exports = async function() {
     command: 'ember test --filter !FastBoot',
     scenarios: [
       {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0',
+            'bootstrap': bootstrapVersion
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Now support starts with the latest LTS release.