### PR TITLE
Fix CI config for running FastBoot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         command:
-          - ember test
+          - ember test --filter="\!FastBoot"
         scenario:
           - ember-lts-3.16
           - ember-release

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,7 +6,6 @@ const bootstrapVersion = process.env.BOOTSTRAPVERSION === '3' ? '^3.4.1' : '^4.3
 module.exports = async function () {
   return {
     useYarn: true,
-    command: 'ember test --filter !FastBoot',
     scenarios: [
       {
         name: 'ember-lts-3.16',


### PR DESCRIPTION
It was intended before to run FastBoot tests only within the explicit ember-try scenario, but actually they did run for every scenario. This should fix it.

However we may revise that later, as FastBoot tests using `ember-cli-fastboot-testing` don't suffer from the overhead they had before. But we should do that eventually only after https://github.com/glimmerjs/glimmer-vm/issues/1141 is fixed, which currently causes FastBoot tests to fail for Ember beta/canary.