### PR TITLE
add handle to prev/next slide

### DIFF
--- a/addon/components/bs-carousel.hbs
+++ b/addon/components/bs-carousel.hbs
@@ -25,6 +25,8 @@
           orderClassName=this.orderClassName
           presentationState=this.presentationState
         )
+        toNextSlide=this.toNextSlide
+        toPrevSlide=this.toPrevSlide
       )
     }}
   </div>


### PR DESCRIPTION
This exposes the `toNextSlide` and `toPrevSlide` functions so that they can be called. I am doing this so that I can mixing ember-gestures (hammer.js) to add support for left/right swipe events. This can enable the requested functionality in
https://github.com/kaliber5/ember-bootstrap/issues/613.