### PR TITLE
Apply default values even if undefined is passed, allowing for easy wrapping of components

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -158,11 +158,11 @@ export default class Form extends Component {
    * Moreover the form's `submit` event handler will validate the model and deny submitting if the model is not validated successfully.
    *
    * @property model
-   * @type Ember.Object
+   * @type object
    * @public
    */
   @defaultValue
-  model = macroCondition(getOwnConfig().useDefaultValueIfUndefined) ? {} : undefined;
+  model = {};
 
   /**
    * Set the layout of the form to either "vertical", "horizontal" or "inline". See http://getbootstrap.com/css/#forms-inline and http://getbootstrap.com/css/#forms-horizontal

--- a/addon/utils/decorators/arg.js
+++ b/addon/utils/decorators/arg.js
@@ -1,16 +1,10 @@
-import { macroCondition, getOwnConfig } from '@embroider/macros';
-
 export default function arg(target, key, descriptor) {
   let defaultValue = descriptor.initializer ? descriptor.initializer() : undefined;
 
   return {
     get() {
-      if (macroCondition(getOwnConfig().useDefaultValueIfUndefined)) {
-        const argValue = this.args[key];
-        return argValue !== undefined ? argValue : defaultValue;
-      } else {
-        return Object.keys(this.args).includes(key) ? this.args[key] : defaultValue;
-      }
+      const argValue = this.args[key];
+      return argValue !== undefined ? argValue : defaultValue;
     },
   };
 }

--- a/addon/utils/default-decorator.js
+++ b/addon/utils/default-decorator.js
@@ -1,5 +1,4 @@
 import { computed } from '@ember/object';
-import { macroCondition, getOwnConfig } from '@embroider/macros';
 
 export default function defaultValue(target, key, descriptor) {
   let { initializer, value } = descriptor;
@@ -9,15 +8,11 @@ export default function defaultValue(target, key, descriptor) {
       return initializer ? initializer.call(this) : value;
     },
     set(_, v) {
-      if (macroCondition(getOwnConfig().useDefaultValueIfUndefined)) {
-        if (v !== undefined) {
-          return v;
-        }
-
-        return initializer ? initializer.call(this) : value;
-      } else {
+      if (v !== undefined) {
         return v;
       }
+
+      return initializer ? initializer.call(this) : value;
     },
   })(target, key, { ...descriptor, value: undefined, initializer: undefined });
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -130,17 +130,6 @@ module.exports = async function () {
           FASTBOOT_DISABLED: true,
         },
       }),
-      {
-        name: 'optional-feature-use-default-value-if-undefined',
-        npm: {
-          devDependencies: {
-            bootstrap: bootstrapVersion,
-          },
-        },
-        env: {
-          OPTIONAL_FEATURE_USE_DEFAULT_VALUE_IF_UNDEFINED: true,
-        },
-      },
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,10 +29,6 @@ module.exports = function (defaults) {
     },
   };
 
-  if (process.env.OPTIONAL_FEATURE_USE_DEFAULT_VALUE_IF_UNDEFINED) {
-    options['ember-bootstrap'].useDefaultValueIfUndefined = true;
-  }
-
   let app = new EmberAddon(defaults, options);
 
   /*

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const defaultOptions = {
   importBootstrapFont: false,
   insertEmberWormholeElementToDom: true,
   bootstrapVersion: 4,
-  useDefaultValueIfUndefined: false,
 };
 
 const supportedPreprocessors = ['less', 'sass'];
@@ -99,9 +98,6 @@ module.exports = {
     // setup config for @embroider/macros
     this.options['@embroider/macros'].setOwnConfig.isBS3 = this.getBootstrapVersion() === 3;
     this.options['@embroider/macros'].setOwnConfig.isBS4 = this.getBootstrapVersion() === 4;
-    this.options['@embroider/macros'].setOwnConfig.useDefaultValueIfUndefined = Boolean(
-      this.bootstrapOptions.useDefaultValueIfUndefined
-    );
   },
 
   options: {

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -1,6 +1,5 @@
 import config from 'dummy/config/environment';
-import { dependencySatisfies, getConfig, getOwnConfig, macroCondition } from '@embroider/macros';
-import { module, skip, test } from 'qunit';
+import { skip, test } from 'qunit';
 import { Promise } from 'rsvp';
 
 const currentBootstrapVersion = parseInt(config.bootstrapVersion);
@@ -27,37 +26,6 @@ export function versionDependent(v3, v4) {
   }
 
   return v4;
-}
-
-// eslint-disable-next-line ember/no-test-module-for
-export function moduleForOptionalFeature(optionalFeature, fn) {
-  let optionalFeatureEnabled;
-
-  // `getConfig('ember-bootstrap')` is the correct way to retrieve the
-  // configuration of the addon it it's dummy app. But the `getConfig`
-  // macro is broken for dummy app of an addon in classic builds.
-  // `getOwnConfig` macro also has a bug in classic builds. It resolves
-  // with the configuration of the addon not of it's dummy app. We can
-  // use that bug as a work-a-round for classic builds until the but of
-  // `getConfig` macro has been fixed.
-  // Both bugs are tracked in this issue:
-  // https://github.com/embroider-build/embroider/issues/537
-  if (macroCondition(dependencySatisfies('@embroider/webpack', '*'))) {
-    optionalFeatureEnabled = getConfig('ember-bootstrap')[optionalFeature];
-  } else {
-    optionalFeatureEnabled = getOwnConfig()[optionalFeature];
-  }
-
-  if (optionalFeatureEnabled === undefined) {
-    throw new Error(`Optional feature ${optionalFeature} does not exist.`);
-  }
-
-  let name = `Optional feature: ${optionalFeature}`;
-  if (optionalFeatureEnabled) {
-    module(name, fn);
-  } else {
-    skip(name, fn);
-  }
 }
 
 export function visibilityClass() {


### PR DESCRIPTION
As discussed in https://github.com/kaliber5/ember-bootstrap/pull/1282#discussion_r502948017, we remove the optional feature introduced in #1248 again, and make its behavior the default one.