### PR TITLE
Fix modals not being able to open after being closed once

### DIFF
--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -128,11 +128,6 @@ export default class Modal extends Component {
    * @default true
    * @public
    */
-
-  /**
-   * @property open
-   * @private
-   */
   @arg
   open = true;
 

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -473,7 +473,7 @@ export default class Modal extends Component {
     if (!this._isOpen) {
       return;
     }
-    this.isOpen = false;
+    this._isOpen = false;
 
     this.resize();
     this.showModal = false;

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -11,7 +11,6 @@ import isFastBoot from 'ember-bootstrap/utils/is-fastboot';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 import arg from '../utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
-import { localCopy } from 'tracked-toolbox';
 
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with custom markup.
@@ -61,25 +60,6 @@ export default class Modal extends Component {
   document;
 
   /**
-   * Visibility of the modal. Toggle to show/hide with CSS transitions.
-   *
-   * When the modal is closed by user interaction this property will not update by using two-way bindings in order
-   * to follow DDAU best practices. If you want to react to such changes, subscribe to the `onHide` action
-   *
-   * @property open
-   * @type boolean
-   * @default true
-   * @public
-   */
-
-  /**
-   * @property isOpen
-   * @private
-   */
-  @localCopy('args.open', true)
-  isOpen;
-
-  /**
    * @property _isOpen
    * @private
    */
@@ -108,7 +88,7 @@ export default class Modal extends Component {
    * @private
    */
   @tracked
-  showModal = this.isOpen && (!this._fade || isFastBoot(this));
+  showModal = this.open && (!this._fade || isFastBoot(this));
 
   /**
    * Render modal markup?
@@ -119,7 +99,7 @@ export default class Modal extends Component {
    * @private
    */
   @tracked
-  inDom = this.isOpen;
+  inDom = this.open;
 
   /**
    * @property paddingLeft
@@ -138,6 +118,25 @@ export default class Modal extends Component {
   paddingRight;
 
   /**
+   * Visibility of the modal. Toggle to show/hide with CSS transitions.
+   *
+   * When the modal is closed by user interaction this property will not update by using two-way bindings in order
+   * to follow DDAU best practices. If you want to react to such changes, subscribe to the `onHide` action
+   *
+   * @property open
+   * @type boolean
+   * @default true
+   * @public
+   */
+
+  /**
+   * @property open
+   * @private
+   */
+  @arg
+  open = true;
+
+  /**
    * Use a semi-transparent modal background to hide the rest of the page.
    *
    * @property backdrop
@@ -154,7 +153,7 @@ export default class Modal extends Component {
    * @private
    */
   @tracked
-  showBackdrop = this.isOpen && this.backdrop;
+  showBackdrop = this.open && this.backdrop;
 
   /**
    * Closes the modal when escape key is pressed.
@@ -515,7 +514,7 @@ export default class Modal extends Component {
   handleBackdrop(callback) {
     let doAnimate = this.usesTransition;
 
-    if (this.isOpen && this.backdrop) {
+    if (this.open && this.backdrop) {
       this.showBackdrop = true;
 
       if (!callback) {
@@ -531,7 +530,7 @@ export default class Modal extends Component {
           callback();
         }
       });
-    } else if (!this.isOpen && this.backdrop) {
+    } else if (!this.open && this.backdrop) {
       let backdrop = this.backdropElement;
       assert('Backdrop element should be in DOM', backdrop);
 
@@ -561,7 +560,7 @@ export default class Modal extends Component {
    * @private
    */
   resize() {
-    if (this.isOpen) {
+    if (this.open) {
       window.addEventListener('resize', this.handleUpdate, false);
     } else {
       window.removeEventListener('resize', this.handleUpdate, false);

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerEvent } from '@ember/test-helpers';
+import { render, click, triggerEvent, settled } from '@ember/test-helpers';
 import { test, visibilityClass } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -203,5 +203,27 @@ module('Integration | Component | bs-modal', function (hooks) {
 
     assert.dom('.modal-backdrop').exists({ count: 1 }, 'Modal has backdrop element');
     assert.dom('.modal-backdrop').hasClass(visibilityClass(), 'Modal backdrop has visibility class');
+  });
+
+  test('it can reopen after closing', async function (assert) {
+    this.set('open', false);
+    await render(hbs`<BsModal @open={{open}}>Hello world!</BsModal>`);
+
+    assert.dom('.modal').doesNotExist('Modal is hidden');
+    this.set('open', true);
+    await settled();
+
+    assert.dom('.modal').hasClass(visibilityClass(), 'Modal is visible');
+    assert.dom('.modal').isVisible();
+
+    this.set('open', false);
+    await settled();
+
+    assert.dom('.modal').doesNotExist('Modal is hidden');
+
+    this.set('open', true);
+    await settled();
+
+    assert.dom('.modal').isVisible('Modal is visible again');
   });
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -207,7 +207,8 @@ module('Integration | Component | bs-modal', function (hooks) {
 
   test('it can reopen after closing', async function (assert) {
     this.set('open', false);
-    await render(hbs`<BsModal @open={{open}}>Hello world!</BsModal>`);
+    this.set('close', () => (this.open = false));
+    await render(hbs`<BsModal @open={{this.open}} @onHidden={{action this.close}}>Hello world!</BsModal>`);
 
     assert.dom('.modal').doesNotExist('Modal is hidden');
     this.set('open', true);
@@ -216,9 +217,7 @@ module('Integration | Component | bs-modal', function (hooks) {
     assert.dom('.modal').hasClass(visibilityClass(), 'Modal is visible');
     assert.dom('.modal').isVisible();
 
-    this.set('open', false);
-    await settled();
-
+    await click('.modal');
     assert.dom('.modal').doesNotExist('Modal is hidden');
 
     this.set('open', true);

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -207,7 +207,7 @@ module('Integration | Component | bs-modal', function (hooks) {
 
   test('it can reopen after closing', async function (assert) {
     this.set('open', false);
-    this.set('close', () => (this.open = false));
+    this.set('close', () => this.set('open', false));
     await render(hbs`<BsModal @open={{this.open}} @onHidden={{action this.close}}>Hello world!</BsModal>`);
 
     assert.dom('.modal').doesNotExist('Modal is hidden');


### PR DESCRIPTION
Currently, modals can only be opened once. After this, it gets stuck in a state on which the BsModal thinks it is open already, causing the `show()` method to do nothing at all.

While the issue I encountered did not exactly fit issue #1386 (I did not receive any errors on my side), it might resolve that issue as well. I however do not know how to test that issue.