### PR TITLE
yield submitButton component from <BsForm>

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -196,6 +196,14 @@ export default class Form extends Component {
   groupComponent = 'bs-form/group';
 
   /**
+   * @property submitButtonComponent
+   * @type {String}
+   * @private
+   */
+  @defaultValue
+  submitButtonComponent = 'bs-button';
+
+  /**
    * `isSubmitting` is `true` after `submit` event has been triggered and until Promise returned by `onSubmit` is
    * fulfilled. If `validate` returns a Promise that one is also taken into consideration.
    *
@@ -237,6 +245,29 @@ export default class Form extends Component {
    */
   @defaultValue
   isRejected = false;
+
+  /**
+   * State of the form expressed as state values expected by `<BsButton>`.
+   *
+   * @property submitButtonState
+   * @type {String}
+   * @private
+   */
+  get submitButtonState() {
+    if (this.isSubmitting) {
+      return 'pending';
+    }
+
+    if (this.isSubmitted) {
+      return 'fulfilled';
+    }
+
+    if (this.isRejected) {
+      return 'rejected';
+    }
+
+    return 'default';
+  }
 
   /**
    * Count of pending submissions.

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -32,7 +32,16 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
   ### Submitting the form
 
-  When the form is submitted (e.g. by clicking a submit button), the event will be intercepted and the `onSubmit` action
+  The form yields a `submitButton` component, which is a preconfigured `<BsButton>` with `@type="primary"` and `@buttonType="submit"`.
+  The button is disabled while a form submission is pending. Additionally the button state is bound to the form submission state.
+
+  ```hbs
+  <BsForm as |form|>
+    <form.submitButton>Submit</form.submitButton>
+  </BsForm>
+  ```
+
+  When the form is submitted (e.g. by clicking the submit button), the event will be intercepted and the `onSubmit` action
   will be sent to the controller or parent component.
   In case the form supports validation (see "Form validation" below), the `onBefore` action is called (which allows you to
   do e.g. model data normalization), then the available validation rules are evaluated, and if those fail, the `onInvalid`
@@ -51,7 +60,7 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
     <form.element @controlType="email" @label="Email" @placeholder="Email" @property="email" />
     <form.element @controlType="password" @label="Password" @placeholder="Password" @property="password" />
     <form.element @controlType="checkbox" @label="Remember me" @property="rememberMe" />
-    <BsButton @defaultText="Submit" @type="primary" @buttonType="submit" />
+    <form.submitButton>Submit</form.submitButton>
   </BsForm>
   ```
 
@@ -82,28 +91,34 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   ### Submission state
 
   A `isSubmitting` property is yielded, which is `true` after submit has been triggered and before the Promise returned
-  by `onSubmit` is fulfilled. It could be used to disable form's submit button and showing a loading spinner for example:
+  by `onSubmit` is fulfilled. It could be used to show a loading spinner instead of the form while it's submitting for example:
 
   ```hbs
   <BsForm @onSubmit={{action "save"}} as |form|>
-    <BsButton @buttonType="submit" @disabled={{form.isSubmitting}}>
-      Save
-      {{#if form.isSubmitting}} {{fa-icon "spinner"}} {{/if}}
-    </BsButton>
+    {{#if form.isSubmitting}}
+      <FaIcon @icon="spinner" />
+    {{else}}
+      <form.element @property="email" @label="email" />
+      <form.element @property="password" @label="password" @controlType="password" />
+      <form.submitButton>Login</form.submitButton>
+    {{/if}}
   </BsForm>
   ```
 
   Additionaly `isSubmitted` and `isRejected` properties are yielded. `isSubmitted` is `true` if last submission was successful.
   `isRejected` is `true` if last submission was rejected due to validation errors or by an action bound to `onSubmit` event, returning a rejected promise.
-  Both are reset as soon as any value of a form element changes. It could be used for visual feedback about last submission:
+  It could be used for visual feedback about last submission:
 
   ```hbs
   <BsForm @onSubmit={{action 'save}} as |form|>
-    <BsButton @buttonType="submit" @type={{if form.isRejected "danger" "primary"}}>
+    <form.submitButton @type={{if form.isRejected "danger" "primary"}}>
       Save
-    </BsButton>
+    </form.submitButton>
   </BsForm>
   ```
+
+  The submission state is reset as soon as any value of a form element changes. Additionally it can be reset programatically by
+  calling the yielded `resetSubmissionState` function.
 
   *Note that only invoking the component in a template as shown above is considered part of its public API. Extending from it (subclassing) is generally not supported, and may break at any time.*
 

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -96,7 +96,8 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
   ```hbs
   <BsForm @onSubmit={{action "save"}} as |form|>
     {{#if form.isSubmitting}}
-      <FaIcon @icon="spinner" />
+      <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+      Logging in...
     {{else}}
       <form.element @property="email" @label="email" />
       <form.element @property="password" @label="password" @controlType="password" />

--- a/addon/templates/components/bs-form.hbs
+++ b/addon/templates/components/bs-form.hbs
@@ -25,6 +25,11 @@
       isRejected=this.isRejected
       resetSubmissionState=this.resetSubmissionState
       submit=this.doSubmit
+      submitButton=(component this.submitButtonComponent
+        buttonType="submit"
+        type="primary"
+        state=this.submitButtonState
+      )
     )
   }}
 </form>

--- a/addon/templates/components/bs-form.hbs
+++ b/addon/templates/components/bs-form.hbs
@@ -29,6 +29,7 @@
         buttonType="submit"
         type="primary"
         state=this.submitButtonState
+        _disabled=this.isSubmitting
       )
     )
   }}

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -1021,24 +1021,30 @@ module('Integration | Component | bs-form', function (hooks) {
           </BsForm>
         `);
         assert.dom('button[type="submit"]').hasNoText();
+        assert.dom('button[type="submit"]').hasNoAttribute('disabled');
 
         await submitForm();
         assert.dom('button[type="submit"]').hasText('isPending');
+        assert.dom('button[type="submit"]').hasAttribute('disabled', '');
 
         deferredSubmitAction.resolve();
         await settled();
         assert.dom('button[type="submit"]').hasText('isFulfilled isSettled');
+        assert.dom('button[type="submit"]').hasNoAttribute('disabled');
 
         deferredSubmitAction = defer();
         await click('button[type="button"]');
         assert.dom('button[type="submit"]').hasNoText();
+        assert.dom('button[type="submit"]').hasNoAttribute('disabled');
 
         await submitForm();
         assert.dom('button[type="submit"]').hasText('isPending');
+        assert.dom('button[type="submit"]').hasAttribute('disabled', '');
 
         deferredSubmitAction.reject();
         await settled();
         assert.dom('button[type="submit"]').hasText('isRejected isSettled');
+        assert.dom('button[type="submit"]').hasNoAttribute('disabled');
       });
     });
   });

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -804,15 +804,17 @@ module('Integration | Component | bs-form', function (hooks) {
     await render(hbs`
       <BsForm @onSubmit={{action "submit"}} @model={{hash }} as |form|>
         <input onchange={{form.resetSubmissionState}}>
-        <button type="submit" class={{if form.isSubmitted "is-submitted"}}>submit</button>
+        {{#if form.isSubmitting}}isSubmitting{{/if}}
+        {{#if form.isSubmitted}}isSubmitted{{/if}}
+        {{#if form.isRejected}}isRejected{{/if}}
       </BsForm>
     `);
 
     await triggerEvent('form', 'submit');
-    assert.dom('form button').hasClass('is-submitted', 'assumption');
+    assert.dom('form').hasText('isSubmitted');
 
     await fillIn('input', 'bar');
-    assert.dom('form button').doesNotHaveClass('is-submitted');
+    assert.dom('form').hasNoText();
   });
 
   test("Adds default onChange action to form elements that updates model's property", async function (assert) {
@@ -953,5 +955,91 @@ module('Integration | Component | bs-form', function (hooks) {
 
     await a11yAudit();
     assert.ok(true, 'A11y audit passed');
+  });
+
+  module('yielded submitButton', function () {
+    test('it yields submitButton component', async function (assert) {
+      await render(hbs`
+        <BsForm as |form|>
+          <form.submitButton />
+        </BsForm>
+      `);
+
+      assert.dom('form button').exists('yielded submitButton component renders a button element');
+      assert.dom('form button').hasAttribute('type', 'submit', 'its type is submit');
+      assert.dom('form button').hasClass('btn-primary', 'its a primary button by default');
+    });
+
+    test('click yielded submitButton component submits the form', async function (assert) {
+      this.set('submitHandler', () => {
+        assert.step('@onSubmit action is exected');
+      });
+
+      await render(hbs`
+        <BsForm @onSubmit={{this.submitHandler}} as |form|>
+          <form.submitButton />
+        </BsForm>
+      `);
+      await click('button');
+      assert.verifySteps(['@onSubmit action is exected']);
+    });
+
+    ['submitted via event', 'submitted via yielded submitButton'].forEach((scenario) => {
+      async function submitForm() {
+        switch (scenario) {
+          case 'submitted via event':
+            await triggerEvent('form', 'submit');
+            break;
+
+          case 'submitted via yielded submitButton':
+            await click('button');
+            break;
+
+          default:
+            throw new Error('scenario is not supported');
+        }
+      }
+
+      test(`state of yielded submitButton component is bound to form submission state if ${scenario}`, async function (assert) {
+        let deferredSubmitAction = defer();
+
+        this.set('resetTrigger', false);
+        this.set('submitHandler', () => {
+          return deferredSubmitAction.promise;
+        });
+
+        await render(hbs`
+          <BsForm @onSubmit={{this.submitHandler}} as |form|>
+            <form.submitButton as |button|>
+              {{#if button.isPending}}isPending{{/if}}
+              {{#if button.isFulfilled}}isFulfilled{{/if}}
+              {{#if button.isRejected}}isRejected{{/if}}
+              {{#if button.isSettled}}isSettled{{/if}}
+            </form.submitButton>
+            <button type="button" {{on "click" form.resetSubmissionState}}>
+            </button>
+          </BsForm>
+        `);
+        assert.dom('button[type="submit"]').hasNoText();
+
+        await submitForm();
+        assert.dom('button[type="submit"]').hasText('isPending');
+
+        deferredSubmitAction.resolve();
+        await settled();
+        assert.dom('button[type="submit"]').hasText('isFulfilled isSettled');
+
+        deferredSubmitAction = defer();
+        await click('button[type="button"]');
+        assert.dom('button[type="submit"]').hasNoText();
+
+        await submitForm();
+        assert.dom('button[type="submit"]').hasText('isPending');
+
+        deferredSubmitAction.reject();
+        await settled();
+        assert.dom('button[type="submit"]').hasText('isRejected isSettled');
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds a `submitButton` component yielded by `<BsForm>`. It's a `<BsButton>` with having `@buttonType="submit"` and `@type="primary"`. It's disabled if the form is submitting.

This new API helps to reduce the code needed to implement a common submit button. It also improves readability in my opinion as it directly states that the button belongs to the form and will submit it.

```hbs
{{! new API added by this PR }}
<BsForm as |form|>
  <form.submitButton>Submit</form>
</BsForm>

{{! the same with current API }}
<BsForm as |form|>
  <BsButton @buttonType="submit" @type="primary" @disabled={{form.isSubmitting}}>Submit</BsButton>
</BsForm>

{{! minimal code needed for a submit button with current API }}
<BsForm as |form|>
  <BsButton @buttonType="submit">Submit</BsButton>
</BsForm>
```

Additionally the submission state of the form is bound to the button state. This is helpful for showing submission state on the submit button.

Using it in isolation would look like this:

```hbs
<BsForm as |form|>
  <form.submitButton as |button|>
    {{#if button.isPending}}
      <FaIcon @icon="spinner" />
    {{/if}}
    {{#if button.isFulfilled}}
      <FaIcon @icon="check" />
    {{/if}}
    {{#if button.isRejected}}
      <FaIcon @icon="times" />
    {{/if}}
  </form.submitButton>
</BsForm>
```

This doesn't provide much value over using `{{form.isSubmitting}}`, `{{form.isSubmitted}}` and `{{form.isRejected}}`. But it gets powerful if a user customizes the `<BsButton>` component to show the state the button is currently. In that case the submission state integration comes out of the box if just doing this:

```hbs
<BsForm as |form|>
  <form.submitButton />
</BsForm>
```

Such a customization could be achived by overwriting `<BsButton>` in the application. Similar to this:

```hbs
// app/components/bs-button.hbs

<BsButton::Original as |button|>
  {{#if button.isPending}}
    <FaIcon @icon="spinner" />
  {{/if}}
  {{#if button.isFulfilled}}
    <FaIcon @icon="check" />
  {{/if}}
  {{#if button.isRejected}}
    <FaIcon @icon="times" />
  {{/if}}
</BsButton>
```

```js
// app/components/bs-button/original.js

export { default } from 'ember-bootstrap/components/bs-button';
```

This is one of the two outstanding features from #638. 