### PR TITLE
Un-deprecate BsButton's buttonType argument

### DIFF
--- a/addon/components/base/bs-button.js
+++ b/addon/components/base/bs-button.js
@@ -476,7 +476,6 @@ export default class Button extends Component {
     // deprecate arguments used for attribute bindings only
     runInDebug(() => {
       [
-        ['buttonType:type', 'submit'],
         ['disabled', true],
         ['title', 'foo'],
       ].forEach(([mapping, value]) => {

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -77,7 +77,6 @@ module('Integration | Component | bs-button', function(hooks) {
     await render(hbs`{{bs-button buttonType="submit"}}`);
 
     assert.dom('button').hasAttribute('type', 'submit');
-    assert.deprecationsInclude('Argument buttonType of <BsButton> component is deprecated.');
   });
 
   test('button with icon property shows icon', async function(assert) {


### PR DESCRIPTION
Due to https://github.com/emberjs/ember.js/issues/18232 we still support the attribute-argument `buttonType` in current 4.0 RCs, so remove the deprecation here to not cause folks to refactor to anything that will actually not work correctly.