### PR TITLE
Refactor BsModalSimple to not extend from BsModal

### DIFF
--- a/addon/components/bs-modal-simple.js
+++ b/addon/components/bs-modal-simple.js
@@ -1,5 +1,5 @@
-import { layout as templateLayout } from '@ember-decorators/component';
-import Modal from 'ember-bootstrap/components/bs-modal';
+import { layout as templateLayout, tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
 import layout from 'ember-bootstrap/templates/components/bs-modal-simple';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 
@@ -77,11 +77,12 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
 
   @class ModalSimple
   @namespace Components
-  @extends Components.Modal
+  @extends Ember.Component
   @public
 */
 @templateLayout(layout)
-export default class ModalSimple extends Modal {
+@tagName('')
+export default class ModalSimple extends Component {
   /**
    * The title of the modal, visible in the modal header. Is ignored if `header` is false.
    *
@@ -89,6 +90,192 @@ export default class ModalSimple extends Modal {
    * @type string
    * @public
    */
+
+  /**
+   * Visibility of the modal. Toggle to show/hide with CSS transitions.
+   *
+   * When the modal is closed by user interaction this property will not update by using two-way bindings in order
+   * to follow DDAU best practices. If you want to react to such changes, subscribe to the `onHide` action
+   *
+   * @property open
+   * @type boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  open = true;
+
+  /**
+   * Set to false to disable fade animations.
+   *
+   * @property fade
+   * @type boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  fade = undefined;
+
+  /**
+   * Use a semi-transparent modal background to hide the rest of the page.
+   *
+   * @property backdrop
+   * @type boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  backdrop = true;
+
+  /**
+   * Closes the modal when escape key is pressed.
+   *
+   * @property keyboard
+   * @type boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  keyboard = true;
+
+  /**
+   * [BS4 only!] Vertical position, either 'top' (default) or 'center'
+   * 'center' will apply the `modal-dialog-centered` class
+   *
+   * @property position
+   * @type {string}
+   * @default 'top'
+   * @public
+   */
+  @defaultValue
+  position = 'top';
+
+  /**
+   * [BS4 only!] Allows scrolling within the modal body
+   * 'true' will apply the `modal-dialog-scrollable` class
+   *
+   * @property scrollable
+   * @type boolean
+   * @default false
+   * @public
+   */
+  @defaultValue
+  scrollable = false;
+
+  /**
+   * Property for size styling, set to null (default), 'lg' or 'sm'
+   *
+   * Also see the [Bootstrap docs](http://getbootstrap.com/javascript/#modals-sizes)
+   *
+   * @property size
+   * @type String
+   * @public
+   */
+  @defaultValue
+  size = null;
+
+  /**
+   * If true clicking on the backdrop will close the modal.
+   *
+   * @property backdropClose
+   * @type boolean
+   * @default true
+   * @public
+   */
+  @defaultValue
+  backdropClose = true;
+
+  /**
+   * If true component will render in place, rather than be wormholed.
+   *
+   * @property renderInPlace
+   * @type boolean
+   * @default false
+   * @public
+   */
+  @defaultValue
+  renderInPlace = false;
+
+  /**
+   * The duration of the fade transition
+   *
+   * @property transitionDuration
+   * @type number
+   * @default 300
+   * @public
+   */
+  @defaultValue
+  transitionDuration = 300;
+
+  /**
+   * The duration of the backdrop fade transition
+   *
+   * @property backdropTransitionDuration
+   * @type number
+   * @default 150
+   * @public
+   */
+  @defaultValue
+  backdropTransitionDuration = 150;
+
+  /**
+   * The action to be sent when the modal footer's submit button (if present) is pressed.
+   * Note that if your modal body contains a form (e.g. [Components.Form](Components.Form.html)) this action will
+   * not be triggered. Instead a submit event will be triggered on the form itself. See the class description for an
+   * example.
+   *
+   * @property onSubmit
+   * @type function
+   * @public
+   */
+  onSubmit() {}
+
+  /**
+   * The action to be sent when the modal is closing.
+   * This will be triggered by pressing the modal header's close button (x button) or the modal footer's close button.
+   * Note that this will happen before the modal is hidden from the DOM, as the fade transitions will still need some
+   * time to finish. Use the `onHidden` if you need the modal to be hidden when the action triggers.
+   *
+   * You can return false to prevent closing the modal automatically, and do that in your action by
+   * setting `open` to false.
+   *
+   * @property onHide
+   * @type function
+   * @public
+   */
+  onHide() {}
+
+  /**
+   * The action to be sent after the modal has been completely hidden (including the CSS transition).
+   *
+   * @property onHidden
+   * @type function
+   * @default null
+   * @public
+   */
+  onHidden() {}
+
+  /**
+   * The action to be sent when the modal is opening.
+   * This will be triggered immediately after the modal is shown (so it's safe to access the DOM for
+   * size calculations and the like). This means that if fade=true, it will be shown in between the
+   * backdrop animation and the fade animation.
+   *
+   * @property onShow
+   * @type function
+   * @default null
+   * @public
+   */
+  onShow() {}
+
+  /**
+   * The action to be sent after the modal has been completely shown (including the CSS transition).
+   *
+   * @property onShown
+   * @type function
+   * @public
+   */
+  onShown() {}
 
   /**
    * Display a close button (x icon) in the corner of the modal header.

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -1,6 +1,5 @@
 import { layout as templateLayout, tagName } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
-import { not } from '@ember/object/computed';
 import { addObserver } from '@ember/object/observers';
 import { assert } from '@ember/debug';
 import Component from '@ember/component';
@@ -95,13 +94,10 @@ export default class Modal extends Component {
   @defaultValue
   fade = undefined;
 
-  /**
-   * @property notFade
-   * @type boolean
-   * @private
-   */
-  @not('fade')
-  notFade;
+  get _fade() {
+    let isFB = isFastBoot(this);
+    return this.fade === undefined ? !isFB : this.fade;
+  }
 
   /**
    * Used to apply Bootstrap's visibility classes.
@@ -326,7 +322,7 @@ export default class Modal extends Component {
    * @readonly
    * @private
    */
-  @usesTransition('fade')
+  @usesTransition('_fade')
   usesTransition;
 
   /**
@@ -698,16 +694,12 @@ export default class Modal extends Component {
 
   init() {
     super.init(...arguments);
-    let { isOpen, backdrop, fade } = this;
+    let { isOpen, backdrop, _fade: fade } = this;
     let isFB = isFastBoot(this);
-    if (fade === undefined) {
-      fade = !isFB;
-    }
     this.setProperties({
       showModal: isOpen && (!fade || isFB),
       showBackdrop: isOpen && backdrop,
       inDom: isOpen,
-      fade,
       destinationElement: getDestinationElement(this),
     });
 

--- a/addon/templates/components/bs-modal-simple.hbs
+++ b/addon/templates/components/bs-modal-simple.hbs
@@ -1,85 +1,35 @@
-{{#if inDom}}
-  {{#if this._renderInPlace}}
-    <BsModal::dialog
-      @onClose={{this.close}}
-      @fade={{this.fade}}
-      @showModal={{this.showModal}}
-      @keyboard={{this.keyboard}}
-      @size={{@size}}
-      @backdropClose={{this.backdropClose}}
-      @inDom={{this.inDom}}
-      @paddingLeft={{this.paddingLeft}}
-      @paddingRight={{this.paddingRight}}
-      @centered={{bs-eq this.position "center"}}
-      @scrollable={{this.scrollable}}
-      class={{@class}}
-      id={{this.modalId}}
-      ...attributes
-    >
-      <BsModal::header @title={{@title}} @closeButton={{this.closeButton}} @onClose={{this.close}} />
-      <BsModal::body>
-        {{yield
-          (hash
-            close=this.close
-            submit=this.doSubmit
-          )
-        }}
-      </BsModal::body>
-      <BsModal::footer
-        @closeTitle={{this.closeTitle}}
-        @submitTitle={{@submitTitle}}
-        @submitButtonType={{this.submitButtonType}}
-        @onClose={{this.close}}
-        @onSubmit={{this.doSubmit}}
-      />
-    </BsModal::dialog>
-
-    <div>
-      {{#if this.showBackdrop}}
-        <div class="modal-backdrop {{if this.fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
-      {{/if}}
-    </div>
-  {{else}}
-    {{#in-element this.destinationElement insertBefore=null}}
-      <BsModal::dialog
-        @onClose={{this.close}}
-        @fade={{this.fade}}
-        @showModal={{this.showModal}}
-        @keyboard={{this.keyboard}}
-        @size={{@size}}
-        @backdropClose={{this.backdropClose}}
-        @inDom={{this.inDom}}
-        @paddingLeft={{this.paddingLeft}}
-        @paddingRight={{this.paddingRight}}
-        @centered={{bs-eq this.position "center"}}
-        @scrollable={{this.scrollable}}
-        class={{@class}}
-        id={{this.modalId}}
-        ...attributes
-      >
-        <BsModal::header @title={{@title}} @closeButton={{this.closeButton}} @onClose={{this.close}} />
-        <BsModal::body>
-          {{yield
-            (hash
-              close=this.close
-              submit=this.doSubmit
-            )
-          }}
-        </BsModal::body>
-        <BsModal::footer
-          @closeTitle={{this.closeTitle}}
-          @submitTitle={{@submitTitle}}
-          @submitButtonType={{this.submitButtonType}}
-          @onClose={{this.close}}
-          @onSubmit={{this.doSubmit}}
-        />
-      </BsModal::dialog>
-
-      <div>
-        {{#if this.showBackdrop}}
-          <div class="modal-backdrop {{if this.fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
-        {{/if}}
-      </div>
-    {{/in-element}}
-  {{/if}}
-{{/if}}
+<BsModal
+  @open={{this.open}}
+  @fade={{this.fade}}
+  @backdrop={{this.backdrop}}
+  @keyboard={{this.keyboard}}
+  @position={{this.position}}
+  @scrollable={{this.scrollable}}
+  @size={{this.size}}
+  @backdropClose={{this.backdropClose}}
+  @renderInPlace={{this.renderInPlace}}
+  @transitionDuration={{this.transitionDuration}}
+  @backdropTransitionDuration={{this.backdropTransitionDuration}}
+  @onSubmit={{this.onSubmit}}
+  @onHide={{this.onHide}}
+  @onHidden={{this.onHidden}}
+  @onShow={{this.onShow}}
+  @onShown={{this.onShown}}
+  ...attributes
+  as |modal|
+>
+  <modal.header @title={{@title}} @closeButton={{this.closeButton}} />
+  <modal.body>
+    {{yield
+      (hash
+        close=modal.close
+        submit=modal.submit
+      )
+    }}
+  </modal.body>
+  <modal.footer
+    @closeTitle={{this.closeTitle}}
+    @submitTitle={{@submitTitle}}
+    @submitButtonType={{this.submitButtonType}}
+  />
+</BsModal>

--- a/addon/templates/components/bs-modal.hbs
+++ b/addon/templates/components/bs-modal.hbs
@@ -1,7 +1,7 @@
 {{#if this.inDom}}
   {{#let (component this.dialogComponent
     onClose=this.close
-    fade=this.fade
+    fade=this._fade
     showModal=this.showModal
     keyboard=this.keyboard
     size=@size
@@ -30,7 +30,7 @@
       </Dialog>
       <div>
         {{#if this.showBackdrop}}
-          <div class="modal-backdrop {{if this.fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
+          <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
         {{/if}}
       </div>
     {{else}}
@@ -52,7 +52,7 @@
         </Dialog>
         <div>
           {{#if this.showBackdrop}}
-            <div class="modal-backdrop {{if this.fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
+            <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isBS4")) "show" "in")}}" id={{this.backdropId}}></div>
           {{/if}}
         </div>
       {{/in-element}}

--- a/addon/utils/cp/uses-transition.js
+++ b/addon/utils/cp/uses-transition.js
@@ -6,6 +6,6 @@ export default function usesTransition(fadeProperty) {
   assert('You have to provide a fadeProperty for typeClass', typeof fadeProperty === 'string');
 
   return computed(fadeProperty, function () {
-    return !isFastBoot(this) && this.fade;
+    return !isFastBoot(this) && this[fadeProperty];
   });
 }

--- a/tests/integration/components/bs-modal-simple-test.js
+++ b/tests/integration/components/bs-modal-simple-test.js
@@ -572,16 +572,6 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
     assert.dom('.modal').hasAttribute('aria-labelledby', modalTitleId);
   });
 
-  test('it passes along class attribute', async function (assert) {
-    await render(hbs`
-      <BsModalSimple @fade={{false}} @class="custom">
-        template block text
-      </BsModalSimple>
-    `);
-
-    assert.dom('.modal.custom').exists({ count: 1 });
-  });
-
   test('it passes along HTML attributes', async function (assert) {
     await render(hbs`
       <BsModalSimple @fade={{false}} class="custom" role="alert" data-test>


### PR DESCRIPTION
The OOP relationship between those two is now of type `has-a` instead of `is-a`, i.e. BsModalSimple *uses* BsModal, instead of *being* one.

Fixes #1105

@lolmaus FYI, IIRC you discovered this implementation a while ago...