### PR TITLE
Remove support for subclassing component classes 

### DIFF
--- a/addon/components/bs-accordion.js
+++ b/addon/components/bs-accordion.js
@@ -32,6 +32,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   In the example above the first accordion item utilizes the yielded `change` action to add some custom behaviour.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Accordion
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-accordion.js
+++ b/addon/components/bs-accordion.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-accordion';
 import listenTo from 'ember-bootstrap/utils/cp/listen-to';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Bootstrap-style [accordion group](http://getbootstrap.com/javascript/#collapse-example-accordion),
@@ -37,6 +38,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Accordion extends Component {
   /**

--- a/addon/components/bs-accordion/item.js
+++ b/addon/components/bs-accordion/item.js
@@ -7,6 +7,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import typeClass from 'ember-bootstrap/utils/cp/type-class';
 import { macroCondition, getOwnConfig } from '@embroider/macros';
 import { guidFor } from '@ember/object/internals';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  A collapsible/expandable item within an accordion
@@ -19,6 +20,7 @@ import { guidFor } from '@ember/object/internals';
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class AccordionItem extends Component {
   /**

--- a/addon/components/bs-accordion/item/body.js
+++ b/addon/components/bs-accordion/item/body.js
@@ -1,6 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-accordion/item/body';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Component for an accordion item body.
@@ -14,6 +15,7 @@ import layout from 'ember-bootstrap/templates/components/bs-accordion/item/body'
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class AccordionItemBody extends Component {
   /**
    * @property collapsed

--- a/addon/components/bs-accordion/item/title.js
+++ b/addon/components/bs-accordion/item/title.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-accordion/item/title';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Component for an accordion item title.
@@ -14,6 +15,7 @@ import layout from 'ember-bootstrap/templates/components/bs-accordion/item/title
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class AccordionItemTitle extends Component {
   /**

--- a/addon/components/bs-alert.js
+++ b/addon/components/bs-alert.js
@@ -9,6 +9,7 @@ import typeClass from 'ember-bootstrap/utils/cp/type-class';
 import listenTo from 'ember-bootstrap/utils/cp/listen-to';
 import usesTransition from 'ember-bootstrap/utils/cp/uses-transition';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Implements [Bootstrap alerts](http://getbootstrap.com/components/#alerts)
@@ -30,6 +31,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Alert extends Component {
   /**

--- a/addon/components/bs-alert.js
+++ b/addon/components/bs-alert.js
@@ -25,6 +25,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </BsAlert>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Alert
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -59,6 +59,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </ul>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class ButtonGroup
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-button-group.js
+++ b/addon/components/bs-button-group.js
@@ -6,6 +6,7 @@ import { A, isArray } from '@ember/array';
 import layout from 'ember-bootstrap/templates/components/bs-button-group';
 import sizeClass from 'ember-bootstrap/utils/cp/size-class';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Bootstrap-style button group, that visually groups buttons, and optionally adds radio/checkbox like behaviour.
@@ -64,6 +65,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class ButtonGroup extends Component {
   ariaRole = 'group';

--- a/addon/components/bs-button-group/button.js
+++ b/addon/components/bs-button-group/button.js
@@ -12,6 +12,8 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  @private
  */
 export default class ButtonGroupButton extends Button {
+  '__ember-bootstrap_subclass' = true;
+
   /**
    * @property groupValue
    * @private

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -12,6 +12,7 @@ import typeClass from 'ember-bootstrap/utils/cp/type-class';
 import overrideableCP from 'ember-bootstrap/utils/cp/overrideable';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { macroCondition, getOwnConfig } from '@embroider/macros';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Implements a HTML button element, with support for all [Bootstrap button CSS styles](http://getbootstrap.com/css/#buttons)
@@ -105,6 +106,7 @@ import { macroCondition, getOwnConfig } from '@embroider/macros';
 */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class Button extends Component {
   /**
    * Default label of the button. Not need if used as a block component

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -99,6 +99,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   You can `reset` the state represented by these properties and used for button's text by setting `reset` property to
   `true`.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Button
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-carousel.js
+++ b/addon/components/bs-carousel.js
@@ -11,6 +11,7 @@ import { task, timeout } from 'ember-concurrency';
 import RSVP from 'rsvp';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { equal } from '@ember/object/computed';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Ember implementation of Bootstrap's Carousel. Supports all original features but API is partially different:
@@ -61,6 +62,7 @@ import { equal } from '@ember/object/computed';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Carousel extends Component.extend(ComponentParent) {
   tabindex = '1';

--- a/addon/components/bs-carousel.js
+++ b/addon/components/bs-carousel.js
@@ -56,6 +56,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   | Wrap | wrap slides, cycles without stopping at first or last slide. |
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Carousel
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-carousel/slide.js
+++ b/addon/components/bs-carousel/slide.js
@@ -6,6 +6,7 @@ import layout from 'ember-bootstrap/templates/components/bs-carousel/slide';
 import { next } from '@ember/runloop';
 import overrideableCP from 'ember-bootstrap/utils/cp/overrideable';
 import { addObserver } from '@ember/object/observers';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   A visible user-defined slide.
@@ -18,6 +19,7 @@ import { addObserver } from '@ember/object/observers';
   @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class CarouselSlide extends Component.extend(ComponentChild) {
   /**

--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -10,6 +10,7 @@ import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import { assert } from '@ember/debug';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { computed } from '@ember/object';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   An Ember component that mimics the behaviour of [Bootstrap's collapse.js plugin](http://getbootstrap.com/javascript/#collapse)
@@ -31,6 +32,7 @@ import { computed } from '@ember/object';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Collapse extends Component {
   /**

--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -26,6 +26,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </BsCollapse>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Collapse
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -6,6 +6,7 @@ import layout from 'ember-bootstrap/templates/components/bs-tooltip/element';
 import { assert } from '@ember/debug';
 import { scheduleOnce } from '@ember/runloop';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Internal (abstract) component for contextual help markup. Should not be used directly.
@@ -17,6 +18,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class ContextualHelpElement extends Component {
   ariaRole = 'tooltip';
 

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -6,7 +6,6 @@ import layout from 'ember-bootstrap/templates/components/bs-tooltip/element';
 import { assert } from '@ember/debug';
 import { scheduleOnce } from '@ember/runloop';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
-import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Internal (abstract) component for contextual help markup. Should not be used directly.
@@ -18,7 +17,6 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
  */
 @templateLayout(layout)
 @tagName('')
-@deprecateSubclassing
 export default class ContextualHelpElement extends Component {
   ariaRole = 'tooltip';
 

--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -165,6 +165,8 @@ const SUPPORTED_KEYCODES = [ESCAPE_KEYCODE, ARROW_DOWN_KEYCODE, ARROW_UP_KEYCODE
   version does. This also allows you to set `renderInPlace=false` on the menu component to render it in a wormhole,
   which you might want to do if you experience clipping issues by an outer `overflow: hidden` element.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Dropdown
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { assert } from '@ember/debug';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 const ESCAPE_KEYCODE = 27; // KeyboardEvent.which value for Escape (Esc) key
 const SPACE_KEYCODE = 32; // KeyboardEvent.which value for space key
@@ -170,6 +171,7 @@ const SUPPORTED_KEYCODES = [ESCAPE_KEYCODE, ARROW_DOWN_KEYCODE, ARROW_UP_KEYCODE
   @public
 s*/
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Dropdown extends Component {
   /**

--- a/addon/components/bs-dropdown/button.js
+++ b/addon/components/bs-dropdown/button.js
@@ -15,6 +15,8 @@ import { computed, action } from '@ember/object';
  */
 @templateLayout(layout)
 export default class DropdownButton extends Button {
+  '__ember-bootstrap_subclass' = true;
+
   @action
   handleKeyDown(e) {
     this.onKeyDown(e);

--- a/addon/components/bs-dropdown/menu.js
+++ b/addon/components/bs-dropdown/menu.js
@@ -5,6 +5,7 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu';
 import { next } from '@ember/runloop';
 import { getDestinationElement } from 'ember-bootstrap/utils/dom';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Component for the dropdown menu.
@@ -18,6 +19,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class DropdownMenu extends Component {
   /**
    * @property ariaRole

--- a/addon/components/bs-dropdown/menu/divider.js
+++ b/addon/components/bs-dropdown/menu/divider.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu/divider';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Component for a dropdown menu divider.
@@ -14,4 +15,5 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu/divide
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class DropdownMenuDivider extends Component {}

--- a/addon/components/bs-dropdown/menu/item.js
+++ b/addon/components/bs-dropdown/menu/item.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu/item';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Component for a dropdown menu item.
@@ -14,4 +15,5 @@ import layout from 'ember-bootstrap/templates/components/bs-dropdown/menu/item';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class DropdownMenuItem extends Component {}

--- a/addon/components/bs-dropdown/toggle.js
+++ b/addon/components/bs-dropdown/toggle.js
@@ -4,6 +4,7 @@ import { layout as templateLayout } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-dropdown/toggle';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { computed, action } from '@ember/object';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Anchor element that triggers the parent dropdown to open.
@@ -17,6 +18,7 @@ import { computed, action } from '@ember/object';
  @publicø
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class DropdownToggle extends Component {
   /**

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -105,6 +105,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </BsForm>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Form
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -10,6 +10,7 @@ import RSVP from 'rsvp';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { macroCondition, getOwnConfig } from '@embroider/macros';
 import { DEBUG } from '@glimmer/env';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Render a form with the appropriate Bootstrap layout class (see `formLayout`).
@@ -111,6 +112,7 @@ import { DEBUG } from '@glimmer/env';
 */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class Form extends Component {
   /**
    * Bootstrap form class name (computed)

--- a/addon/components/bs-form/element/control/checkbox.js
+++ b/addon/components/bs-form/element/control/checkbox.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/control/checkbox';
 import Control from '../control';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,6 +13,7 @@ import Control from '../control';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementControlCheckbox extends Control {
   @action
   handleClick(event) {

--- a/addon/components/bs-form/element/control/input.js
+++ b/addon/components/bs-form/element/control/input.js
@@ -5,6 +5,7 @@ import Control from '../control';
 import { isEmpty } from '@ember/utils';
 import sizeClass from 'ember-bootstrap/utils/cp/size-class';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 const allowedTypes = new Map();
 function canUseType(type) {
@@ -36,6 +37,7 @@ function canUseType(type) {
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementControlInput extends Control {
   /**
    * @property type

--- a/addon/components/bs-form/element/control/radio.js
+++ b/addon/components/bs-form/element/control/radio.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Control from '../control';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/control/radio';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,6 +13,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementControlRadio extends Control {
   /**
    * @property inline

--- a/addon/components/bs-form/element/control/textarea.js
+++ b/addon/components/bs-form/element/control/textarea.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/control/textarea';
 import Control from '../control';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,6 +13,7 @@ import Control from '../control';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementControlTextarea extends Control {
   @action
   handleChange(event) {

--- a/addon/components/bs-form/element/errors.js
+++ b/addon/components/bs-form/element/errors.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/errors';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  @class FormElementErrors
@@ -11,6 +12,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementErrors extends Component {
   /**
    * @property show

--- a/addon/components/bs-form/element/feedback-icon.js
+++ b/addon/components/bs-form/element/feedback-icon.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/feedback-icon';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,6 +13,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementFeedbackIcon extends Component {
   /**
    * @property show

--- a/addon/components/bs-form/element/help-text.js
+++ b/addon/components/bs-form/element/help-text.js
@@ -1,6 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/help-text';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -10,5 +11,6 @@ import layout from 'ember-bootstrap/templates/components/bs-form/element/help-te
  @private
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class FormElementHelpText extends Component {}

--- a/addon/components/bs-form/element/label.js
+++ b/addon/components/bs-form/element/label.js
@@ -5,6 +5,7 @@ import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/label';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { isBlank } from '@ember/utils';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -15,6 +16,7 @@ import { isBlank } from '@ember/utils';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementLabel extends Component {
   /**
    * @property label

--- a/addon/components/bs-form/element/layout.js
+++ b/addon/components/bs-form/element/layout.js
@@ -1,7 +1,6 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
-import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -11,7 +10,6 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
  @private
  */
 @tagName('')
-@deprecateSubclassing
 export default class FormElementLayout extends Component {
   /**
    * @property formElementId

--- a/addon/components/bs-form/element/layout.js
+++ b/addon/components/bs-form/element/layout.js
@@ -1,6 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -10,6 +11,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  @private
  */
 @tagName('')
+@deprecateSubclassing
 export default class FormElementLayout extends Component {
   /**
    * @property formElementId

--- a/addon/components/bs-form/element/layout/horizontal.js
+++ b/addon/components/bs-form/element/layout/horizontal.js
@@ -1,4 +1,4 @@
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { layout as templateLayout } from '@ember-decorators/component';
 import { computed } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isBlank } from '@ember/utils';
@@ -14,7 +14,6 @@ import { macroCondition, getOwnConfig } from '@embroider/macros';
  @extends Components.FormElementLayout
  @private
  */
-@tagName('')
 @templateLayout(layout)
 export default class FormElementLayoutHorizontal extends FormElementLayout {
   /**

--- a/addon/components/bs-form/element/layout/horizontal/checkbox.js
+++ b/addon/components/bs-form/element/layout/horizontal/checkbox.js
@@ -1,4 +1,4 @@
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { layout as templateLayout } from '@ember-decorators/component';
 import FormElementLayoutVertical from '../vertical';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/horizontal/checkbox';
 
@@ -9,6 +9,5 @@ import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/
  @extends Components.FormElementLayout
  @private
  */
-@tagName('')
 @templateLayout(layout)
 export default class FormElementLayoutVerticalCheckbox extends FormElementLayoutVertical {}

--- a/addon/components/bs-form/element/layout/vertical.js
+++ b/addon/components/bs-form/element/layout/vertical.js
@@ -1,4 +1,4 @@
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { layout as templateLayout } from '@ember-decorators/component';
 import FormElementLayout from '../layout';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/vertical';
 
@@ -9,6 +9,5 @@ import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/
  @extends Components.FormElementLayout
  @private
  */
-@tagName('')
 @templateLayout(layout)
 export default class FormElementLayoutVertical extends FormElementLayout {}

--- a/addon/components/bs-form/element/layout/vertical/checkbox.js
+++ b/addon/components/bs-form/element/layout/vertical/checkbox.js
@@ -1,4 +1,4 @@
-import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import { layout as templateLayout } from '@ember-decorators/component';
 import FormElementLayoutVertical from '../vertical';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/vertical/checkbox';
 
@@ -9,6 +9,5 @@ import layout from 'ember-bootstrap/templates/components/bs-form/element/layout/
  @extends Components.FormElementLayout
  @private
  */
-@tagName('')
 @templateLayout(layout)
 export default class FormElementLayoutVerticalCheckbox extends FormElementLayoutVertical {}

--- a/addon/components/bs-form/element/legend.js
+++ b/addon/components/bs-form/element/legend.js
@@ -6,4 +6,6 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 @templateLayout(layout)
 @tagName('')
 @deprecateSubclassing
-export default class FormElementLegend extends FormElementLabel {}
+export default class FormElementLegend extends FormElementLabel {
+  '__ember-bootstrap_subclass' = true;
+}

--- a/addon/components/bs-form/element/legend.js
+++ b/addon/components/bs-form/element/legend.js
@@ -1,7 +1,9 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import FormElementLabel from 'ember-bootstrap/components/bs-form/element/label';
 import layout from 'ember-bootstrap/templates/components/bs-form/element/legend';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class FormElementLegend extends FormElementLabel {}

--- a/addon/components/bs-form/group.js
+++ b/addon/components/bs-form/group.js
@@ -7,6 +7,7 @@ import Config from 'ember-bootstrap/config';
 import { isBlank } from '@ember/utils';
 import sizeClass from 'ember-bootstrap/utils/cp/size-class';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   This component renders a `<div class="form-group">` element, with support for validation states and feedback icons (only for BS3).
@@ -31,6 +32,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class FormGroup extends Component {
   /**

--- a/addon/components/bs-form/group.js
+++ b/addon/components/bs-form/group.js
@@ -7,7 +7,6 @@ import Config from 'ember-bootstrap/config';
 import { isBlank } from '@ember/utils';
 import sizeClass from 'ember-bootstrap/utils/cp/size-class';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
-import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   This component renders a `<div class="form-group">` element, with support for validation states and feedback icons (only for BS3).
@@ -32,7 +31,6 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   @public
 */
 @tagName('')
-@deprecateSubclassing
 @templateLayout(layout)
 export default class FormGroup extends Component {
   /**

--- a/addon/components/bs-modal-simple.js
+++ b/addon/components/bs-modal-simple.js
@@ -76,6 +76,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   If you want the modal to render in place, rather than being wormholed, you can set renderInPlace=true.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class ModalSimple
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-modal-simple.js
+++ b/addon/components/bs-modal-simple.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal-simple';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with a some common default markup
@@ -82,6 +83,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class ModalSimple extends Component {
   /**
    * The title of the modal, visible in the modal header. Is ignored if `header` is false.

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -50,6 +50,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   See the documentation of the [bs-modal-simple](Components.ModalSimple.html) component for further examples.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Modal
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -13,6 +13,7 @@ import { guidFor } from '@ember/object/internals';
 import usesTransition from 'ember-bootstrap/utils/cp/uses-transition';
 import isFastBoot from 'ember-bootstrap/utils/is-fastboot';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with custom markup.
@@ -56,6 +57,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class Modal extends Component {
   @service('-document')
   document;

--- a/addon/components/bs-modal/body.js
+++ b/addon/components/bs-modal/body.js
@@ -1,6 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/body';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,5 +13,6 @@ import layout from 'ember-bootstrap/templates/components/bs-modal/body';
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class ModalBody extends Component {}

--- a/addon/components/bs-modal/dialog.js
+++ b/addon/components/bs-modal/dialog.js
@@ -5,6 +5,7 @@ import { isBlank } from '@ember/utils';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/dialog';
 import { next } from '@ember/runloop';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  Internal component for modal's markup and event handling. Should not be used directly.
@@ -15,6 +16,7 @@ import { next } from '@ember/runloop';
  @private
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class ModalDialog extends Component {
   @readOnly('titleId')

--- a/addon/components/bs-modal/footer.js
+++ b/addon/components/bs-modal/footer.js
@@ -4,6 +4,7 @@ import { notEmpty } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/footer';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -16,6 +17,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class ModalFooter extends Component {
   /**
    * The title of the default close button. Will be ignored (i.e. no close button) if you provide your own block

--- a/addon/components/bs-modal/header.js
+++ b/addon/components/bs-modal/header.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/header';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -13,6 +14,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class ModalHeader extends Component {
   /**

--- a/addon/components/bs-modal/header/close.js
+++ b/addon/components/bs-modal/header/close.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/header/close';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -12,6 +13,7 @@ import layout from 'ember-bootstrap/templates/components/bs-modal/header/close';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class ModalHeaderClose extends Component {
   /**
    * @event onClick

--- a/addon/components/bs-modal/header/title.js
+++ b/addon/components/bs-modal/header/title.js
@@ -1,6 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal/header/title';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -11,4 +12,5 @@ import layout from 'ember-bootstrap/templates/components/bs-modal/header/title';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class ModalHeaderTitle extends Component {}

--- a/addon/components/bs-nav.js
+++ b/addon/components/bs-nav.js
@@ -76,6 +76,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   The `fill` styling is only available with Bootstrap 4
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Nav
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-nav.js
+++ b/addon/components/bs-nav.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-nav';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component to generate [bootstrap navs](http://getbootstrap.com/components/#nav)
@@ -83,6 +84,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class Nav extends Component {
   @computed('type')
   get typeClass() {

--- a/addon/components/bs-nav/item.js
+++ b/addon/components/bs-nav/item.js
@@ -9,6 +9,7 @@ import layout from 'ember-bootstrap/templates/components/bs-nav/item';
 import ComponentParent from 'ember-bootstrap/mixins/component-parent';
 import overrideableCP from 'ember-bootstrap/utils/cp/overrideable';
 import { assert } from '@ember/debug';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -22,6 +23,7 @@ import { assert } from '@ember/debug';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class NavItem extends Component.extend(ComponentParent) {
   /**
    * Render the nav item as disabled (see [Bootstrap docs](http://getbootstrap.com/components/#nav-disabled-links)).

--- a/addon/components/bs-navbar.js
+++ b/addon/components/bs-navbar.js
@@ -97,6 +97,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   Bootstrap 4 navbars are fluid by default without the need for an additional container. An
   additional container is added like with Bootstrap 3 if `fluid` is `false`.
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Navbar
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-navbar.js
+++ b/addon/components/bs-navbar.js
@@ -8,6 +8,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { assert } from '@ember/debug';
 import { macroCondition, getOwnConfig } from '@embroider/macros';
 import { isBlank } from '@ember/utils';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component to generate [Bootstrap navbars](http://getbootstrap.com/components/#navbar).
@@ -103,6 +104,7 @@ import { isBlank } from '@ember/utils';
 */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class Navbar extends Component {
   /**
    * Manages the state for the responsive menu between the toggle and the content.

--- a/addon/components/bs-navbar/content.js
+++ b/addon/components/bs-navbar/content.js
@@ -1,6 +1,7 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import layout from 'ember-bootstrap/templates/components/bs-navbar/content';
 import Component from '@ember/component';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  * Component to wrap the collapsible content of a [Components.Navbar](Components.Navbar.html) component.
@@ -12,5 +13,6 @@ import Component from '@ember/component';
  * @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class NavbarContent extends Component {}

--- a/addon/components/bs-navbar/nav.js
+++ b/addon/components/bs-navbar/nav.js
@@ -14,6 +14,8 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  * @public
  */
 export default class NavbarNav extends BsNavComponent {
+  '__ember-bootstrap_subclass' = true;
+
   @defaultValue
   justified = false;
 

--- a/addon/components/bs-navbar/toggle.js
+++ b/addon/components/bs-navbar/toggle.js
@@ -3,6 +3,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-navbar/toggle';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  * Component to implement the responsive menu toggle behavior in a [Components.Navbar](Components.Navbar.html)
@@ -20,6 +21,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
  */
 @templateLayout(layout)
 @tagName('')
+@deprecateSubclassing
 export default class NavbarToggle extends Component {
   @defaultValue
   collapsed = true;

--- a/addon/components/bs-popover.js
+++ b/addon/components/bs-popover.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import ContextualHelp from './bs-contextual-help';
 import layout from 'ember-bootstrap/templates/components/bs-popover';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component that implements Bootstrap [popovers](http://getbootstrap.com/javascript/#popovers).
@@ -70,6 +71,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @templateLayout(layout)
+@deprecateSubclassing
 export default class Popover extends ContextualHelp {
   /**
    * @property placement

--- a/addon/components/bs-popover.js
+++ b/addon/components/bs-popover.js
@@ -65,6 +65,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   * `onHide`
   * `onHidden`
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Popover
   @namespace Components
   @extends Components.ContextualHelp

--- a/addon/components/bs-progress.js
+++ b/addon/components/bs-progress.js
@@ -2,6 +2,7 @@ import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-progress';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component to display a Bootstrap progress bar, see http://getbootstrap.com/components/#progress.
@@ -37,6 +38,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Progress extends Component {
   /**

--- a/addon/components/bs-progress.js
+++ b/addon/components/bs-progress.js
@@ -32,6 +32,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </BsProgress>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Progress
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-progress/bar.js
+++ b/addon/components/bs-progress/bar.js
@@ -5,6 +5,7 @@ import layout from 'ember-bootstrap/templates/components/bs-progress/bar';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import typeClass from 'ember-bootstrap/utils/cp/type-class';
 import { macroCondition, getOwnConfig } from '@embroider/macros';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
 
@@ -16,6 +17,7 @@ import { macroCondition, getOwnConfig } from '@embroider/macros';
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class ProgressBar extends Component {
   /**

--- a/addon/components/bs-tab.js
+++ b/addon/components/bs-tab.js
@@ -9,6 +9,7 @@ import ComponentParent from 'ember-bootstrap/mixins/component-parent';
 import TabPane from 'ember-bootstrap/components/bs-tab/pane';
 import listenTo from 'ember-bootstrap/utils/cp/listen-to';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Tab component for dynamic tab functionality that mimics the behaviour of Bootstrap's tab.js plugin,
@@ -113,6 +114,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class Tab extends Component.extend(ComponentParent) {
   /**

--- a/addon/components/bs-tab.js
+++ b/addon/components/bs-tab.js
@@ -107,6 +107,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   </div>
   ```
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Tab
   @namespace Components
   @extends Ember.Component

--- a/addon/components/bs-tab/pane.js
+++ b/addon/components/bs-tab/pane.js
@@ -9,6 +9,7 @@ import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import usesTransition from 'ember-bootstrap/utils/cp/uses-transition';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { guidFor } from '@ember/object/internals';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
  The tab pane of a tab component.
@@ -21,6 +22,7 @@ import { guidFor } from '@ember/object/internals';
  @public
  */
 @tagName('')
+@deprecateSubclassing
 @templateLayout(layout)
 export default class TabPane extends Component.extend(ComponentChild) {
   /**

--- a/addon/components/bs-tooltip.js
+++ b/addon/components/bs-tooltip.js
@@ -3,6 +3,7 @@ import { computed } from '@ember/object';
 import ContextualHelp from './bs-contextual-help';
 import layout from 'ember-bootstrap/templates/components/bs-tooltip';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 /**
   Component that implements Bootstrap [tooltips](http://getbootstrap.com/javascript/#tooltips).
@@ -80,6 +81,7 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @public
 */
 @templateLayout(layout)
+@deprecateSubclassing
 export default class Tooltip extends ContextualHelp {
   /**
    * @property elementComponent

--- a/addon/components/bs-tooltip.js
+++ b/addon/components/bs-tooltip.js
@@ -75,6 +75,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   * `onHide`
   * `onHidden`
 
+  *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
+
   @class Tooltip
   @namespace Components
   @extends Components.ContextualHelp

--- a/addon/utils/deprecate-subclassing.js
+++ b/addon/utils/deprecate-subclassing.js
@@ -5,20 +5,20 @@ export default function deprecateSubclassing(target) {
   if (DEBUG) {
     const originalInit = target.prototype.init;
 
-    if (originalInit) {
-      target.prototype.init = function () {
-        deprecate(
-          `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
-          // the `__ember-bootstrap_subclass` flag is an escape hatch for "priviliged" addons like validations addons that currently still have to rely on subclassing
-          target === this.constructor || this['__ember-bootstrap_subclass'] === true,
-          {
-            id: `ember-bootstrap.subclassing#${target.name}`,
-            until: '5.0.0',
-          }
-        );
+    target.prototype.init = function () {
+      deprecate(
+        `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
+        // the `__ember-bootstrap_subclass` flag is an escape hatch for "privileged" addons like validations addons that currently still have to rely on subclassing
+        target === this.constructor || this['__ember-bootstrap_subclass'] === true,
+        {
+          id: `ember-bootstrap.subclassing#${target.name}`,
+          until: '5.0.0',
+        }
+      );
 
+      if (originalInit) {
         return originalInit.apply(this, arguments);
-      };
-    }
+      }
+    };
   }
 }

--- a/addon/utils/deprecate-subclassing.js
+++ b/addon/utils/deprecate-subclassing.js
@@ -1,0 +1,23 @@
+import { DEBUG } from '@glimmer/env';
+import { deprecate } from '@ember/debug';
+
+export default function deprecateSubclassing(target) {
+  if (DEBUG) {
+    const originalInit = target.prototype.init;
+
+    if (originalInit) {
+      target.prototype.init = function () {
+        deprecate(
+          `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
+          target === this.constructor || this['__ember-bootstrap_subclass'] === true,
+          {
+            id: `ember-bootstrap.subclassing#${target.name}`,
+            until: '5.0.0',
+          }
+        );
+
+        return originalInit.apply(this, arguments);
+      };
+    }
+  }
+}

--- a/addon/utils/deprecate-subclassing.js
+++ b/addon/utils/deprecate-subclassing.js
@@ -9,6 +9,7 @@ export default function deprecateSubclassing(target) {
       target.prototype.init = function () {
         deprecate(
           `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <Bs${target.name}> component.`,
+          // the `__ember-bootstrap_subclass` flag is an escape hatch for "priviliged" addons like validations addons that currently still have to rely on subclassing
           target === this.constructor || this['__ember-bootstrap_subclass'] === true,
           {
             id: `ember-bootstrap.subclassing#${target.name}`,

--- a/tests/integration/components/subclassing-test.js
+++ b/tests/integration/components/subclassing-test.js
@@ -12,7 +12,6 @@ import BsCarousel from 'ember-bootstrap/components/bs-carousel';
 import BsCollapse from 'ember-bootstrap/components/bs-collapse';
 import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
 import BsForm from 'ember-bootstrap/components/bs-form';
-import BsModalSimple from 'ember-bootstrap/components/bs-modal-simple';
 import BsModal from 'ember-bootstrap/components/bs-modal';
 import BsNav from 'ember-bootstrap/components/bs-nav';
 import BsNavbar from 'ember-bootstrap/components/bs-navbar';
@@ -54,10 +53,12 @@ const tests = [
     name: 'BsForm',
     clazz: BsForm,
   },
-  {
-    name: 'BsModalSimple',
-    clazz: BsModalSimple,
-  },
+  // As BsModalSimple extends from BsModal itself, the subclassing check is disabled
+  // @todo enable again when https://github.com/kaliber5/ember-bootstrap/issues/1105 is resolved
+  // {
+  //   name: 'BsModalSimple',
+  //   clazz: BsModalSimple,
+  // },
   {
     name: 'BsModal',
     clazz: BsModal,

--- a/tests/integration/components/subclassing-test.js
+++ b/tests/integration/components/subclassing-test.js
@@ -1,0 +1,122 @@
+import { module } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { test } from '../../helpers/bootstrap-test';
+import hbs from 'htmlbars-inline-precompile';
+import setupNoDeprecations from '../../helpers/setup-no-deprecations';
+import BsAccordion from 'ember-bootstrap/components/bs-accordion';
+import BsAlert from 'ember-bootstrap/components/bs-alert';
+import BsButton from 'ember-bootstrap/components/bs-button';
+import BsButtonGroup from 'ember-bootstrap/components/bs-button-group';
+import BsCarousel from 'ember-bootstrap/components/bs-carousel';
+import BsCollapse from 'ember-bootstrap/components/bs-collapse';
+import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
+import BsForm from 'ember-bootstrap/components/bs-form';
+import BsModalSimple from 'ember-bootstrap/components/bs-modal-simple';
+import BsModal from 'ember-bootstrap/components/bs-modal';
+import BsNav from 'ember-bootstrap/components/bs-nav';
+import BsNavbar from 'ember-bootstrap/components/bs-navbar';
+import BsPopover from 'ember-bootstrap/components/bs-popover';
+import BsProgress from 'ember-bootstrap/components/bs-progress';
+import BsTab from 'ember-bootstrap/components/bs-tab';
+import BsTooltip from 'ember-bootstrap/components/bs-tooltip';
+
+const tests = [
+  {
+    name: 'BsAccordion',
+    clazz: BsAccordion,
+  },
+  {
+    name: 'BsAlert',
+    clazz: BsAlert,
+  },
+  {
+    name: 'BsButton',
+    clazz: BsButton,
+  },
+  {
+    name: 'BsButtonGroup',
+    clazz: BsButtonGroup,
+  },
+  {
+    name: 'BsCarousel',
+    clazz: BsCarousel,
+  },
+  {
+    name: 'BsCollapse',
+    clazz: BsCollapse,
+  },
+  {
+    name: 'BsDropdown',
+    clazz: BsDropdown,
+  },
+  {
+    name: 'BsForm',
+    clazz: BsForm,
+  },
+  {
+    name: 'BsModalSimple',
+    clazz: BsModalSimple,
+  },
+  {
+    name: 'BsModal',
+    clazz: BsModal,
+  },
+  {
+    name: 'BsNav',
+    clazz: BsNav,
+  },
+  {
+    name: 'BsNavbar',
+    clazz: BsNavbar,
+  },
+  {
+    name: 'BsPopover',
+    clazz: BsPopover,
+  },
+  {
+    name: 'BsProgress',
+    clazz: BsProgress,
+  },
+  {
+    name: 'BsTab',
+    clazz: BsTab,
+  },
+  {
+    name: 'BsTooltip',
+    clazz: BsTooltip,
+  },
+];
+
+module('Integration | subclassing', function (hooks) {
+  setupRenderingTest(hooks);
+  setupNoDeprecations(hooks);
+
+  tests.forEach(({ name, clazz }) => {
+    module(name, function () {
+      test('it should not be subclassed', async function (assert) {
+        class MyClass extends clazz {}
+
+        this.owner.register('component:my-class', MyClass);
+
+        await render(hbs`<MyClass />`);
+
+        assert.deprecationsInclude(
+          `Extending from ember-bootstrap component classes is not supported, and might break anytime. Detected subclassing of <${name}> component.`
+        );
+      });
+
+      test('subclass warning can be silenced', async function (assert) {
+        class MyClass extends clazz {
+          '__ember-bootstrap_subclass' = true;
+        }
+
+        this.owner.register('component:my-class', MyClass);
+
+        await render(hbs`<MyClass />`);
+
+        assert.deprecations(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Subclassing makes non-breaking refactorings difficult/impossible, e.g. the current move to tagless components, or further to Glimmer components in the future. Therefore we only consider template invocations as part of a components public API.

Addons like `ember-bootstrap-cp-validations` still make use of subclassing, and until we come up with better APIs to support their use cases that don't need subclassing, we offer them an escape hatch to silence the warnings. This seems acceptable to me, as they can be considered "privileged" addons as *we* are in control to make sure they continue to work when changes are introduced that would break subclassing.

This PR could be backported to the `v3` branch to publish a new v3 release that also contains the deprecation messages.