### PR TITLE
Skip Embroider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
           - scenario: ember-default
             command: ember test --launch Firefox
           - scenario: node-tests
-          - scenario: embroider-safe
-            allow-failure: true
-          - scenario: embroider-optimized
-            allow-failure: true
+#          - scenario: embroider-safe
+#            allow-failure: true
+#          - scenario: embroider-optimized
+#            allow-failure: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Skip failing tests until #1341 lands, as recently added `continue-on-error` config does not prevent the whole workflow from failing, causing a long queue of dependabot PRs.