### PR TITLE
<BsForm> should support @onBefore, @onSubmit and @onInvalid arguments to be undefined

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -381,7 +381,6 @@ export default class Form extends Component {
    * @param { Object } model  The form's `model`
    * @public
    */
-  onBefore(model) {} // eslint-disable-line no-unused-vars
 
   /**
    * Action is called when submit has been triggered and the model has passed all validations (if present).
@@ -391,7 +390,6 @@ export default class Form extends Component {
    * @param { Object } result The returned result from the validate method, if validation is available
    * @public
    */
-  onSubmit(model, result) {} // eslint-disable-line no-unused-vars
 
   /**
    * Action is called when validation of the model has failed.
@@ -401,7 +399,6 @@ export default class Form extends Component {
    * @param { Object } error
    * @public
    */
-  onInvalid(model, error) {} // eslint-disable-line no-unused-vars
 
   /**
    * Submit handler that will send the default action ("action") to the controller when submitting the form.
@@ -426,7 +423,10 @@ export default class Form extends Component {
     let model = this.model;
 
     this.incrementProperty('pendingSubmissions');
-    this.onBefore(model);
+
+    if (typeof this.onBefore === 'function') {
+      this.onBefore(model);
+    }
 
     return RSVP.resolve()
       .then(() => {
@@ -440,7 +440,9 @@ export default class Form extends Component {
 
           return RSVP.resolve()
             .then(() => {
-              return this.onSubmit(model, record);
+              if (typeof this.onSubmit === 'function') {
+                return this.onSubmit(model, record);
+              }
             })
             .then(() => {
               if (this.isDestroyed) {
@@ -474,7 +476,9 @@ export default class Form extends Component {
         (error) => {
           return RSVP.resolve()
             .then(() => {
-              return this.onInvalid(model, error);
+              if (typeof this.onInvalid === 'function') {
+                return this.onInvalid(model, error);
+              }
             })
             .finally(() => {
               if (this.isDestroyed) {

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -499,8 +499,8 @@ module('Integration | Component | bs-form', function (hooks) {
 
   test('yielded submit action rejects for expected scenarios', async function (assert) {
     let scenarios = [
-      { validate: sinon.fake.rejects('rejected value') },
-      { onSubmit: sinon.fake.rejects('rejected value') },
+      { validate: sinon.fake.rejects('rejected value'), onSubmit: sinon.fake.resolves() },
+      { validate: sinon.fake.resolves(), onSubmit: sinon.fake.rejects('rejected value') },
     ];
 
     class TestComponent extends Component {
@@ -518,7 +518,12 @@ module('Integration | Component | bs-form', function (hooks) {
     for (let i = 0; i < scenarios.length; i++) {
       this.setProperties(scenarios[i]);
       await render(hbs`
-        <BsForm @onSubmit={{onSubmit}} @validate={{validate}} as |form|>
+        <BsForm
+          @onSubmit={{this.onSubmit}}
+          @validate={{this.validate}}
+          @hasValidator={{true}}
+          as |form|
+        >
           {{test-component onSubmit=form.submit}}
         </BsForm>
       `);

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -1048,4 +1048,17 @@ module('Integration | Component | bs-form', function (hooks) {
       });
     });
   });
+
+  test('arguments @onBefore, @onSubmit, @onInvalid can be undefined', async function (assert) {
+    assert.expect(0);
+
+    this.set('onBefore', undefined);
+    this.set('onSubmit', undefined);
+    this.set('onInvalid', undefined);
+
+    await render(hbs`
+      <BsForm @onBefore={{this.onBefore}} @onSubmit={{this.onSubmit}} @onInvalid={{this.onInvalid}} />
+    `);
+    await triggerEvent('form', 'submit');
+  });
 });


### PR DESCRIPTION
Before it was throwing if value of `@onBefore`, `@onSubmit` or `@onInvalid` is `undefined`. With this changes it supports all of them being `undefined`.

This makes usage of `<BsForm>` in addons, which forward the arguments difficult. A wrapping addon needed to pass a noop function itself if the consumer hasn't passed that argument. The code looked like this:

```hbs
<BsForm
  @onBefore={{if @onBefore @onBefore this.noop}}
  @onSubmit={{if @onSubmit @onSubmit this.noop}}
  @onInvalid={{if @onInvalid @onInvalid this.noop}}
  as |form|
>
  {{yield form}}
</BsForm>
```

After this change a wrapping addon can do this:

```hbs
<BsForm
  @onBefore={{@onBefore}}
  @onSubmit={{@onSubmit}}
  @onInvalid={{@onInvalid}}
  as |form|
>
  {{yield form}}
</BsForm>
```

This is the companion to #1248.

While fixing that issue I noticed that one of the tests was not testing what it claimed to do. I fixed that test on the go with the minimum changes needed. The test needs a refactoring for sure. But didn't wanted to touch it too much in a bug fix PR.