### PR TITLE
<BsDropdown> should use defaultValue if @htmlTag is undefined

### DIFF
--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -182,6 +182,7 @@ export default class Dropdown extends Component {
    * @type {string}
    * @public
    */
+  @defaultValue
   htmlTag = 'div';
 
   /**


### PR DESCRIPTION
Due to missing `@defaultValue` decorator `<BsDropdown>` was not using default value if `@htmlTag={{undefined}}`.

I don't think this requires test coverage. It is very unlikely to have a regression as soon as the component is refactored to `@glimmer/component`.