### PR TITLE
upgrade ember-cli-content-security-policy to ^2.0.0-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-blueprint-test-helpers": "^0.19.1",
     "ember-cli-browserstack": "^0.0.7",
-    "ember-cli-content-security-policy": "^1.0.0",
+    "ember-cli-content-security-policy": "^2.0.0-1",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^5.1.0",
     "ember-cli-fastboot": "^2.0.0",

--- a/tests/dummy/config/content-security-policy.js
+++ b/tests/dummy/config/content-security-policy.js
@@ -1,0 +1,18 @@
+module.exports = function() {
+  return {
+    delivery: ['meta'],
+    policy: {
+      'default-src':  ["'none'"],
+      'script-src':   ["'self'"],
+      'font-src':     ["'self'"],
+      'connect-src':  ["'self'"],
+      'img-src':      [
+        "'self'",
+        // Bootstrap 4 uses data URL for some SVG images in CSS
+        "data:",
+      ],
+      'style-src':    ["'self'"],
+      'media-src':    ["'self'"],
+    },
+  };
+}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -24,17 +24,6 @@ module.exports = function(environment) {
 
     bootstrapVersion: process.env.BOOTSTRAPVERSION || 4,
     failOnDeprecation: !!process.env.FAIL_ON_DEPRECATION,
-    contentSecurityPolicy: {
-      'script-src': [
-        "'self'"
-      ],
-      'img-src': [
-        "'self'",
-        // Bootstrap 4 uses data URL for some SVG images in CSS
-        "data:",
-      ]
-    },
-    contentSecurityPolicyMeta: true,
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/]
     },

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -8,17 +8,5 @@ if (typeof Promise === 'undefined') {
   window.Promise = EmberPromise;
 }
 
-document.addEventListener('securitypolicyviolation', function({ target, blockedURI, violatedDirective }) {
-  if (target.className && target.className.match(/ember-basic-dropdown/) || target.hasAttribute && target.hasAttribute('data-test-ignore-csp')) {
-    return;
-  }
-
-  throw new Error(
-    'Content-Security-Policy violation detected: ' +
-    `Violated directive: ${violatedDirective}. ` +
-    `Blocked URI: ${blockedURI}`
-  );
-});
-
 setApplication(Application.create(config.APP));
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4553,6 +4553,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -5872,13 +5880,15 @@ ember-cli-build-config-editor@0.5.0:
   dependencies:
     recast "^0.12.0"
 
-ember-cli-content-security-policy@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-content-security-policy/-/ember-cli-content-security-policy-1.1.1.tgz#7d91a695319d8f99c317f3a594fba77bbfedf6c7"
-  integrity sha512-QgGAFt1nmsb0qF2YXI5iSM7jJVb09R2hrfX7uR+kkXMb5VyNQXdo2ZlX/DuIbePQVY4q9THpRh8Yf0UHJNbvDQ==
+ember-cli-content-security-policy@^2.0.0-1:
+  version "2.0.0-1"
+  resolved "https://registry.yarnpkg.com/ember-cli-content-security-policy/-/ember-cli-content-security-policy-2.0.0-1.tgz#ed54e506cd51e9566b05ea1f5d3e886f47fd18ed"
+  integrity sha512-Iz2qFGZdNYQony/v1rp19ohAHE/JNoz4+MsK2E0XDLRTuFVeIOvpCLp+7On0915taQi+RkG8GyC46XM1IagMsQ==
   dependencies:
     body-parser "^1.17.0"
-    chalk "^2.0.0"
+    chalk "^4.0.0"
+    ember-cli-babel "^7.17.2"
+    ember-cli-version-checker "^5.0.2"
 
 ember-cli-dependency-checker@^3.2.0:
   version "3.2.0"
@@ -6163,6 +6173,15 @@ ember-cli-version-checker@^4.1.0:
   dependencies:
     resolve-package-path "^2.0.0"
     semver "^6.3.0"
+    silent-error "^1.1.1"
+
+ember-cli-version-checker@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.0.2.tgz#7e96157be4b13b083a68078b188820193275d8c4"
+  integrity sha512-cqFrIg9++GKdpMv2DP8pryAhTcmCYUL2hzHatLwkcJe23s+ioZ0JQWte0avxZ5lJnwn5e3kzUKkLkDfHDFBMUw==
+  dependencies:
+    resolve-package-path "^2.0.0"
+    semver "^7.1.3"
     silent-error "^1.1.1"
 
 ember-cli-yuidoc@^0.8.8:
@@ -12297,6 +12316,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.3:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
- Upgrades `ember-cli-content-security-policy` to ^2.0.0-1.
- Migrates it's configuration to `config/content-security-policy.js`. The config in `content/environment.js` is deprecated.
- Removes our custom solution to fail tests on CSP violations as it's provided by `ember-cli-content-security-policy@v2` out of the box.