### PR TITLE
<BsForm::Element> should respect @value argument

### DIFF
--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -258,24 +258,17 @@ export default class FormElement extends FormGroup {
    * @public
    */
   get value() {
+    assert(
+      'You can not set both property and value on a form element',
+      isBlank(this.args.property) || isBlank(this.args.value)
+    );
+
     if (this.args.property && this.args.model) {
       return get(this.args.model, this.args.property);
     }
-    return this._value;
+
+    return this.args.value;
   }
-
-  set value(value) {
-    assert('You cannot set both property and value on a form element', isBlank(this.args.property));
-
-    this._value = value;
-  }
-
-  /**
-   * Cache for value
-   * @type {null}
-   * @private
-   */
-  @tracked _value = null;
 
   /**
    The property name of the form element's `model` (by default the `model` of its parent `Components.Form`) that this

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -824,6 +824,22 @@ module('Integration | Component | bs-form/element', function (hooks) {
     );
   });
 
+  test('it can change a value instead of a property', async function (assert) {
+    this.set('update', (name) => this.set('name', name));
+    this.set('name', 'Tomster');
+
+    await render(hbs`
+      <BsForm::Element @onChange={{this.update}} @value={{this.name}} />
+    `);
+
+    assert.dom('input').hasValue('Tomster');
+
+    await fillIn('input', 'Zoey');
+
+    assert.dom('input').hasValue('Zoey');
+    assert.equal(this.name, 'Zoey');
+  });
+
   // test for size property here to prevent regression of https://github.com/kaliber5/ember-bootstrap/issues/492
   testBS3('support size classes', async function (assert) {
     await render(hbs`<BsForm::Element @size="lg" />`);


### PR DESCRIPTION
#1339 refactored `<BsForm::Element>` from `@ember/component` to `@glimmer/component`. For a `@ember/component` setting the `@value` argument executed the `value` setter of the component. But this is not the case anymore after changing to `@glimmer/component`. Therefore the component was not using the `@value` argument anymore at all.

The good thing is that keeping a local copy of the state it is not needed anymore at all. As argument and component property is decoupled by `@glimmer/component` we can handle all cases in the getter.

Thanks a lot to @lindyhopchris for providing the failing test.

Closes #1403 and #1404