### PR TITLE
value yielded by FormElement should provide two-way binding

### DIFF
--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -286,9 +286,14 @@ export default class FormElement extends FormGroup {
   }
 
   set value(value) {
-    assert('You cannot set both property and value on a form element', isBlank(this.property));
-
     this._value = value;
+  }
+
+  get twoWayBoundValue() {
+    return this.value;
+  }
+  set twoWayBoundValue(value) {
+    this.doChange(value);
   }
 
   /**
@@ -875,10 +880,18 @@ export default class FormElement extends FormGroup {
 
   init() {
     super.init(...arguments);
+
     if (this.showValidationOn === null) {
       this.set('showValidationOn', ['focusOut']);
     }
+
     if (!isBlank(this.property)) {
+      assert(
+        'You cannot set both property and value on a form element',
+        // eslint-disable-next-line ember/no-attrs-in-components
+        !Object.keys(this.attrs).includes('value')
+      );
+
       this.setupValidations();
     }
 

--- a/addon/templates/components/bs-form/element.hbs
+++ b/addon/templates/components/bs-form/element.hbs
@@ -56,7 +56,7 @@
       {{#if hasBlock}}
         {{yield
           (hash
-            value=this.value
+            value=this.twoWayBoundValue
             id=this.formElementId
             validation=this.validation
             control=Control

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -415,6 +415,26 @@ module('Integration | Component | bs-form/element', function (hooks) {
     assert.dom('#control input[type=text]').exists({ count: 1 }, 'control component is yielded');
   });
 
+  test('Yielded value is writeable', async function (assert) {
+    let model = { name: '' };
+    this.set('model', model);
+
+    await render(hbs`
+      <BsForm @model={{this.model}} as |form|>
+        <form.element @property="name" as |el|>
+          <input
+            type="text"
+            value={{el.value}}
+            {{on "change" (action (mut el.value) value="target.value")}}
+          />
+        </form.element>
+      </BsForm>
+    `);
+
+    await fillIn('input', 'Klara');
+    assert.equal(model.name, 'Klara');
+  });
+
   test('required property propagates', async function (assert) {
     await render(hbs`<BsForm::Element @label="myLabel" @required={{true}} />`);
     assert.dom('.form-group').hasClass('is-required', 'component has is-required class');


### PR DESCRIPTION
This restores the v3 and documented behavior to update a value yielded by `<form.element>` in a custom control. This would fix the regression reported in #1192. 

It does so by providing a two-way binding of the yielded value. This is a little bit contradictory to the intend of #1097, which removed two-way binding but only discussed it on `FormElement` itself - not on the yielded `value` property.

An alternative solution would be yielded an additional `setValue` this would feel more inline with DDAU. The usage would look like this:

```hbs
<BsForm @model={{this.model}} as |form|>
  <form.element @property="name" as |el|>
    <input
      type="text"
      value={{el.value}}
      {{on "change" (action this.setValue value="target.value")}}
    />
  </form.element>
</BsForm>
```
The control component has an `onChange` argument, which provide the same value. But I'm not convinced by that name. I think a `value` property and a `setValue` function to update it, would be a more intuitive API.

To be honest I'm tending toward that API but only noticed after I had the fix nearly finished. So I wanted to provide that one as well to start the discussion.