### PR TITLE
Fix for showOwnValidation throwing "same computation" Ember assertion

### DIFF
--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -579,8 +579,6 @@ export default class FormElement extends FormGroup {
   showValidationOnHandler({ target, type }) {
     // Should not do anything if
     if (
-      // validations are already shown or
-      this.showOwnValidation ||
       // validations should not be shown for this event type or
       this._showValidationOn.indexOf(type) === -1 ||
       // validation should not be shown for this event target

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -1147,4 +1147,38 @@ module('Integration | Component | bs-form', function (hooks) {
     );
     assert.dom('input').doesNotHaveAttribute('readonly');
   });
+
+  /**
+   * @see https://github.com/kaliber5/ember-bootstrap/issues/1414
+   */
+  test('it does not have a showOwnValidation bug', async function (assert) {
+    assert.expect(1);
+    this.set('submit', ({ name }) => assert.equal(name, 'Zoey'));
+    this.set('beforeSubmit', (model) => {
+      if (this.user) {
+        model.set('name', this.user.name);
+      }
+    });
+
+    await render(hbs`
+      <BsForm
+        @model={{this}}
+        @onBefore={{this.beforeSubmit}}
+        @onSubmit={{this.submit}}
+        as |Form|
+      >
+        {{#unless this.user}}
+          <Form.element @property="name" />
+        {{/unless}}
+
+        <Form.submitButton @defaultText="Submit" />
+      </BsForm>
+    `);
+
+    await fillIn('input', 'Tomster');
+
+    this.set('user', { name: 'Zoey' });
+
+    await click('button');
+  });
 });


### PR DESCRIPTION
Adds a test for #1414 that fails before the fix (also included in this PR) was implemented. The fix is to remove two lines from `bs-form/element.js` as suggested by @jelhan 