### PR TITLE
Fix cleanup of event listeners for Tooltips/Popovers

### DIFF
--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -711,9 +711,8 @@ export default class ContextualHelp extends Component {
     }
   }
 
-  // eslint-disable-next-line ember/no-component-lifecycle-hooks
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
+  willDestroy() {
+    super.willDestroy(...arguments);
     this.removeListeners();
   }
 }


### PR DESCRIPTION
Still used `willDestroyElement` hook that does not exist anymore for Glimmer components.