### PR TITLE
<BsAccordion> should support @onChange={{undefined}}

### DIFF
--- a/addon/components/bs-accordion.js
+++ b/addon/components/bs-accordion.js
@@ -81,7 +81,6 @@ export default class Accordion extends Component {
    * @param oldValue
    * @public
    */
-  onChange(newValue, oldValue) {} // eslint-disable-line no-unused-vars
 
   @action
   doChange(newValue) {
@@ -89,7 +88,7 @@ export default class Accordion extends Component {
     if (oldValue === newValue) {
       newValue = null;
     }
-    if (this.onChange(newValue, oldValue) !== false) {
+    if (this.onChange?.(newValue, oldValue) !== false) {
       this.set('isSelected', newValue);
     }
   }

--- a/tests/integration/components/bs-accordion-test.js
+++ b/tests/integration/components/bs-accordion-test.js
@@ -164,6 +164,19 @@ module('Integration | Component | bs-accordion', function (hooks) {
     assert.dom(`.${accordionClassFor()}:first-child .collapse`).hasNoClass(visibilityClass(), 'tabpanel is hidden');
   });
 
+  test('supports undefined as value of onChange argument', async function (assert) {
+    await render(hbs`
+      <BsAccordion @onChange={{undefined}} as |acc|>
+        <acc.item @value={{1}} @title="TITLE1" data-test-item="1">CONTENT1</acc.item>
+        <acc.item @value={{2}} @title="TITLE2">CONTENT2</acc.item>
+      </BsAccordion>
+    `);
+    assert.dom(`[data-test-item="1"] .collapse`).hasNoClass(visibilityClass());
+
+    await click(`[data-test-item="1"] .${accordionItemHeadClass()}`);
+    assert.dom(`[data-test-item="1"] .collapse`).hasClass(visibilityClass());
+  });
+
   test('changing selection does not leak to public selected property (DDAU)', async function (assert) {
     this.set('selected', 1);
     await render(hbs`


### PR DESCRIPTION
Similar as already done for `@onBefore`, `@onSubmit` and `@onInvalid` of `<BsForm>` in #1250. #1248 has added support for most of the properties.