### PR TITLE
Reset style attribute after transition of BsCollapse

### DIFF
--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -3,12 +3,13 @@ import layout from 'ember-bootstrap/templates/components/bs-collapse';
 import { alias, and, not } from '@ember/object/computed';
 import { addObserver } from '@ember/object/observers';
 import Component from '@ember/component';
-import { isPresent } from '@ember/utils';
+import { isPresent, isNone } from '@ember/utils';
 import { next } from '@ember/runloop';
 import { camelize } from '@ember/string';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import { assert } from '@ember/debug';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import { computed } from '@ember/object';
 
 /**
   An Ember component that mimics the behaviour of [Bootstrap's collapse.js plugin](http://getbootstrap.com/javascript/#collapse)
@@ -91,6 +92,29 @@ export default class Collapse extends Component {
    * @public
    */
   expandedSize = null;
+
+  /**
+   * Calculates a hash for style attribute.
+   */
+  @computed('collapseDimension', 'collapseSize')
+  get cssStyle() {
+    if (isNone(this.collapseSize)) {
+      return {};
+    }
+
+    if (this.transitionDuration) {
+      const transitionDurationS = this.transitionDuration / 1000;
+
+      return {
+        [this.collapseDimension]: `${this.collapseSize}px`,
+        transition: `${this.collapseDimension} ${transitionDurationS}s ease`,
+      };
+    }
+
+    return {
+      [this.collapseDimension]: `${this.collapseSize}px`,
+    };
+  }
 
   /**
    * Usually the size (height) of the element is only set while transitioning, and reseted afterwards. Set to true to always set a size.

--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -102,15 +102,6 @@ export default class Collapse extends Component {
       return {};
     }
 
-    if (this.transitionDuration) {
-      const transitionDurationS = this.transitionDuration / 1000;
-
-      return {
-        [this.collapseDimension]: `${this.collapseSize}px`,
-        transition: `${this.collapseDimension} ${transitionDurationS}s ease`,
-      };
-    }
-
     return {
       [this.collapseDimension]: `${this.collapseSize}px`,
     };

--- a/addon/templates/components/bs-collapse.hbs
+++ b/addon/templates/components/bs-collapse.hbs
@@ -2,10 +2,7 @@
   class="{{if this.collapse "collapse"}} {{if this.collapsing "collapsing"}} {{if this.showContent (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}"
   ...attributes
   {{ref this "_element"}}
-  {{style
-    width=(if (bs-eq this.collapseDimension "height") (if this.width (concat this.collapseSize "px") ""))
-    height=(if (bs-eq this.collapseDimension "height") (if this.collapseSize (concat this.collapseSize "px") ""))
-  }}
+  {{style this.cssStyle}}
 >
   {{yield}}
 </div>

--- a/addon/templates/components/bs-collapse.hbs
+++ b/addon/templates/components/bs-collapse.hbs
@@ -3,8 +3,8 @@
   ...attributes
   {{ref this "_element"}}
   {{style
-    width=(if (bs-eq this.collapseDimension "width") (concat this.collapseSize "px"))
-    height=(if (bs-eq this.collapseDimension "height") (concat this.collapseSize "px"))
+    width=(if (bs-eq this.collapseDimension "height") (if this.width (concat this.collapseSize "px") ""))
+    height=(if (bs-eq this.collapseDimension "height") (if this.collapseSize (concat this.collapseSize "px") ""))
   }}
 >
   {{yield}}

--- a/addon/utils/transition-end.js
+++ b/addon/utils/transition-end.js
@@ -2,13 +2,23 @@ import Ember from 'ember';
 import { cancel, later } from '@ember/runloop';
 import { Promise, reject } from 'rsvp';
 
+let _skipTransition;
+
+export function skipTransition(bool) {
+  _skipTransition = bool;
+}
+
+function _isSkipped() {
+  return (_skipTransition === true) | (_skipTransition !== false) && Ember.testing;
+}
+
 export default function waitForTransitionEnd(node, duration = 0) {
   if (!node) {
     return reject();
   }
   let backup;
 
-  if (Ember.testing) {
+  if (_isSkipped()) {
     duration = 0;
   }
 

--- a/tests/integration/components/bs-collapse-test.js
+++ b/tests/integration/components/bs-collapse-test.js
@@ -71,6 +71,25 @@ module('Integration | Component | bs-collapse', function (hooks) {
     assert.dom('.collapse').hasNoClass('in', 'collapse does not have in class');
   });
 
+  test('after collapsing/expanding height/width is set correctly ', async function (assert) {
+    this.set('collapsed', true);
+    await render(
+      hbs`<BsCollapse @expandedSize={{200}} @transitionDuration={{500}} @collapsed={{collapsed}}><p>Just some content</p></BsCollapse>`
+    );
+    this.set('collapsed', false);
+
+    assert.equal(this.element.querySelector('div.collapsing').style.height, '200px', 'should have height of 200px');
+
+    // wait for transitions to complete
+    await settled();
+
+    assert.equal(
+      this.element.querySelector('div.collapse').style.height,
+      '',
+      'should have height removed after transition'
+    );
+  });
+
   test('it passes accessibility checks', async function (assert) {
     await render(hbs`<button type="button">Test</button><BsCollapse><p>Just some content</p></BsCollapse>`);
 

--- a/tests/integration/components/bs-collapse-test.js
+++ b/tests/integration/components/bs-collapse-test.js
@@ -2,13 +2,22 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { waitFor, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { test, visibilityClass } from '../../helpers/bootstrap-test';
+import { test, visibilityClass, delay } from '../../helpers/bootstrap-test';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { skipTransition } from 'ember-bootstrap/utils/transition-end';
 
 module('Integration | Component | bs-collapse', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
+
+  hooks.before(function () {
+    skipTransition(false);
+  });
+
+  hooks.after(function () {
+    skipTransition(undefined);
+  });
 
   hooks.beforeEach(function () {
     this.actions = {};
@@ -78,13 +87,14 @@ module('Integration | Component | bs-collapse', function (hooks) {
     );
     this.set('collapsed', false);
 
-    await waitFor('.collapsing');
+    await waitFor('.collapsing[style*=height]');
+    await delay(100);
 
-    assert.dom('.collapsing').hasStyle({ height: '200px' });
+    assert.dom('.collapsing').hasAttribute('style', 'height: 200px;');
 
     await waitFor('.collapse');
 
-    assert.dom('.collapse').doesNotHaveStyle({ height: '200px' });
+    assert.dom('.collapse').hasAttribute('style', '');
   });
 
   test('it passes accessibility checks', async function (assert) {

--- a/tests/integration/components/bs-collapse-test.js
+++ b/tests/integration/components/bs-collapse-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { waitFor, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { test, visibilityClass } from '../../helpers/bootstrap-test';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -74,20 +74,17 @@ module('Integration | Component | bs-collapse', function (hooks) {
   test('after collapsing/expanding height/width is set correctly ', async function (assert) {
     this.set('collapsed', true);
     await render(
-      hbs`<BsCollapse @expandedSize={{200}} @transitionDuration={{500}} @collapsed={{collapsed}}><p>Just some content</p></BsCollapse>`
+      hbs`<BsCollapse @expandedSize={{200}} @transitionDuration={{200}} @collapsed={{collapsed}}><p>Just some content</p></BsCollapse>`
     );
     this.set('collapsed', false);
 
-    assert.equal(this.element.querySelector('div.collapsing').style.height, '200px', 'should have height of 200px');
+    await waitFor('.collapsing');
 
-    // wait for transitions to complete
-    await settled();
+    assert.dom('.collapsing').hasStyle({ height: '200px' });
 
-    assert.equal(
-      this.element.querySelector('div.collapse').style.height,
-      '',
-      'should have height removed after transition'
-    );
+    await waitFor('.collapse');
+
+    assert.dom('.collapse').doesNotHaveStyle({ height: '200px' });
   });
 
   test('it passes accessibility checks', async function (assert) {


### PR DESCRIPTION
I noticed that the height attribute of the accordion component wasn't removed after the transition was finished, which would lead to issues when the dimensions of the contained content would change.

Looks like we were sending 'px' to the style modifier were is should have been ''.

This PR fixes that.

