### PR TITLE
Fix autofocus for Modals in IE11

### DIFF
--- a/addon/components/bs-modal/dialog.js
+++ b/addon/components/bs-modal/dialog.js
@@ -4,6 +4,7 @@ import { readOnly } from '@ember/object/computed';
 import { isBlank } from '@ember/utils';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/dialog';
+import { next } from '@ember/runloop';
 
 /**
  Internal component for modal's markup and event handling. Should not be used directly.
@@ -73,7 +74,7 @@ export default class ModalDialog extends Component {
   setInitialFocus(element) {
     let autofocus = element && element.querySelector('[autofocus]');
     if (autofocus) {
-      autofocus.focus();
+      next(() => autofocus.focus());
     }
   }
 


### PR DESCRIPTION
There seem to be some timing differences for IE11 related to the focus handling of `focus-trap` and our own `setInitialFocus`. Delaying our own focus handling seems to fix the issue, which was not just a flakey IE11 test issue, but a real one.