### PR TITLE
render header for <BsAlert> using named blocks

### DIFF
--- a/addon/components/bs-alert.hbs
+++ b/addon/components/bs-alert.hbs
@@ -9,6 +9,19 @@
         <span aria-hidden="true">&times;</span>
       </button>
     {{/if}}
-    {{yield}}
+
+    {{#if (has-block "header")}}
+      {{#let (element (bs-default @headerTag "h4")) as |Tag|}}
+        <Tag class="alert-heading">
+          {{yield to="header"}}
+        </Tag>
+      {{/let}}
+    {{/if}}
+
+    {{#if (has-block "body")}}
+      {{yield to="body"}}
+    {{else}}
+      {{yield}}
+    {{/if}}
   {{/unless}}
 </div>

--- a/addon/helpers/bs-default.js
+++ b/addon/helpers/bs-default.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function bsDefault(params) {
+  return params[0] ?? params[1];
+}
+
+export default helper(bsDefault);

--- a/app/helpers/bs-default.js
+++ b/app/helpers/bs-default.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/helpers/bs-default';

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-element-helper": "^0.3.1",
     "ember-focus-trap": "^0.4.0",
     "ember-in-element-polyfill": "^1.0.0",
+    "ember-named-blocks-polyfill": "^0.2.3",
     "ember-on-helper": "^0.1.0",
     "ember-popper": "^0.11.3",
     "ember-ref-bucket": "^1.0.1",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,18 @@
+<BsAlert>Plain</BsAlert>
+
+{{!--
+<BsAlert>
+  <:header>Header only</:header>
+</BsAlert>
+
+<BsAlert>
+  <:body>Body only</:body>
+</BsAlert>
+--}}
+
+<BsAlert>
+  <:header>Header</:header>
+  <:body>Body</:body>
+</BsAlert>
+
 {{outlet}}

--- a/tests/integration/components/bs-alert-test.js
+++ b/tests/integration/components/bs-alert-test.js
@@ -119,4 +119,28 @@ module('Integration | Component | bs-alert', function (hooks) {
     await a11yAudit();
     assert.ok(true, 'A11y audit passed');
   });
+
+  test('it allows to set a header using named blocks', async function (assert) {
+    await render(hbs`
+      <BsAlert>
+        <:header>Warning</:header>
+        <:body><p>Some content</p></:body>
+      </BsAlert>
+    `);
+
+    assert.dom('.alert .alert-heading').exists({ count: 1 }, 'header exists');
+    assert.dom('.alert .alert-heading').hasText('Warning', 'block content is rendered inside header');
+    assert.dom('.alert .alert-heading').hasTagName('h4', 'header uses a h4 tag');
+    assert.dom('.alert .alert-heading + p').exists({ count: 1 }, 'body is rendered a as silbing of header');
+  });
+
+  test('tagName used for header element can be customized with headerTag argument', async function (assert) {
+    await render(hbs`
+      <BsAlert @headerTag="h1">
+        <:header>Warning</:header>
+        <:body><p>Some content</p></:body>
+      </BsAlert>
+    `);
+    assert.dom('.alert .alert-heading').hasTagName('h1');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6297,6 +6297,15 @@ ember-modifier@^2.1.0:
     ember-destroyable-polyfill "^2.0.1"
     ember-modifier-manager-polyfill "^1.2.0"
 
+ember-named-blocks-polyfill@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ember-named-blocks-polyfill/-/ember-named-blocks-polyfill-0.2.3.tgz#05fb3b40cff98a0d30e8c3b1e3d2155951007d84"
+  integrity sha512-RrhkgWmfte2lRuOmRWWa7sS2Eo6W3O0VybK0iPhhnLvk7VtUSOmFxuDlhAtEaJ0lBieISrNcmSIZRnmgca/HcA==
+  dependencies:
+    ember-cli-babel "^7.19.0"
+    ember-cli-htmlbars "^4.3.1"
+    ember-cli-version-checker "^5.1.1"
+
 ember-on-helper@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ember-on-helper/-/ember-on-helper-0.1.0.tgz#c8b1fef9173fc8546c4933b57ecd7ffbcebad99e"


### PR DESCRIPTION
Provide a declarative API to render an alert with a header:

```hbs
<BsAlert>
  <:header>Warning</:header>
  <:body><p>Named blocks are getting reality.</p></:body>
</BsAlert>
```

It's the same as:

```hbs
<BsAlert>
  <h4 class="alert-heading">Warning</h4>
  <p>Named blocks are getting reality.</p>
</BsAlert>
```

So actually it's already possible with existing APIs. It even requires less code with existing APIs. We decided to prefer it in our current project nevertheless for three reasons:

1. It provides a better developer experience as the developer does not need to care about Bootstrap markup and class namings. `<:header>` is easier to read and remember than `<h4 class="alert-heading">`.
2. `<h4 class="alert-heading">` invites for derivation. `<:header>` makes that less likely and therefore helps to ensure same look across the application (or suite of applications).
3. If needed a wrapper around the body or a different class on the header can be applied. This may help with upgrades, e.g. if that part of the markup changes in Bootstrap 5.

I'm not very much opinionated if this belongs in Ember Bootstrap or not. If you don't see the value, we can also keep it in our UI library build on top of Bootstrap.