### PR TITLE
yield setValue function from <form.element> to mutate the value in custom controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 #### :boom: Breaking Change
 * [#1104](https://github.com/kaliber5/ember-bootstrap/pull/1104) Remove support for subclassing component classes  ([@simonihmig](https://github.com/simonihmig))
-* [#1097](https://github.com/kaliber5/ember-bootstrap/pull/1097) Remove leftover two-way binding of form element's `@value` argument ([@basz](https://github.com/basz))
+* [#1097](https://github.com/kaliber5/ember-bootstrap/pull/1097) Remove leftover two-way binding of form element's `@value` argument and yielded `value` ([@basz](https://github.com/basz))
 * [#1106](https://github.com/kaliber5/ember-bootstrap/pull/1106) Refactor BsModalSimple to not extend from BsModal ([@simonihmig](https://github.com/simonihmig))
 
 #### Features

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -74,7 +74,7 @@ const nonDefaultLayouts = A(['checkbox']);
   ```hbs
   <BsForm @model={{this}} @onSubmit={{action "submit"}} as |form|>
     <form.element @label="Select-2" @property="gender" @useIcons={{false}} as |el|>
-      <PikadayInput @value={{el.value}} @onSelection={{action (mut el.value)}} id={{el.id}} />
+      <PikadayInput @value={{el.value}} @onSelection={{action el.setValue}} id={{el.id}} />
     </form.element>
   </BsForm>
   ```
@@ -83,6 +83,7 @@ const nonDefaultLayouts = A(['checkbox']);
   * `control`: the component that would be used for rendering the form control based on the given `controlType`
   * `id`: id to be used for the form control, so it matches the labels `for` attribute
   * `value`: the value of the form element
+  * `setValue`: function to change the value of the form element
   * `validation`: the validation state of the element, `null` if no validation is to be shown, otherwise 'success', 'error' or 'warning'
 
   If your custom control does not render an input element, you should set `useIcons` to `false` since bootstrap only supports

--- a/addon/templates/components/bs-form/element.hbs
+++ b/addon/templates/components/bs-form/element.hbs
@@ -57,6 +57,7 @@
         {{yield
           (hash
             value=this.value
+            setValue=this.doChange
             id=this.formElementId
             validation=this.validation
             control=Control

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -399,20 +399,31 @@ module('Integration | Component | bs-form/element', function (hooks) {
     );
     await render(hbs`
       <BsForm @model={{model}} as |form|>
-        <form.element @label="Gender" @property="gender" @showAllValidations={{true}} @hasValidator={{true}} as |el|>
-          <div id="value">{{el.value}}</div>
-          <div id="id">{{el.id}}</div>
-          <div id="validation">{{el.validation}}</div>
-          <div id="control">{{el.control}}</div>
+        <form.element
+          @controlType="textarea"
+          @label="Gender"
+          @property="gender"
+          @showAllValidations={{true}}
+          @hasValidator={{true}}
+          as |el|
+        >
+          <input
+            type="text"
+            id={{el.id}}
+            value={{el.value}}
+            class={{el.validation}}
+            {{on "input" (action el.setValue value="target.value")}}
+          >
+          <el.control />
         </form.element>
       </BsForm>
     `);
 
-    assert.dom('#value').exists({ count: 1 }, 'block template is rendered');
-    assert.dom('#value').hasText('male', 'value is yielded to block template');
-    assert.dom('#id').hasAnyText('id is yielded to block template');
-    assert.dom('#validation').hasText('success');
-    assert.dom('#control input[type=text]').exists({ count: 1 }, 'control component is yielded');
+    assert.dom('input').exists({ count: 1 }, 'block template is rendered');
+    assert.dom('input').hasValue('male', 'value is yielded to block template');
+    assert.dom('input').hasAttribute('id', { any: true }, 'id is yielded to block template');
+    assert.dom('input').hasClass('success', 'validation status is yielded to block template');
+    assert.dom('textarea').exists({ count: 1 }, 'control component is yielded');
   });
 
   test('required property propagates', async function (assert) {


### PR DESCRIPTION
In #1097 the two-way binding of `value` yielded from `<form.element>` was removed. We missed to provide an alternative for custom controls to change the value. This regression was reported in #1192.

This PR adds the missing capability by yielding a `setValue` function from `<form.element>`:

```hbs
<BsForm @model={{hash}} as |form|>
  <form.element @property="name" as |el|>
    <input value={{el.value}} {{on "input" (action el.setValue value="target.value")}} />
  </form.element>
</BsForm>
```

We do not consider this a breaking change cause two-way binding of yielded `value` was removed in `v4.0.0-rc2`. It was never working in `v4.0.0`.

We evaluated reintroducing two-way binding of yielded `value` in #1202. But choose to prefer a separated `setValue` function. Providing a separate function feels more inline with the rest of our API and the data down, actions up pattern in general.

Closes #1192 and #1202 