### PR TITLE
Refactor <BsForm::Group> and <BsForm::Element> to glimmer component and tracked properties

### DIFF
--- a/addon/components/bs-form/element.hbs
+++ b/addon/components/bs-form/element.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="form-group {{if @disabled "disabled"}} {{if @required "is-required"}} {{if this.isValidating "is-validating"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
+  class="form-group {{if @disabled "disabled"}} {{if @required "is-required"}} {{if this.isValidating "is-validating"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class "form-group" @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
   ...attributes
   {{create-ref "mainNode"}}
   {{on "focusout" this.showValidationOnHandler}}

--- a/addon/components/bs-form/element.hbs
+++ b/addon/components/bs-form/element.hbs
@@ -1,13 +1,14 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="form-group {{if this.disabled "disabled"}} {{if this.required "is-required"}} {{if this.isValidating "is-validating"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.sizeClass}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if this.isHorizontal "row")}}"
+  class="form-group {{if @disabled "disabled"}} {{if @required "is-required"}} {{if this.isValidating "is-validating"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
   ...attributes
   {{create-ref "mainNode"}}
   {{on "focusout" this.showValidationOnHandler}}
   {{on "change" this.showValidationOnHandler}}
   {{on "input" this.showValidationOnHandler}}
   {{did-insert this.adjustFeedbackIcons}}
-  {{did-update this.adjustFeedbackIcons this.hasFeedback this.formLayout}}
+  {{did-update this.adjustFeedbackIcons this.hasFeedback @formLayout}}
+  {{did-update this.showAllValidations this.handleShowAllValidationsChange}}
 >
   {{#component
     (bs-default
@@ -36,7 +37,7 @@
     )
     hasLabel=this.hasLabel
     formElementId=this.formElementId
-    horizontalLabelGridClass=this.horizontalLabelGridClass
+    horizontalLabelGridClass=@horizontalLabelGridClass
     errorsComponent=(component (bs-default @errorsComponent (component "bs-form/element/errors"))
       messages=this.validationMessages
       show=this.showValidationMessages
@@ -60,19 +61,24 @@
         )
       )
       label=@label
-      invisibleLabel=this.invisibleLabel
+      invisibleLabel=@invisibleLabel
       formElementId=this.formElementId
       controlType=this.controlType
-      formLayout=this.formLayout
+      formLayout=@formLayout
       size=@size
     )
-    helpTextComponent=(if this.hasHelpText
+    helpTextComponent=(if @helpText
       (component (bs-default @helpTextComponent (component "bs-form/element/help-text"))
         text=@helpText
         id=this.ariaDescribedBy
       )
     )
   }}
+    {{!
+      Ember does not allow to access a variable with `@` in template if its name start with an underscore.
+      `@_disabled` and `@_readonly` are affected by this. As a work-a-round we access them on `this.args`.
+    }}
+    {{!-- template-lint-disable no-args-paths --}}
     {{#let
       (component
         (bs-default
@@ -98,16 +104,17 @@
         id=this.formElementId
         type=this.controlType
         label=@label
-        disabled=this._disabled
-        readonly=this._readonly
+        disabled=this.args._disabled
+        readonly=this.args._readonly
         required=@required
         options=this.options
         optionLabelPath=this.optionLabelPath
-        ariaDescribedBy=(if this.hasHelpText this.ariaDescribedBy)
+        ariaDescribedBy=(if @helpText this.ariaDescribedBy)
         onChange=(action this.doChange)
         validationType=this.validation
-        size=this.size
+        size=@size
     ) as |Control|}}
+    {{!-- template-lint-enable no-args-paths --}}
       {{#if hasBlock}}
         {{yield
           (hash

--- a/addon/components/bs-form/element.hbs
+++ b/addon/components/bs-form/element.hbs
@@ -35,7 +35,7 @@
         )
       )
     )
-    hasLabel=this.hasLabel
+    hasLabel=(if @label true false)
     formElementId=this.formElementId
     horizontalLabelGridClass=@horizontalLabelGridClass
     errorsComponent=(component (bs-default @errorsComponent (component "bs-form/element/errors"))

--- a/addon/components/bs-form/element.hbs
+++ b/addon/components/bs-form/element.hbs
@@ -107,8 +107,8 @@
         disabled=this.args._disabled
         readonly=this.args._readonly
         required=@required
-        options=this.options
-        optionLabelPath=this.optionLabelPath
+        options=@options
+        optionLabelPath=@optionLabelPath
         ariaDescribedBy=(if @helpText this.ariaDescribedBy)
         onChange=(action this.doChange)
         validationType=this.validation

--- a/addon/components/bs-form/element.hbs
+++ b/addon/components/bs-form/element.hbs
@@ -8,7 +8,7 @@
   {{on "input" this.showValidationOnHandler}}
   {{did-insert this.adjustFeedbackIcons}}
   {{did-update this.adjustFeedbackIcons this.hasFeedback @formLayout}}
-  {{did-update this.showAllValidations this.handleShowAllValidationsChange}}
+  {{did-update this.handleShowAllValidationsChange this.showAllValidations}}
 >
   {{#component
     (bs-default

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -295,8 +295,6 @@ export default class FormElement extends FormGroup {
    * @property model
    * @public
    */
-  @arg
-  model = null;
 
   /**
    * Show a help text next to the control
@@ -327,18 +325,14 @@ export default class FormElement extends FormGroup {
    * @type {Array}
    * @public
    */
-  @arg
-  options = null;
 
   /**
-   * Property path (e.g. 'title' or 'related.name') to render the label of an selection option. See `options`.s
+   * Property path (e.g. 'title' or 'related.name') to render the label of an selection option. See `options`.
    *
    * @property optionLabelPath
    * @type {String}
    * @public
    */
-  @arg
-  optionLabelPath = null;
 
   /**
    * The array of error messages from the `model`'s validation.

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -213,8 +213,6 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @arg
-  label = null;
 
   /**
    * Controls label visibility by adding 'sr-only' class.
@@ -224,16 +222,6 @@ export default class FormElement extends FormGroup {
    * @default false
    * @public
    */
-
-  /**
-   * @property hasLabel
-   * @type boolean
-   * @readonly
-   * @private
-   */
-  get hasLabel() {
-    return isPresent(this.label);
-  }
 
   /**
    * The type of the control widget.

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -422,8 +422,6 @@ export default class FormElement extends FormGroup {
    * @type String
    * @public
    */
-  @arg
-  size = null;
 
   /**
    * The array of validation messages (either errors or warnings) from either custom error/warnings or , if we are showing model validation messages, the model's validation

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -341,6 +341,9 @@ export default class FormElement extends FormGroup {
    * @type array
    * @protected
    */
+  // This shouldn't be an argument. It's only an argument because tests rely on
+  // setting it as an argument. See https://github.com/kaliber5/ember-bootstrap/issues/1338
+  // for details.
   @arg errors;
 
   /**
@@ -360,6 +363,9 @@ export default class FormElement extends FormGroup {
    * @type array
    * @protected
    */
+  // This shouldn't be an argument. It's only an argument because tests rely on
+  // setting it as an argument. See https://github.com/kaliber5/ember-bootstrap/issues/1338
+  // for details.
   @arg warnings;
 
   /**
@@ -380,8 +386,6 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @arg
-  customError = null;
 
   /**
    * @property hasCustomError
@@ -390,7 +394,7 @@ export default class FormElement extends FormGroup {
    * @private
    */
   get hasCustomError() {
-    return isPresent(this.customError);
+    return isPresent(this.args.customError);
   }
 
   /**
@@ -402,8 +406,6 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @arg
-  customWarning = null;
 
   /**
    * @property hasCustomWarning
@@ -412,7 +414,7 @@ export default class FormElement extends FormGroup {
    * @private
    */
   get hasCustomWarning() {
-    return isPresent(this.customWarning);
+    return isPresent(this.args.customWarning);
   }
 
   /**
@@ -432,13 +434,13 @@ export default class FormElement extends FormGroup {
    */
   get validationMessages() {
     if (this.hasCustomError) {
-      return A([this.customError]);
+      return A([this.args.customError]);
     }
     if (this.hasErrors && this.showModelValidation) {
       return A(this.errors);
     }
     if (this.hasCustomWarning) {
-      return A([this.customWarning]);
+      return A([this.args.customWarning]);
     }
     if (this.hasWarnings && this.showModelValidation) {
       return A(this.warnings);
@@ -462,6 +464,9 @@ export default class FormElement extends FormGroup {
    * @default false
    * @protected
    */
+  // This shouldn't be an argument. It's only an argument because tests rely on
+  // setting it as an argument. See https://github.com/kaliber5/ember-bootstrap/issues/1338
+  // for details.
   @arg
   hasValidator = false;
 

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -1,15 +1,15 @@
-import { and, gt, notEmpty, or } from '@ember/object/computed';
-import { action, computed, get } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { action, get } from '@ember/object';
 import { assert, warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
-import { isBlank, typeOf } from '@ember/utils';
+import { isBlank, isPresent, typeOf } from '@ember/utils';
 import { A, isArray } from '@ember/array';
 import { getOwner } from '@ember/application';
 import FormGroup from 'ember-bootstrap/components/bs-form/group';
-import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { getOwnConfig, macroCondition } from '@embroider/macros';
 import { guidFor } from '@ember/object/internals';
 import { ref } from 'ember-ref-bucket';
+import arg from 'ember-bootstrap/utils/decorators/arg';
 
 /**
   Sub class of `Components.FormGroup` that adds automatic form layout markup and form validation features.
@@ -202,11 +202,6 @@ export default class FormElement extends FormGroup {
    */
   @ref('mainNode') _element = null;
 
-  @defaultValue
-  doNotShowValidationForEventTargets = macroCondition(getOwnConfig().isBS3)
-    ? ['.input-group-addon', '.input-group-btn']
-    : ['.input-group-append', '.input-group-prepend'];
-
   /**
    * Text to display within a `<label>` tag.
    *
@@ -218,7 +213,7 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   label = null;
 
   /**
@@ -229,8 +224,6 @@ export default class FormElement extends FormGroup {
    * @default false
    * @public
    */
-  @defaultValue
-  invisibleLabel = false;
 
   /**
    * @property hasLabel
@@ -238,8 +231,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @notEmpty('label')
-  hasLabel;
+  get hasLabel() {
+    return isPresent(this.label);
+  }
 
   /**
    * The type of the control widget.
@@ -257,7 +251,7 @@ export default class FormElement extends FormGroup {
    * @default 'text'
    * @public
    */
-  @defaultValue
+  @arg
   controlType = 'text';
 
   /**
@@ -276,14 +270,14 @@ export default class FormElement extends FormGroup {
    * @public
    */
   get value() {
-    if (this.property && this.model) {
-      return get(this.model, this.property);
+    if (this.args.property && this.args.model) {
+      return get(this.args.model, this.args.property);
     }
     return this._value;
   }
 
   set value(value) {
-    assert('You cannot set both property and value on a form element', isBlank(this.property));
+    assert('You cannot set both property and value on a form element', isBlank(this.args.property));
 
     this._value = value;
   }
@@ -293,8 +287,7 @@ export default class FormElement extends FormGroup {
    * @type {null}
    * @private
    */
-  @defaultValue
-  _value = null;
+  @tracked _value = null;
 
   /**
    The property name of the form element's `model` (by default the `model` of its parent `Components.Form`) that this
@@ -307,8 +300,6 @@ export default class FormElement extends FormGroup {
    @type string
    @public
    */
-  @defaultValue
-  property = null;
 
   /**
    * The model used for validation. Defaults to the parent `Components.Form`'s `model`
@@ -316,7 +307,7 @@ export default class FormElement extends FormGroup {
    * @property model
    * @public
    */
-  @defaultValue
+  @arg
   model = null;
 
   /**
@@ -326,8 +317,6 @@ export default class FormElement extends FormGroup {
    * @type {string}
    * @public
    */
-  @defaultValue
-  helpText = null;
 
   /**
    * Only if there is a validator, this property makes all errors to be displayed at once
@@ -338,7 +327,7 @@ export default class FormElement extends FormGroup {
    * @public
    * @type {Boolean}
    */
-  @defaultValue
+  @arg
   showMultipleErrors = false;
 
   /**
@@ -350,7 +339,7 @@ export default class FormElement extends FormGroup {
    * @type {Array}
    * @public
    */
-  @defaultValue
+  @arg
   options = null;
 
   /**
@@ -360,17 +349,8 @@ export default class FormElement extends FormGroup {
    * @type {String}
    * @public
    */
-  @defaultValue
+  @arg
   optionLabelPath = null;
-
-  /**
-   * @property hasHelpText
-   * @type boolean
-   * @readonly
-   * @private
-   */
-  @(notEmpty('helpText').readOnly())
-  hasHelpText;
 
   /**
    * The array of error messages from the `model`'s validation.
@@ -379,8 +359,7 @@ export default class FormElement extends FormGroup {
    * @type array
    * @protected
    */
-  @defaultValue
-  errors = null;
+  @arg errors;
 
   /**
    * @property hasErrors
@@ -388,8 +367,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @gt('errors.length', 0)
-  hasErrors;
+  get hasErrors() {
+    return Array.isArray(this.errors) && this.errors.length > 0;
+  }
 
   /**
    * The array of warning messages from the `model`'s validation.
@@ -398,8 +378,7 @@ export default class FormElement extends FormGroup {
    * @type array
    * @protected
    */
-  @defaultValue
-  warnings = null;
+  @arg warnings;
 
   /**
    * @property hasWarnings
@@ -407,8 +386,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @gt('warnings.length', 0)
-  hasWarnings;
+  get hasWarnings() {
+    return Array.isArray(this.warnings) && this.warnings.length > 0;
+  }
 
   /**
    * Show a custom error message that does not come from the model's validation. Will be immediately shown, regardless
@@ -418,7 +398,7 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   customError = null;
 
   /**
@@ -427,8 +407,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @notEmpty('customError')
-  hasCustomError;
+  get hasCustomError() {
+    return isPresent(this.customError);
+  }
 
   /**
    * Show a custom warning message that does not come from the model's validation. Will be immediately shown, regardless
@@ -439,7 +420,7 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   customWarning = null;
 
   /**
@@ -448,8 +429,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @notEmpty('customWarning')
-  hasCustomWarning;
+  get hasCustomWarning() {
+    return isPresent(this.customWarning);
+  }
 
   /**
    * Property for size styling, set to 'lg', 'sm' or 'xs' (the latter only for BS3)
@@ -458,7 +440,7 @@ export default class FormElement extends FormGroup {
    * @type String
    * @public
    */
-  @defaultValue
+  @arg
   size = null;
 
   /**
@@ -468,17 +450,6 @@ export default class FormElement extends FormGroup {
    * @type array
    * @private
    */
-  @computed(
-    'hasCustomError',
-    'customError',
-    'hasErrors',
-    'hasCustomWarning',
-    'customWarning',
-    'hasWarnings',
-    'errors.[]',
-    'warnings.[]',
-    'showModelValidation'
-  )
   get validationMessages() {
     if (this.hasCustomError) {
       return A([this.customError]);
@@ -501,8 +472,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @gt('validationMessages.length', 0)
-  hasValidationMessages;
+  get hasValidationMessages() {
+    return Array.isArray(this.validationMessages) && this.validationMessages.length > 0;
+  }
 
   /**
    * @property hasValidator
@@ -510,7 +482,7 @@ export default class FormElement extends FormGroup {
    * @default false
    * @protected
    */
-  @defaultValue
+  @arg
   hasValidator = false;
 
   /**
@@ -521,8 +493,7 @@ export default class FormElement extends FormGroup {
    * @default false
    * @protected
    */
-  @defaultValue
-  isValidating = false;
+  @tracked isValidating = false;
 
   /**
    * If `true` form validation markup is rendered (requires a validatable `model`).
@@ -532,8 +503,9 @@ export default class FormElement extends FormGroup {
    * @default false
    * @private
    */
-  @or('showOwnValidation', 'showAllValidations', 'hasCustomError', 'hasCustomWarning')
-  showValidation;
+  get showValidation() {
+    return this.showOwnValidation || this.showAllValidations || this.hasCustomError || this.hasCustomWarning;
+  }
 
   /**
    * @property showOwnValidation
@@ -541,8 +513,7 @@ export default class FormElement extends FormGroup {
    * @default false
    * @private
    */
-  @defaultValue
-  showOwnValidation = false;
+  @tracked showOwnValidation = false;
 
   /**
    * @property showAllValidations
@@ -550,16 +521,18 @@ export default class FormElement extends FormGroup {
    * @default false
    * @private
    */
-  @computed
-  get showAllValidations() {
-    return false;
-  }
+  @arg
+  showAllValidations = false;
 
-  set showAllValidations(value) {
-    if (value === false) {
-      this.set('showOwnValidation', false);
+  /*
+   * Resets `showOwnValidation` if `@showAllValidatoins` argument is changed to `false`.
+   * Must be called whenever `@showAllValidations` argument changes.
+   */
+  @action
+  handleShowAllValidationsChange() {
+    if (this.args.showAllValidations === false) {
+      this.showOwnValidation = false;
     }
-    return value;
   }
 
   /**
@@ -568,8 +541,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @or('showOwnValidation', 'showAllValidations')
-  showModelValidation;
+  get showModelValidation() {
+    return this.showOwnValidation || this.showAllValidations;
+  }
 
   /**
    * @property showValidationMessages
@@ -577,8 +551,9 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @and('showValidation', 'hasValidationMessages')
-  showValidationMessages;
+  get showValidationMessages() {
+    return this.showValidation && this.hasValidationMessages;
+  }
 
   /**
    * Event or list of events which enable form validation markup rendering.
@@ -589,8 +564,8 @@ export default class FormElement extends FormGroup {
    * @default ['focusout']
    * @public
    */
-  @defaultValue
-  showValidationOn = null;
+  @arg
+  showValidationOn = ['focusOut'];
 
   /**
    * @property _showValidationOn
@@ -598,7 +573,6 @@ export default class FormElement extends FormGroup {
    * @readonly
    * @private
    */
-  @computed('showValidationOn.[]')
   get _showValidationOn() {
     let showValidationOn = this.showValidationOn;
 
@@ -642,7 +616,7 @@ export default class FormElement extends FormGroup {
       return;
     }
 
-    this.set('showOwnValidation', true);
+    this.showOwnValidation = true;
   }
 
   /**
@@ -660,6 +634,10 @@ export default class FormElement extends FormGroup {
    * @type ?array
    * @public
    */
+  @arg
+  doNotShowValidationForEventTargets = macroCondition(getOwnConfig().isBS3)
+    ? ['.input-group-addon', '.input-group-btn']
+    : ['.input-group-append', '.input-group-prepend'];
 
   /**
    * The validation ("error" (BS3)/"danger" (BS4), "warning", or "success") or null if no validation is to be shown. Automatically computed from the
@@ -670,19 +648,8 @@ export default class FormElement extends FormGroup {
    * @type string
    * @private
    */
-  @computed(
-    'hasCustomError',
-    'hasErrors',
-    'hasCustomWarning',
-    'hasWarnings',
-    'hasValidator',
-    'showValidation',
-    'showModelValidation',
-    'isValidating',
-    '_disabled'
-  )
   get validation() {
-    if (!this.showValidation || !this.hasValidator || this.isValidating || this._disabled) {
+    if (!this.showValidation || !this.hasValidator || this.isValidating || this.args._disabled) {
       return null;
     } else if (this.showModelValidation) {
       /* The display of model validation messages has been triggered */
@@ -704,7 +671,6 @@ export default class FormElement extends FormGroup {
    * @type boolean
    * @public
    */
-  @computed('customControlComponent', 'controlType')
   get useIcons() {
     let { controlType } = this;
     return (
@@ -738,8 +704,6 @@ export default class FormElement extends FormGroup {
    * @type string
    * @public
    */
-  @defaultValue
-  horizontalLabelGridClass = null;
 
   _elementId = guidFor(this);
 
@@ -776,7 +740,6 @@ export default class FormElement extends FormGroup {
    * @type {String}
    * @private
    */
-  @computed('controlType')
   get customControlComponent() {
     const controlType = this.controlType;
     const componentName = `bs-form/element/control/${controlType}`;
@@ -819,7 +782,6 @@ export default class FormElement extends FormGroup {
    * @method setupValidations
    * @private
    */
-  setupValidations() {}
 
   /**
    * The action is called whenever the input value is changed, e.g. by typing text
@@ -830,7 +792,6 @@ export default class FormElement extends FormGroup {
    * @param {String} property The value of `property`
    * @public
    */
-  onChange() {}
 
   /**
    * Private duplicate of onChange event used for internal state handling between form and it's elements.
@@ -838,15 +799,12 @@ export default class FormElement extends FormGroup {
    * @event _onChange
    * @private
    */
-  _onChange() {}
 
-  init() {
-    super.init(...arguments);
-    if (this.showValidationOn === null) {
-      this.set('showValidationOn', ['focusOut']);
-    }
-    if (!isBlank(this.property)) {
-      this.setupValidations();
+  constructor() {
+    super(...arguments);
+
+    if (!isBlank(this.args.property)) {
+      this.setupValidations?.();
     }
 
     // deprecate arguments used for attribute bindings only
@@ -905,14 +863,9 @@ export default class FormElement extends FormGroup {
           `  </BsForm>\n` +
           `A codemod is available to help with the required migration. See https://github.com/kaliber5/ember-bootstrap-codemods/blob/master/transforms/deprecated-attribute-arguments/README.md`;
 
-        warn(
-          warningMessage,
-          // eslint-disable-next-line ember/no-attrs-in-components
-          !Object.keys(this.attrs).includes(argument),
-          {
-            id: `ember-bootstrap.removed-argument.form-element#${argument}`,
-          }
-        );
+        warn(warningMessage, !Object.keys(this.args).includes(argument), {
+          id: `ember-bootstrap.removed-argument.form-element#${argument}`,
+        });
       });
     }
   }
@@ -962,8 +915,8 @@ export default class FormElement extends FormGroup {
 
   @action
   doChange(value) {
-    let { onChange, model, property, _onChange } = this;
-    onChange(value, model, property);
-    _onChange();
+    let { onChange, model, property, _onChange } = this.args;
+    onChange?.(value, model, property);
+    _onChange?.();
   }
 }

--- a/addon/components/bs-form/group.hbs
+++ b/addon/components/bs-form/group.hbs
@@ -1,5 +1,5 @@
 <div
-  class="form-group {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
+  class="form-group {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class "form-group" @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
   ...attributes
 >
   {{yield}}

--- a/addon/components/bs-form/group.hbs
+++ b/addon/components/bs-form/group.hbs
@@ -1,5 +1,5 @@
 <div
-  class="form-group {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.sizeClass}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if this.isHorizontal "row")}}"
+  class="form-group {{if (macroCondition (macroGetOwnConfig "isBS3")) this.validationClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.hasFeedback "has-feedback")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (bs-size-class @size)}} {{if (macroCondition (macroGetOwnConfig "isBS4")) (if (bs-eq @formLayout "horizontal") "row")}}"
   ...attributes
 >
   {{yield}}

--- a/addon/components/bs-form/group.js
+++ b/addon/components/bs-form/group.js
@@ -1,11 +1,8 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { and, equal, notEmpty } from '@ember/object/computed';
+import Component from '@glimmer/component';
 import Config from 'ember-bootstrap/config';
-import { isBlank } from '@ember/utils';
-import sizeClass from 'ember-bootstrap/utils/cp/size-class';
-import defaultValue from 'ember-bootstrap/utils/default-decorator';
+import { isBlank, isPresent } from '@ember/utils';
+import arg from 'ember-bootstrap/utils/decorators/arg';
+import { localCopy } from 'tracked-toolbox';
 
 /**
   This component renders a `<div class="form-group">` element, with support for validation states and feedback icons (only for BS3).
@@ -29,7 +26,6 @@ import defaultValue from 'ember-bootstrap/utils/default-decorator';
   @extends Ember.Component
   @public
 */
-@tagName('')
 export default class FormGroup extends Component {
   /**
    * @property classTypePrefix
@@ -46,8 +42,9 @@ export default class FormGroup extends Component {
    * @private
    * @readonly
    */
-  @(notEmpty('validation').readOnly())
-  hasValidation;
+  get hasValidation() {
+    return isPresent(this.validation);
+  }
 
   /**
    * [BS3 only] Set to a validation state to render the form-group with a validation style.
@@ -61,6 +58,7 @@ export default class FormGroup extends Component {
    * @type string
    * @public
    */
+  @localCopy('args.validation') validation;
 
   /**
    * [BS3 only] Whether to show validation state icons.
@@ -71,7 +69,7 @@ export default class FormGroup extends Component {
    * @default true
    * @public
    */
-  @defaultValue
+  @arg
   useIcons = true;
 
   /**
@@ -82,8 +80,9 @@ export default class FormGroup extends Component {
    * @private
    * @readonly
    */
-  @(and('hasValidation', 'useIcons', 'hasIconForValidationState').readOnly())
-  hasFeedback;
+  get hasFeedback() {
+    return this.hasValidation && this.useIcons && this.hasIconForValidationState;
+  }
 
   /**
    * [BS3 only] The icon classes to be used for a feedback icon in a "success" validation state.
@@ -105,7 +104,7 @@ export default class FormGroup extends Component {
    * @default 'glyphicon glyphicon-ok'
    * @public
    */
-  @defaultValue
+  @arg
   successIcon = Config.formValidationSuccessIcon;
 
   /**
@@ -127,7 +126,7 @@ export default class FormGroup extends Component {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   errorIcon = Config.formValidationErrorIcon;
 
   /**
@@ -149,7 +148,7 @@ export default class FormGroup extends Component {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   warningIcon = Config.formValidationWarningIcon;
 
   /**
@@ -179,23 +178,8 @@ export default class FormGroup extends Component {
    * @type string
    * @public
    */
-  @defaultValue
+  @arg
   infoIcon = Config.formValidationInfoIcon;
-
-  /**
-   * [BS3 only] Property for size styling, set to 'lg', 'sm' or 'xs'
-   *
-   * Also see the [Bootstrap docs](https://getbootstrap.com/docs/3.4/css/#forms-control-sizes)
-   *
-   * @property size
-   * @type String
-   * @public
-   */
-  @defaultValue
-  size = null;
-
-  @sizeClass('form-group', 'size')
-  sizeClass;
 
   /**
    * [BS3 only]
@@ -205,10 +189,9 @@ export default class FormGroup extends Component {
    * @readonly
    * @private
    */
-  @(computed('validation').readOnly())
   get iconName() {
     let validation = this.validation || 'success';
-    return this.get(`${validation}Icon`);
+    return this[`${validation}Icon`];
   }
 
   /**
@@ -219,8 +202,9 @@ export default class FormGroup extends Component {
    * @readonly
    * @private
    */
-  @(notEmpty('iconName').readOnly())
-  hasIconForValidationState;
+  get hasIconForValidationState() {
+    return isPresent(this.iconName);
+  }
 
   /**
    * [BS3 only]
@@ -230,19 +214,8 @@ export default class FormGroup extends Component {
    * @readonly
    * @private
    */
-  @(computed('validation').readOnly())
   get validationClass() {
     let validation = this.validation;
     return !isBlank(validation) ? `has-${validation}` : undefined;
   }
-
-  /**
-   * Indicates whether the form type equals `horizontal`
-   *
-   * @property isHorizontal
-   * @type boolean
-   * @private
-   */
-  @(equal('formLayout', 'horizontal').readOnly())
-  isHorizontal;
 }

--- a/addon/components/bs-form/group.js
+++ b/addon/components/bs-form/group.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import Config from 'ember-bootstrap/config';
 import { isBlank, isPresent } from '@ember/utils';
 import arg from 'ember-bootstrap/utils/decorators/arg';
-import { localCopy } from 'tracked-toolbox';
 
 /**
   This component renders a `<div class="form-group">` element, with support for validation states and feedback icons (only for BS3).
@@ -58,7 +57,7 @@ export default class FormGroup extends Component {
    * @type string
    * @public
    */
-  @localCopy('args.validation') validation;
+  @arg validation;
 
   /**
    * [BS3 only] Whether to show validation state icons.


### PR DESCRIPTION
This continues the journey of Octane refactoring. `<BsForm::Group>` and `<BsForm::Element>` are refactored to `@glimmer/component` and tracked properties.

I picked this two components because I hope that it also resolves two issues:

1. The current integration of Ember Changeset as validation provider is broken for recent Ember versions. The root problem is the integration of tracked properties used by Ember Changeset and computed properties used by `<BsForm::Element>`. Already before we have struggled a lot with integrating both worlds in `ember-bootstrap-changeset-validations`. But so far we haven't found any solution for an assertion added in Ember 3.21.2 and backported to 3.20.6. See https://github.com/kaliber5/ember-bootstrap-changeset-validations/issues/33 for details. Using tracked properties on both sides will remove the root of the problem.
2. We started using a custom `@elementComponent` with `<BsForm>`. Our custom element component is build on top of `<BsForm::Element>` by invoking it in the template. Doing so we uncovered some bugs related to default property handling. E.g. `@showValidationOn` argument was not using it's default value if the argument's value is `undefined`. Refactoring to `@glimmer/component` seemed to be the most valuable way to fix these bugs. As it's very unlikely to introduce these kind of bugs with `@glimmer/component` I avoided adding a test for it.

I noticed that some internal properties used for validation were overwritten by passing arguments in our test suite. `hasValidator`, `validate` and `errors` only need to be arguments cause they are used as such in existing tests. I didn't wanted to touch tests while doing the glimmer component refactoring. So I kept it as is but created an issue to not loose track of that one: https://github.com/kaliber5/ember-bootstrap/issues/1338