### PR TITLE
Fix CSP failures in FastBoot tests

### DIFF
--- a/tests/dummy/config/content-security-policy.js
+++ b/tests/dummy/config/content-security-policy.js
@@ -11,7 +11,11 @@ module.exports = function () {
         // Bootstrap 4 uses data URL for some SVG images in CSS
         'data:',
       ],
-      'style-src': ["'self'"],
+      'style-src': [
+        "'self'",
+        "'sha256-TfKF8gl0QHp566h8GzfYjTsiRn3j9Ll7S0zdoLOq7ic='",
+        "'sha256-9jmMc10d3gtj1r8cOJX+x+p1bMOS+vX+i8iVCr3h18A='",
+      ],
       'media-src': ["'self'"],
     },
   };


### PR DESCRIPTION
This was caused by several facts:
* `ember-a11y-testing` adds two styles tags with inline content
* `ember-cli-fastboot-testing` parses the FastBoot rendered HTML string here: https://github.com/embermap/ember-cli-fastboot-testing/blob/47882cebaaf9fb482df3e3b1eae1067807726890/addon-test-support/index.js#L120
* while the inline style violating our CSP was somehow ignored before, it seems the latest Chrome 85 now triggers a CSP violation event on that line above
* which in turn makes the test fail

This adds hash values to our CSP policy to specifically allow these two inline style elements