### PR TITLE
use @embroider/test-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
             command: ember test --launch Firefox
           - scenario: fastboot-tests
           - scenario: node-tests
-          - scenario: embroider-tests
+          - scenario: embroider-safe
+          - scenario: embroider-optimized
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,7 @@
 
 const getChannelURL = require('ember-source-channel-url');
 const bootstrapVersion = process.env.BOOTSTRAPVERSION === '3' ? '^3.4.1' : '^4.3.1';
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
@@ -119,19 +120,16 @@ module.exports = async function () {
           },
         },
       },
-      {
-        name: 'embroider-tests',
-        npm: {
-          devDependencies: {
-            '@embroider/core': '*',
-            '@embroider/webpack': '*',
-            '@embroider/compat': '*',
-          },
-        },
+      embroiderSafe({
         env: {
           FASTBOOT_DISABLED: true,
         },
-      },
+      }),
+      embroiderOptimized({
+        env: {
+          FASTBOOT_DISABLED: true,
+        },
+      }),
       {
         name: 'optional-feature-use-default-value-if-undefined',
         npm: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 /* eslint-env node */
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const { maybeEmbroider } = require('@embroider/test-setup');
 
 module.exports = function (defaults) {
   let trees = {};
@@ -41,31 +42,21 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  if ('@embroider/webpack' in app.dependencies()) {
-    const { Webpack } = require('@embroider/webpack'); // eslint-disable-line node/no-missing-require
-    return require('@embroider/compat') // eslint-disable-line node/no-missing-require
-      .compatBuild(app, Webpack, {
-        staticAddonTestSupportTrees: true,
-        staticAddonTrees: true,
-        staticHelpers: true,
-        staticComponents: true,
-        packageRules: [
-          {
-            package: 'dummy',
-            components: {
-              '{{test-component}}': {
-                safeToIgnore: true,
-              },
-            },
-          },
-        ],
-        packagerOptions: {
-          webpackConfig: {
-            devtool: false,
+  return maybeEmbroider(app, {
+    packageRules: [
+      {
+        package: 'dummy',
+        components: {
+          '{{test-component}}': {
+            safeToIgnore: true,
           },
         },
-      });
-  } else {
-    return app.toTree();
-  }
+      },
+    ],
+    packagerOptions: {
+      webpackConfig: {
+        devtool: false,
+      },
+    },
+  });
 };

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@embroider/test-setup": "^0.27.0",
     "babel-eslint": "^10.1.0",
     "bootstrap": "^4.5.2",
     "bootstrap-sass": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,14 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
+"@embroider/test-setup@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.27.0.tgz#0212641723b470177b902aa8a9c20976bdb7f199"
+  integrity sha512-pkcvV3YENZ1BxcpHdE4UQqp6l8/JjJmteuqPmTKy94V8FsI6qVhaXI/ah5NQ7ddWnti+tWZBc/qJc1as9sykYg==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"


### PR DESCRIPTION
I have packaged up the best-practices (some of them piloted by this addon, thanks!) for testing addons under embroider in the new library `@embroider/test-setup`. This switches to using it.