### PR TITLE
Introduce useDefaultValueIfUndefined optional feature to ease passing arguments through

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -161,6 +161,8 @@ export default class Form extends Component {
    * @type Ember.Object
    * @public
    */
+  @defaultValue
+  model = macroCondition(getOwnConfig().useDefaultValueIfUndefined) ? {} : undefined;
 
   /**
    * Set the layout of the form to either "vertical", "horizontal" or "inline". See http://getbootstrap.com/css/#forms-inline and http://getbootstrap.com/css/#forms-horizontal

--- a/addon/utils/decorators/arg.js
+++ b/addon/utils/decorators/arg.js
@@ -1,10 +1,16 @@
+import { macroCondition, getOwnConfig } from '@embroider/macros';
+
 export default function arg(target, key, descriptor) {
   let defaultValue = descriptor.initializer ? descriptor.initializer() : undefined;
 
   return {
     get() {
-      const argValue = this.args[key];
-      return argValue !== undefined ? argValue : defaultValue;
+      if (macroCondition(getOwnConfig().useDefaultValueIfUndefined)) {
+        const argValue = this.args[key];
+        return argValue !== undefined ? argValue : defaultValue;
+      } else {
+        return Object.keys(this.args).includes(key) ? this.args[key] : defaultValue;
+      }
     },
   };
 }

--- a/addon/utils/default-decorator.js
+++ b/addon/utils/default-decorator.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+import { macroCondition, getOwnConfig } from '@embroider/macros';
 
 export default function defaultValue(target, key, descriptor) {
   let { initializer, value } = descriptor;
@@ -8,7 +9,15 @@ export default function defaultValue(target, key, descriptor) {
       return initializer ? initializer.call(this) : value;
     },
     set(_, v) {
-      return v;
+      if (macroCondition(getOwnConfig().useDefaultValueIfUndefined)) {
+        if (v !== undefined) {
+          return v;
+        }
+
+        return initializer ? initializer.call(this) : value;
+      } else {
+        return v;
+      }
     },
   })(target, key, { ...descriptor, value: undefined, initializer: undefined });
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -120,6 +120,17 @@ module.exports = async function () {
           FASTBOOT_DISABLED: true,
         },
       },
+      {
+        name: 'optional-feature-use-default-value-if-undefined',
+        npm: {
+          devDependencies: {
+            bootstrap: bootstrapVersion,
+          },
+        },
+        env: {
+          OPTIONAL_FEATURE_USE_DEFAULT_VALUE_IF_UNDEFINED: true,
+        },
+      },
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,7 +14,8 @@ module.exports = function (defaults) {
     });
   }
 
-  let app = new EmberAddon(defaults, {
+  const options = {
+    'ember-bootstrap': {},
     'ember-cli-babel': {
       includePolyfill: !!process.env.BABELPOLYFILL,
     },
@@ -25,7 +26,16 @@ module.exports = function (defaults) {
     addons: {
       blacklist: process.env.FASTBOOT_DISABLED ? ['ember-cli-fastboot-testing'] : [],
     },
-  });
+  };
+
+  if (process.env.OPTIONAL_FEATURE_USE_DEFAULT_VALUE_IF_UNDEFINED) {
+    console.log('enabling optional feature useDefaultValueIfUndefined');
+    options['ember-bootstrap'].useDefaultValueIfUndefined = true;
+  } else {
+    console.log(process.env);
+  }
+
+  let app = new EmberAddon(defaults, options);
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,10 +29,7 @@ module.exports = function (defaults) {
   };
 
   if (process.env.OPTIONAL_FEATURE_USE_DEFAULT_VALUE_IF_UNDEFINED) {
-    console.log('enabling optional feature useDefaultValueIfUndefined');
     options['ember-bootstrap'].useDefaultValueIfUndefined = true;
-  } else {
-    console.log(process.env);
   }
 
   let app = new EmberAddon(defaults, options);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const defaultOptions = {
   importBootstrapFont: false,
   insertEmberWormholeElementToDom: true,
   bootstrapVersion: 4,
+  useDefaultValueIfUndefined: false,
 };
 
 const supportedPreprocessors = ['less', 'sass'];
@@ -98,6 +99,9 @@ module.exports = {
     // setup config for @embroider/macros
     this.options['@embroider/macros'].setOwnConfig.isBS3 = this.getBootstrapVersion() === 3;
     this.options['@embroider/macros'].setOwnConfig.isBS4 = this.getBootstrapVersion() === 4;
+    this.options['@embroider/macros'].setOwnConfig.useDefaultValueIfUndefined = Boolean(
+      this.bootstrapOptions.useDefaultValueIfUndefined
+    );
   },
 
   options: {

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -1,5 +1,6 @@
 import config from 'dummy/config/environment';
-import { skip, test } from 'qunit';
+import { getOwnConfig } from '@embroider/macros';
+import { module, skip, test } from 'qunit';
 import { Promise } from 'rsvp';
 
 const currentBootstrapVersion = parseInt(config.bootstrapVersion);
@@ -26,6 +27,23 @@ export function versionDependent(v3, v4) {
   }
 
   return v4;
+}
+
+// eslint-disable-next-line ember/no-test-module-for
+export function moduleForOptionalFeature(optionalFeature, fn) {
+  let ownConfig = getOwnConfig();
+
+  if (!Object.keys(ownConfig).includes(optionalFeature)) {
+    throw new Error(`Optional feature ${optionalFeature} does not exist.`);
+  }
+
+  let optionalFeatureEnabled = ownConfig[optionalFeature];
+  let name = `Optional feature: ${optionalFeature}`;
+  if (optionalFeatureEnabled) {
+    module(name, fn);
+  } else {
+    skip(name, fn);
+  }
 }
 
 export function visibilityClass() {

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -1,5 +1,5 @@
 import config from 'dummy/config/environment';
-import { getOwnConfig } from '@embroider/macros';
+import { dependencySatisfies, getConfig, getOwnConfig, macroCondition } from '@embroider/macros';
 import { module, skip, test } from 'qunit';
 import { Promise } from 'rsvp';
 
@@ -31,13 +31,27 @@ export function versionDependent(v3, v4) {
 
 // eslint-disable-next-line ember/no-test-module-for
 export function moduleForOptionalFeature(optionalFeature, fn) {
-  let ownConfig = getOwnConfig();
+  let optionalFeatureEnabled;
 
-  if (!Object.keys(ownConfig).includes(optionalFeature)) {
+  // `getConfig('ember-bootstrap')` is the correct way to retrieve the
+  // configuration of the addon it it's dummy app. But the `getConfig`
+  // macro is broken for dummy app of an addon in classic builds.
+  // `getOwnConfig` macro also has a bug in classic builds. It resolves
+  // with the configuration of the addon not of it's dummy app. We can
+  // use that bug as a work-a-round for classic builds until the but of
+  // `getConfig` macro has been fixed.
+  // Both bugs are tracked in this issue:
+  // https://github.com/embroider-build/embroider/issues/537
+  if (macroCondition(dependencySatisfies('@embroider/webpack', '*'))) {
+    optionalFeatureEnabled = getConfig('ember-bootstrap')[optionalFeature];
+  } else {
+    optionalFeatureEnabled = getOwnConfig()[optionalFeature];
+  }
+
+  if (optionalFeatureEnabled === undefined) {
     throw new Error(`Optional feature ${optionalFeature} does not exist.`);
   }
 
-  let optionalFeatureEnabled = ownConfig[optionalFeature];
   let name = `Optional feature: ${optionalFeature}`;
   if (optionalFeatureEnabled) {
     module(name, fn);


### PR DESCRIPTION
We are wrapping components provided by Ember Bootstrap in custom addons. So we have many code like this:

```hbs
// addon/components/my-form.hbs

<BsForm
  @formLayout={{@formLayout}}
  @model={{@model}}
  @onSubmit={{@onSubmit}}
>
  {{yield form}}
</BsForm>
```

We noticed that the current implementation of `defaultValue` decorator does not use the defaults if the argument is passed but being `undefined`. So we would need to redeclare all default value:

```hbs
// addon/components/my-form.hbs

<BsForm
  @formLayout={{if @formLayout @formLayout "vertical"}}
  @model={{if @model @model (hash)}}
  @onSubmit={{if @onSubmit @onSubmit this.noop}}
>
  {{yield form}}
</BsForm>
```

Not great solution. So we thought we might want to change the `defaultValue` decorator.

I also noticed that `arg` decorator used for the components, which have been refactored to `@glimmer/component` seem to fall back to default value if `undefined` is passed: https://github.com/kaliber5/ember-bootstrap/blob/c740df9f818a8081e523e265a8e438418b78648c/addon/utils/decorators/arg.js#L5-L8 So I think we can consider the current implementation of `defaultValue` to be a bug.

I wasn't sure how to test this as it affects so many places. Just added one test as a showcase.

Disclaimer: Decorators are still scary to me. I'm definitely not an expert on that topic. Came up with that fix by try and error rather than by understanding what I'm doing. Please let me know if it's totally wrong.