### PR TITLE
Avoid deprecation warning for dropdown button

### DIFF
--- a/addon/components/bs-dropdown/button.js
+++ b/addon/components/bs-dropdown/button.js
@@ -10,4 +10,6 @@ import Button from 'ember-bootstrap/components/bs-button';
  @extends Components.Button
  @public
  */
-export default class DropdownButton extends Button {}
+export default class DropdownButton extends Button {
+  '__ember-bootstrap_subclass' = true;
+}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -23,7 +23,6 @@ module.exports = function (environment) {
     },
 
     bootstrapVersion: process.env.BOOTSTRAPVERSION || 4,
-    failOnDeprecation: !!process.env.FAIL_ON_DEPRECATION,
     fastboot: {
       hostWhitelist: [/^localhost:\d+$/],
     },

--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -1,6 +1,5 @@
 import QUnit from 'qunit';
 import { registerDeprecationHandler } from '@ember/debug';
-import config from 'dummy/config/environment';
 
 let isRegistered = false;
 let deprecations;
@@ -19,7 +18,7 @@ export default function setupNoDeprecations({ beforeEach, afterEach }) {
 
   afterEach(function (assert) {
     // guard in if instead of using assert.equal(), to not make assert.expect() fail
-    if (config.failOnDeprecation && deprecations && deprecations.length > 0) {
+    if (deprecations && deprecations.length > 0) {
       assert.ok(false, `Expected no deprecations, found: ${deprecations.map((msg) => `"${msg}"`).join(', ')}`);
     }
   });


### PR DESCRIPTION
Fixes #1270

Deprecations should fail in tests, but this was lost, probably while migrating to Github actions. Previously we checked deprecations only for specific Ember versions, as some older threw some without any means to prevent that. That's not needed anymore, so deprecations will fail tests now always.