### PR TITLE
Support both ember-concurrency 1.x and 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
           - ember-canary
           - ember-default-with-jquery
           - ember-classic
-          - ember-concurrency-1.x
           - ember-concurrency-2.x
         bootstrap:
           - 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           - ember-canary
           - ember-default-with-jquery
           - ember-classic
+          - ember-concurrency-1.x
+          - ember-concurrency-2.x
         bootstrap:
           - 3
           - 4

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -108,6 +108,22 @@ module.exports = async function () {
         command: 'yarn run nodetest',
       },
       {
+        name: 'ember-concurrency-1.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^1.3.0',
+          },
+        },
+      },
+      {
+        name: 'ember-concurrency-2.x',
+        npm: {
+          dependencies: {
+            'ember-concurrency': '^2.0.0-beta.1',
+          },
+        },
+      },
+      {
         name: 'embroider-tests',
         npm: {
           devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -108,20 +108,14 @@ module.exports = async function () {
         command: 'yarn run nodetest',
       },
       {
-        name: 'ember-concurrency-1.x',
-        npm: {
-          dependencies: {
-            'ember-concurrency': '^1.3.0',
-            bootstrap: bootstrapVersion,
-          },
-        },
-      },
-      {
         name: 'ember-concurrency-2.x',
         npm: {
           dependencies: {
             'ember-concurrency': '^2.0.0-beta.1',
             bootstrap: bootstrapVersion,
+          },
+          resolutions: {
+            'ember-concurrency': '^2.0.0-beta.1',
           },
         },
       },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -112,6 +112,7 @@ module.exports = async function () {
         npm: {
           dependencies: {
             'ember-concurrency': '^1.3.0',
+            bootstrap: bootstrapVersion,
           },
         },
       },
@@ -120,6 +121,7 @@ module.exports = async function () {
         npm: {
           dependencies: {
             'ember-concurrency': '^2.0.0-beta.1',
+            bootstrap: bootstrapVersion,
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "resolutions": {
     "ember-cli-htmlbars/semver": "~7.0.0",
-    "ember-concurrency": "^1.0.0",
     "ip-regex": "^2.1.0"
   },
   "dependencies": {
@@ -55,7 +54,7 @@
     "ember-cli-build-config-editor": "0.5.1",
     "ember-cli-htmlbars": "^5.1.2",
     "ember-cli-version-checker": "^5.1.1",
-    "ember-concurrency": "^1.3.0",
+    "ember-concurrency": "^1.3.0 <3",
     "ember-decorators": "^6.1.0",
     "ember-element-helper": "^0.3.1",
     "ember-focus-trap": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-build-config-editor": "0.5.1",
     "ember-cli-htmlbars": "^5.1.2",
     "ember-cli-version-checker": "^5.1.1",
-    "ember-concurrency": "^1.3.0 <3",
+    "ember-concurrency": ">=1.3.0 <3",
     "ember-decorators": "^6.1.0",
     "ember-element-helper": "^0.3.1",
     "ember-focus-trap": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "resolutions": {
     "ember-cli-htmlbars/semver": "~7.0.0",
+    "ember-concurrency": "^1.3.0",
     "ip-regex": "^2.1.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,7 +6184,7 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-"ember-concurrency@^1.3.0 <3":
+"ember-concurrency@>=1.3.0 <3":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.3.0.tgz#66f90fb792687470bcee1172adc0ebf33f5e8b9c"
   integrity sha512-DwGlfWFpYyAkTwsedlEtK4t1DznJSculAW6Vq5S1C0shVPc5b6tTpHB2FFYisannSYkm+wpm1f1Pd40qiNPtOQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,7 +6184,7 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-"ember-concurrency@>=1.3.0 <3":
+"ember-concurrency@>=1.3.0 <3", ember-concurrency@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.3.0.tgz#66f90fb792687470bcee1172adc0ebf33f5e8b9c"
   integrity sha512-DwGlfWFpYyAkTwsedlEtK4t1DznJSculAW6Vq5S1C0shVPc5b6tTpHB2FFYisannSYkm+wpm1f1Pd40qiNPtOQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,7 +6184,7 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-concurrency@^1.0.0, ember-concurrency@^1.3.0:
+"ember-concurrency@^1.3.0 <3":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.3.0.tgz#66f90fb792687470bcee1172adc0ebf33f5e8b9c"
   integrity sha512-DwGlfWFpYyAkTwsedlEtK4t1DznJSculAW6Vq5S1C0shVPc5b6tTpHB2FFYisannSYkm+wpm1f1Pd40qiNPtOQ==


### PR DESCRIPTION
We've just released ember-concurrency 2.0.0-beta.1. It's a largely API-compatible re-engineering of ember-concurrency's internals to support tracked properties and decouple from Ember (shedding EmberObject, etc.). As a popular library which depends on ember-concurrency, it would be nice for `ember-power-select` to support both 1.x and 2.x versions concurrently so that folks can upgrade the version of ember-concurrency in their applications at their leisure without waiting for all the add-ons they use to switch over to a newer version (and risk leaving folks who cannot upgrade yet behind.)

This PR adds some scenarios to ember-try to enable testing against both major releases and relaxes the version restriction.