### PR TITLE
Fix CI config for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,12 @@
 name: Publish docs
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published,edited]
 
 jobs:
   deploy:
     runs-on: ubuntu-18.04
-    # only run on master branch, to prevent publishing docs for previous release branches
-    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The previous `if` condition did not work correctly, resulting in a skipped job. Note this will only run when a release in Github is published, not merely a git tag. But as we use `release-it` this will happen automatically. Added the `edited` event type just to be able to manually trigger the (previously skipped) job run. Hopefully this works now...