### PR TITLE
Do not use implicit this fallback in templates

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,6 +5,15 @@ module.exports = {
   rules: {
     'no-html-comments': false,
     'attribute-indentation': false,
+    'no-implicit-this': true,
   },
   ignore: ['fastboot-tests/fixtures/**/*'],
+  overrides: [
+    {
+      files: ['docs/**/*'],
+      rules: {
+        'no-implicit-this': false,
+      },
+    },
+  ],
 };

--- a/addon/components/bs-accordion/item.hbs
+++ b/addon/components/bs-accordion/item.hbs
@@ -2,16 +2,16 @@
   class="{{if this.disabled "disabled"}} {{this.typeClass}} {{if (macroCondition (macroGetOwnConfig "isBS4")) "card"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "panel"}}"
   ...attributes
 >
-  {{#if hasBlockParams}}
+  {{#if (has-block-params)}}
     {{yield
       (hash
-        title=(component (bs-default @titleComponent (component "bs-accordion/item/title")) collapsed=this.collapsed disabled=this.disabled onClick=(action onClick this.value))
+        title=(component (bs-default @titleComponent (component "bs-accordion/item/title")) collapsed=this.collapsed disabled=this.disabled onClick=(action this.onClick this.value))
         body=(component (bs-default @bodyComponent (component "bs-accordion/item/body")) collapsed=this.collapsed)
       )
     }}
   {{else}}
-    {{#component (bs-default @titleComponent (component "bs-accordion/item/title")) collapsed=this.collapsed disabled=this.disabled onClick=(action onClick this.value)}}
-      {{title}}
+    {{#component (bs-default @titleComponent (component "bs-accordion/item/title")) collapsed=this.collapsed disabled=this.disabled onClick=(action this.onClick this.value)}}
+      {{@title}}
     {{/component}}
     {{#component (bs-default @bodyComponent (component "bs-accordion/item/body")) collapsed=this.collapsed}}
       {{yield}}

--- a/addon/components/bs-accordion/item.js
+++ b/addon/components/bs-accordion/item.js
@@ -28,8 +28,6 @@ export default class AccordionItem extends Component {
    * @type string
    * @public
    */
-  @defaultValue
-  title = null;
 
   /**
    * The value of the accordion item, which is used as the value of the `selected` property of the parent [Components.Accordion](Components.Accordion.html) component

--- a/addon/components/bs-dropdown.hbs
+++ b/addon/components/bs-dropdown.hbs
@@ -11,7 +11,7 @@
         )
         toggle=(component (bs-default @toggleComponent (component "bs-dropdown/toggle"))
           isOpen=this.isOpen
-          inNav=inNav
+          inNav=@inNav
           onClick=this.toggleDropdown
           onKeyDown=this.handleKeyEvent
           registerChildElement=this.registerChildElement

--- a/addon/components/bs-modal/header.hbs
+++ b/addon/components/bs-modal/header.hbs
@@ -1,5 +1,5 @@
 <div class="modal-header" ...attributes>
-  {{#if hasBlockParams}}
+  {{#if (has-block-params)}}
     {{yield
       (hash
         title=(bs-default @titleComponent (component "bs-modal/header/title"))

--- a/addon/components/bs-popover.hbs
+++ b/addon/components/bs-popover.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-unbound }}
-{{unbound _parentFinder}}
+{{unbound this._parentFinder}}
 {{#if this.inDom}}
   {{#let (bs-default @elementComponent (component "bs-popover/element")) as |Element|}}
     <Element

--- a/addon/components/bs-tooltip.hbs
+++ b/addon/components/bs-tooltip.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-unbound }}
-{{unbound _parentFinder}}
+{{unbound this._parentFinder}}
 {{#if this.inDom}}
   {{#let (bs-default @elementComponent (component "bs-tooltip/element")) as |Element|}}
     <Element

--- a/tests/dummy/app/templates/acceptance/modal.hbs
+++ b/tests/dummy/app/templates/acceptance/modal.hbs
@@ -1,7 +1,7 @@
 <BsButton id="openModal" @onClick={{action "addModal"}}>Open</BsButton>
 
-{{#if hasModal}}
-  <BsModalSimple @open={{modal}} @onHidden={{action "removeModal"}} @title="Dynamic Dialog">
+{{#if this.hasModal}}
+  <BsModalSimple @open={{this.modal}} @onHidden={{action "removeModal"}} @title="Dynamic Dialog">
     Hi there
   </BsModalSimple>
 {{/if}}

--- a/tests/integration/components/bs-accordion-test.js
+++ b/tests/integration/components/bs-accordion-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | bs-accordion', function (hooks) {
   test('accordion with preselected item has this item expanded', async function (assert) {
     this.set('selected', 1);
     await render(hbs`
-      <BsAccordion @selected={{selected}} as |acc|>
+      <BsAccordion @selected={{this.selected}} as |acc|>
         <acc.item @value={{1}} @title="TITLE1">CONTENT1</acc.item>
         <acc.item @value={{2}} @title="TITLE2">CONTENT2</acc.item>
       </BsAccordion>
@@ -74,7 +74,7 @@ module('Integration | Component | bs-accordion', function (hooks) {
   test('changing selected item expands this item', async function (assert) {
     this.set('selected', 1);
     await render(hbs`
-      <BsAccordion @selected={{selected}} as |acc|>
+      <BsAccordion @selected={{this.selected}} as |acc|>
         <acc.item @value={{1}} @title="TITLE1">CONTENT1</acc.item>
         <acc.item @value={{2}} @title="TITLE2">CONTENT2</acc.item>
       </BsAccordion>
@@ -180,7 +180,7 @@ module('Integration | Component | bs-accordion', function (hooks) {
   test('changing selection does not leak to public selected property (DDAU)', async function (assert) {
     this.set('selected', 1);
     await render(hbs`
-      <BsAccordion @selected={{selected}} as |acc|>
+      <BsAccordion @selected={{this.selected}} as |acc|>
         <acc.item @value={{1}} @title="TITLE1">CONTENT1</acc.item>
         <acc.item @value={{2}} @title="TITLE2">CONTENT2</acc.item>
       </BsAccordion>

--- a/tests/integration/components/bs-alert-test.js
+++ b/tests/integration/components/bs-alert-test.js
@@ -54,7 +54,7 @@ module('Integration | Component | bs-alert', function (hooks) {
 
   test('alert can be hidden by setting visible property', async function (assert) {
     this.set('visible', true);
-    await render(hbs`<BsAlert @type="success" @fade={{false}} @visible={{visible}}>Test</BsAlert>`);
+    await render(hbs`<BsAlert @type="success" @fade={{false}} @visible={{this.visible}}>Test</BsAlert>`);
 
     this.set('visible', false);
 
@@ -143,7 +143,7 @@ module('Integration | Component | bs-alert', function (hooks) {
 
   test('alert can be made visible when setting visible=true', async function (assert) {
     this.set('visible', false);
-    await render(hbs`<BsAlert @type="success" @visible={{visible}} @fade={{false}}>Test</BsAlert>`);
+    await render(hbs`<BsAlert @type="success" @visible={{this.visible}} @fade={{false}}>Test</BsAlert>`);
     this.set('visible', true);
 
     assert.dom('.alert').exists('alert has alert class');
@@ -152,7 +152,7 @@ module('Integration | Component | bs-alert', function (hooks) {
 
   test('dismissing alert does not change public visible property (DDAU)', async function (assert) {
     this.set('visible', true);
-    await render(hbs`<BsAlert @type="success" @visible={{visible}} @fade={{false}}>Test</BsAlert>`);
+    await render(hbs`<BsAlert @type="success" @visible={{this.visible}} @fade={{false}}>Test</BsAlert>`);
 
     await click('button.close');
 

--- a/tests/integration/components/bs-button-group-test.js
+++ b/tests/integration/components/bs-button-group-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
     let action = sinon.spy();
     this.actions.change = action;
     await render(
-      hbs`{{#bs-button-group type="radio" value=value onChange=(action "change") as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="radio" value=this.value onChange=(action "change") as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
 
     for (let i = 0; i < 3; i++) {
@@ -64,7 +64,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
       assert.deepEqual(value, expectedValue);
     };
     await render(
-      hbs`{{#bs-button-group type="checkbox" value=value onChange=(action "change") as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="checkbox" value=this.value onChange=(action "change") as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
     this.set('value', [1]);
     await click('button:nth-child(2)');
@@ -72,7 +72,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
 
   test('radio button group with value set activates button with same value', async function (assert) {
     await render(
-      hbs`{{#bs-button-group type="radio" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="radio" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
     this.set('value', 1);
 
@@ -91,7 +91,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
   test('checkbox button group with value set activates buttons with same value', async function (assert) {
     let value = A([1, 3]);
     await render(
-      hbs`{{#bs-button-group type="checkbox" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="checkbox" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
     this.set('value', value);
 
@@ -109,7 +109,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
 
   test('setting radio button group value activates button with same value', async function (assert) {
     await render(
-      hbs`{{#bs-button-group type="radio" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="radio" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
 
     for (let i = 0; i < 3; i++) {
@@ -129,7 +129,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
 
   test('setting checkbox button group value with array of values activates buttons with same value', async function (assert) {
     await render(
-      hbs`{{#bs-button-group type="checkbox" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="checkbox" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
 
     let value = A([1, 3]);
@@ -159,7 +159,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
 
   test('setting radio button group value to null sets buttons active state to false', async function (assert) {
     await render(
-      hbs`{{#bs-button-group type="radio" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="radio" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
 
     for (let i = 0; i < 3; i++) {
@@ -177,7 +177,7 @@ module('Integration | Component | bs-button-group', function (hooks) {
     let value = A([1]);
     this.set('value', value);
     await render(
-      hbs`{{#bs-button-group type="checkbox" value=value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
+      hbs`{{#bs-button-group type="checkbox" value=this.value as |bg|}}{{#bg.button value=1}}1{{/bg.button}}{{#bg.button value=2}}2{{/bg.button}}{{#bg.button value=3}}3{{/bg.button}}{{/bs-button-group}}`
     );
 
     await click('button:nth-child(3)');

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -93,7 +93,7 @@ module('Integration | Component | bs-button', function (hooks) {
 
   test('button with iconActive and iconInactive properties shows icon depending on active state', async function (assert) {
     this.set('active', false);
-    await render(hbs`<BsButton @active={{active}} @iconInactive="fas fa-plus" @iconActive="fas fa-minus" />`);
+    await render(hbs`<BsButton @active={{this.active}} @iconInactive="fas fa-plus" @iconActive="fas fa-minus" />`);
 
     assert.dom('button i').hasClass('fas');
     assert.dom('button i').hasClass('fa-plus');
@@ -130,7 +130,7 @@ module('Integration | Component | bs-button', function (hooks) {
         @pendingText="text for pending state"
         @fulfilledText="text for fulfilled state"
         @rejectedText="text for rejected state"
-        @onClick={{clickAction}}
+        @onClick={{this.clickAction}}
       />
     `);
     assert.dom('button').hasText('default text');
@@ -161,7 +161,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`<BsButton @defaultText="default text" @onClick={{clickAction}} />`);
+    await render(hbs`<BsButton @defaultText="default text" @onClick={{this.clickAction}} />`);
     assert.dom('button').hasText('default text');
 
     click('button');
@@ -190,7 +190,7 @@ module('Integration | Component | bs-button', function (hooks) {
     });
 
     await render(hbs`
-      <BsButton @defaultText="default text" @fulfilledText="text for fulfilled state" @reset={{reset}} @onClick={{clickAction}} />
+      <BsButton @defaultText="default text" @fulfilledText="text for fulfilled state" @reset={{this.reset}} @onClick={{this.clickAction}} />
     `);
     assert.dom('button').hasText('default text');
 
@@ -207,7 +207,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`<BsButton @onClick={{clickAction}} />`);
+    await render(hbs`<BsButton @onClick={{this.clickAction}} />`);
     assert.dom('button').isNotDisabled();
 
     await click('button');
@@ -224,7 +224,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`<BsButton @onClick={{clickAction}} @preventConcurrency={{false}} />`);
+    await render(hbs`<BsButton @onClick={{this.clickAction}} @preventConcurrency={{false}} />`);
     await click('button');
     assert.dom('button').isNotDisabled();
 
@@ -240,7 +240,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`<BsButton @onClick={{clickAction}} disabled={{false}} />`);
+    await render(hbs`<BsButton @onClick={{this.clickAction}} disabled={{false}} />`);
     await click('button');
     assert.dom('button').isNotDisabled();
 
@@ -254,7 +254,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
     await render(hbs`
-      <BsButton @reset={{reset}} @onClick={{clickAction}} as |button|>
+      <BsButton @reset={{this.reset}} @onClick={{this.clickAction}} as |button|>
         {{#if button.isPending}}isPending{{/if}}
         {{#if button.isFulfilled}}isFulfilled{{/if}}
         {{#if button.isRejected}}isRejected{{/if}}
@@ -291,7 +291,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return resolve();
     });
     await render(hbs`
-      <BsButton @reset={{reset}} @onClick={{clickAction}} as |button|>
+      <BsButton @reset={{this.reset}} @onClick={{this.clickAction}} as |button|>
         {{#if button.isSettled}}isSettled{{/if}}
       </BsButton>
     `);
@@ -361,7 +361,7 @@ module('Integration | Component | bs-button', function (hooks) {
       return deferredClickAction.promise;
     });
 
-    await render(hbs`<BsButton @onClick={{clickAction}} />`);
+    await render(hbs`<BsButton @onClick={{this.clickAction}} />`);
     click('button');
     await waitUntil(() => clickActionHasBeenExecuted);
 
@@ -388,7 +388,7 @@ module('Integration | Component | bs-button', function (hooks) {
       clickActionExecutionCount++;
       return deferredClickAction.promise;
     });
-    await render(hbs`<BsButton @onClick={{clickAction}} @preventConcurrency={{false}} />`);
+    await render(hbs`<BsButton @onClick={{this.clickAction}} @preventConcurrency={{false}} />`);
 
     await click('button');
     assert.equal(clickActionExecutionCount, 1);

--- a/tests/integration/components/bs-carousel-test.js
+++ b/tests/integration/components/bs-carousel-test.js
@@ -116,7 +116,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel autoPlay=false must not start sliding', async function (assert) {
     await render(
-      hbs`<BsCarousel @autoPlay={{false}} @interval={{300}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{false}} @interval={{300}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime();
     assert.ok(getActivatedSlide(1), 'autoPlay has correct behavior');
@@ -126,7 +126,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
   // very flakey :-(
   skip('carousel autoPlay=true must start sliding', async function (assert) {
     render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{interval}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{this.interval}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime();
     assert.notOk(getActivatedSlide(1), 'autoPlay has correct behavior');
@@ -138,7 +138,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
     let action = sinon.spy();
     this.set('action', action);
     await render(
-      hbs`<BsCarousel @onSlideChanged={{this.action}} @wrap={{false}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @onSlideChanged={{this.action}} @wrap={{false}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     clickToNextSlide();
     assert.ok(action.notCalled, 'onSlideChanged action has not been called.');
@@ -148,7 +148,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel wrap=false must not cross lower bound', async function (assert) {
     await render(
-      hbs`<BsCarousel @wrap={{false}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @wrap={{false}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     clickToPrevSlide();
     await waitTransitionTime();
@@ -158,7 +158,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel wrap=false must not cross upper bound', async function (assert) {
     await render(
-      hbs`<BsCarousel @wrap={{false}} @index={{1}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @wrap={{false}} @index={{1}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     clickToNextSlide();
     await waitTransitionTime();
@@ -168,7 +168,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel wrap=true must cross lower bound', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @wrap={{true}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @wrap={{true}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickToPrevSlide();
     assert.notOk(getActivatedSlide(1), 'wrap has correct behavior');
@@ -177,7 +177,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel wrap=true must cross upper bound', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @wrap={{true}} @index={{1}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @wrap={{true}} @index={{1}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickToNextSlide();
     assert.ok(getActivatedSlide(1), 'wrap has correct behavior');
@@ -192,7 +192,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel interval=0 must not trigger automatic sliding', async function (assert) {
     await render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{0}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{0}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime();
     assert.ok(getActivatedSlide(1), 'interval has correct behavior');
@@ -202,7 +202,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
   // very flakey :-(
   skip('carousel ltr=false does right-to-left automatic sliding', async function (assert) {
     render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{interval}} @transitionDuration={{transitionDuration}} @ltr={{false}} as |car|>{{car.slide}}{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{this.interval}} @transitionDuration={{this.transitionDuration}} @ltr={{false}} as |car|>{{car.slide}}{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime();
     assert.notOk(getActivatedSlide(1), 'ltr has correct behavior');
@@ -214,7 +214,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
   // very flakey :-(
   skip('carousel ltr=true does left-to-right automatic sliding', async function (assert) {
     render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{interval}} @transitionDuration={{transitionDuration}} @ltr={{true}} as |car|>{{car.slide}}{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{this.interval}} @transitionDuration={{this.transitionDuration}} @ltr={{true}} as |car|>{{car.slide}}{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime();
     assert.ok(getActivatedSlide(2), 'ltr has correct behavior');
@@ -223,7 +223,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel pauseOnMouseEnter=false must not pause automatic sliding', async function (assert) {
     render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{interval}} @transitionDuration={{transitionDuration}} @pauseOnMouseEnter={{false}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{this.interval}} @transitionDuration={{this.transitionDuration}} @pauseOnMouseEnter={{false}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime(10);
     triggerEvent('.carousel', 'mouseenter');
@@ -235,7 +235,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel pauseOnMouseEnter=true must pause automatic sliding', async function (assert) {
     render(
-      hbs`<BsCarousel @autoPlay={{true}} @interval={{interval}} @transitionDuration={{transitionDuration}} @pauseOnMouseEnter={{true}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @autoPlay={{true}} @interval={{this.interval}} @transitionDuration={{this.transitionDuration}} @pauseOnMouseEnter={{true}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await waitTransitionTime(10);
     triggerEvent('.carousel', 'mouseenter');
@@ -249,7 +249,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel has functional right control', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickToNextSlide();
     assert.notOk(getActivatedSlide(1), 'right control changes slide');
@@ -258,7 +258,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel has functional left control', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @transitionDuration={{transitionDuration}} @index={{1}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @transitionDuration={{this.transitionDuration}} @index={{1}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickToPrevSlide();
     assert.ok(getActivatedSlide(1), 'left control changes slide');
@@ -267,7 +267,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel has functional indicators', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickIndicator(2);
     assert.dom('.carousel-indicators > li:nth-child(2).active').exists('indicators changes indicator index');
@@ -277,7 +277,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
 
   test('carousel can move right then back to the left', async function (assert) {
     await render(
-      hbs`<BsCarousel @interval={{0}} @transitionDuration={{transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
+      hbs`<BsCarousel @interval={{0}} @transitionDuration={{this.transitionDuration}} as |car|>{{car.slide}}{{car.slide}}</BsCarousel>`
     );
     await clickToNextSlide();
     await clickToPrevSlide();

--- a/tests/integration/components/bs-collapse-test.js
+++ b/tests/integration/components/bs-collapse-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | bs-collapse', function (hooks) {
 
     this.set('collapsed', true);
     await render(
-      hbs`<BsCollapse @collapsed={{collapsed}} @onShow={{action "show"}} @onShown={{action "shown"}}><p>Just some content</p></BsCollapse>`
+      hbs`<BsCollapse @collapsed={{this.collapsed}} @onShow={{action "show"}} @onShown={{action "shown"}}><p>Just some content</p></BsCollapse>`
     );
     this.set('collapsed', false);
 
@@ -68,7 +68,7 @@ module('Integration | Component | bs-collapse', function (hooks) {
 
     this.set('collapsed', false);
     await render(
-      hbs`<BsCollapse @collapsed={{collapsed}} @onHide={{action "hide"}} @onHidden={{action "hidden"}}><p>Just some content</p></BsCollapse>`
+      hbs`<BsCollapse @collapsed={{this.collapsed}} @onHide={{action "hide"}} @onHidden={{action "hidden"}}><p>Just some content</p></BsCollapse>`
     );
     this.set('collapsed', true);
 
@@ -86,7 +86,7 @@ module('Integration | Component | bs-collapse', function (hooks) {
   test('after collapsing/expanding height/width is set correctly ', async function (assert) {
     this.set('collapsed', true);
     await render(
-      hbs`<BsCollapse @expandedSize={{200}} @transitionDuration={{200}} @collapsed={{collapsed}}><p>Just some content</p></BsCollapse>`
+      hbs`<BsCollapse @expandedSize={{200}} @transitionDuration={{200}} @collapsed={{this.collapsed}}><p>Just some content</p></BsCollapse>`
     );
     this.set('collapsed', false);
 

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -144,7 +144,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
         <dd.toggle>Dropdown <span class="caret"></span></dd.toggle>
         <dd.menu><li><a href="#">Something</a></li></dd.menu>
       </BsDropdown>
-      <div id="target" role="button" onclick={{action stopEvent}} />
+      <div id="target" role="button" onclick={{action this.stopEvent}} />
     `);
 
     await click('a.dropdown-toggle');

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -60,7 +60,7 @@ module('Integration | Component | bs-form', function (hooks) {
 
     for (let layout in classSpec) {
       this.set('formLayout', layout);
-      await render(hbs`<BsForm @formLayout={{formLayout}}>Test</BsForm>`);
+      await render(hbs`<BsForm @formLayout={{this.formLayout}}>Test</BsForm>`);
       assert.dom('form').hasClass(classSpec[layout], `form has expected class for ${layout}`);
     }
   });
@@ -74,7 +74,7 @@ module('Integration | Component | bs-form', function (hooks) {
 
     for (let layout in classSpec) {
       this.set('formLayout', layout);
-      await render(hbs`<BsForm @formLayout={{formLayout}}>Test</BsForm>`);
+      await render(hbs`<BsForm @formLayout={{this.formLayout}}>Test</BsForm>`);
 
       let expectation = classSpec[layout];
       assert.equal(
@@ -101,7 +101,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.actions.submit = submit;
     this.actions.invalid = invalid;
     await render(
-      hbs`<BsForm @model={{model}} @onBefore={{action "before"}} @onSubmit={{action "submit"}} @onInvalid={{action "invalid"}}>Test</BsForm>`
+      hbs`<BsForm @model={{this.model}} @onBefore={{action "before"}} @onSubmit={{action "submit"}} @onInvalid={{action "invalid"}}>Test</BsForm>`
     );
 
     await triggerEvent('form', 'submit');
@@ -149,9 +149,9 @@ module('Integration | Component | bs-form', function (hooks) {
     });
     await render(hbs`
       <BsForm
-        @model={{model}}
+        @model={{this.model}}
         @hasValidator={{true}}
-        @validate={{validateStub}}
+        @validate={{this.validateStub}}
         @onBefore={{action "before"}}
         @onSubmit={{action "submit"}}
         @onInvalid={{action "invalid"}}
@@ -181,7 +181,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.actions.invalid = invalid;
     this.set('validateStub', sinon.fake.rejects(rejectsWith));
     await render(hbs`
-      <BsForm @model={{model}} @hasValidator={{true}} @validate={{validateStub}} @onBefore={{action "before"}} @onSubmit={{action "submit"}} @onInvalid={{action "invalid"}}>Test</BsForm>
+      <BsForm @model={{this.model}} @hasValidator={{true}} @validate={{this.validateStub}} @onBefore={{action "before"}} @onSubmit={{action "submit"}} @onInvalid={{action "invalid"}}>Test</BsForm>
     `);
 
     await triggerEvent('form', 'submit');
@@ -200,7 +200,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.set('errors', A(['There is an error']));
     this.set('validateStub', sinon.fake.rejects());
     await render(
-      hbs`<BsForm @model={{model}} @hasValidator={{true}} @validate={{validateStub}} as |form|><form.element @hasValidator={{true}} @errors={{errors}} /></BsForm>`
+      hbs`<BsForm @model={{this.model}} @hasValidator={{true}} @validate={{this.validateStub}} as |form|><form.element @hasValidator={{true}} @errors={{this.errors}} /></BsForm>`
     );
 
     assert
@@ -223,7 +223,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.set('invalid', () => deferredInvalidAction.promise);
 
     await render(
-      hbs`<BsForm @model={{model}} @hasValidator={{true}} @validate={{validateStub}} @onInvalid={{this.invalid}} as |form|><form.element @hasValidator={{true}} @errors={{errors}} /></BsForm>`
+      hbs`<BsForm @model={{this.model}} @hasValidator={{true}} @validate={{this.validateStub}} @onInvalid={{this.invalid}} as |form|><form.element @hasValidator={{true}} @errors={{this.errors}} /></BsForm>`
     );
 
     await triggerEvent('form', 'submit');
@@ -249,7 +249,7 @@ module('Integration | Component | bs-form', function (hooks) {
     Ember.onerror = onErrorStub;
 
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}}>
+      <BsForm @onSubmit={{this.submitAction}}>
         <button type="submit">submit</button>
       </BsForm>
     `);
@@ -260,7 +260,7 @@ module('Integration | Component | bs-form', function (hooks) {
   test('form with validation has novalidate attribute', async function (assert) {
     let model = {};
     this.set('model', model);
-    await render(hbs`<BsForm @model={{model}} @hasValidator={{true}}>Test</BsForm>`);
+    await render(hbs`<BsForm @model={{this.model}} @hasValidator={{true}}>Test</BsForm>`);
 
     assert.dom('form').hasAttribute('novalidate');
   });
@@ -268,7 +268,7 @@ module('Integration | Component | bs-form', function (hooks) {
   test('form with validation allows overriding novalidate attribute', async function (assert) {
     let model = {};
     this.set('model', model);
-    await render(hbs`<BsForm @model={{model}} @hasValidator={{true}} novalidate={{false}}>Test</BsForm>`);
+    await render(hbs`<BsForm @model={{this.model}} @hasValidator={{true}} novalidate={{false}}>Test</BsForm>`);
 
     assert.dom('form').doesNotHaveAttribute('novalidate');
   });
@@ -284,8 +284,8 @@ module('Integration | Component | bs-form', function (hooks) {
     });
     await render(
       hbs`
-        <BsForm @model={{model}} @onSubmit={{submitAction}} @hasValidator={{true}} @validate={{validateStub}} as |form|>
-          <form.element @property="dummy" @hasValidator={{true}} @errors={{errors}} />
+        <BsForm @model={{this.model}} @onSubmit={{this.submitAction}} @hasValidator={{true}} @validate={{this.validateStub}} as |form|>
+          <form.element @property="dummy" @hasValidator={{true}} @errors={{this.errors}} />
         </BsForm>`
     );
 
@@ -326,8 +326,8 @@ module('Integration | Component | bs-form', function (hooks) {
       });
       await render(
         hbs`
-        <BsForm @hideValidationsOnSubmit={{true}} @model={{model}} @onSubmit={{submitAction}} @hasValidator={{true}} @validate={{validateStub}} as |form|>
-          <form.element @property="dummy" @hasValidator={{true}} @errors={{errors}} />
+        <BsForm @hideValidationsOnSubmit={{true}} @model={{this.model}} @onSubmit={{this.submitAction}} @hasValidator={{true}} @validate={{this.validateStub}} as |form|>
+          <form.element @property="dummy" @hasValidator={{true}} @errors={{this.errors}} />
         </BsForm>`
       );
 
@@ -375,8 +375,8 @@ module('Integration | Component | bs-form', function (hooks) {
       this.set('submitAction', () => {});
       await render(
         hbs`
-        <BsForm @hideValidationsOnSubmit={{true}} @model={{model}} @onSubmit={{submitAction}} @hasValidator={{true}} @validate={{validateStub}} as |form|>
-          <form.element @property="dummy" @hasValidator={{true}} @errors={{errors}} />
+        <BsForm @hideValidationsOnSubmit={{true}} @model={{this.model}} @onSubmit={{this.submitAction}} @hasValidator={{true}} @validate={{this.validateStub}} as |form|>
+          <form.element @property="dummy" @hasValidator={{true}} @errors={{this.errors}} />
         </BsForm>`
       );
 
@@ -487,7 +487,7 @@ module('Integration | Component | bs-form', function (hooks) {
     for (let i = 0; i < scenarios.length; i++) {
       this.setProperties(scenarios[i]);
       await render(hbs`
-        <BsForm @onSubmit={{onSubmit}} @validate={{validate}} as |form|>
+        <BsForm @onSubmit={{this.onSubmit}} @validate={{this.validate}} as |form|>
           {{test-component onClick=form.submit}}
         </BsForm>
       `);
@@ -535,7 +535,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return deferredSubmitAction.promise;
     });
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} as |form|>
+      <BsForm @onSubmit={{this.submitAction}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -556,7 +556,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.set('validate', () => {});
     this.set('hasValidator', true);
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} @validate={{validate}} @hasValidator={{hasValidator}} as |form|>
+      <BsForm @onSubmit={{this.submitAction}} @validate={{this.validate}} @hasValidator={{this.hasValidator}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -574,7 +574,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return deferredSubmitAction.promise;
     });
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} as |form|>
+      <BsForm @onSubmit={{this.submitAction}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -598,7 +598,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return reject();
     });
     await render(hbs`
-      <BsForm @onInvalid={{submitAction}} @hasValidator={{true}} @validate={{validate}} as |form|>
+      <BsForm @onInvalid={{this.submitAction}} @hasValidator={{true}} @validate={{this.validate}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -620,7 +620,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return deferredValidateAction.promise;
     });
     await render(hbs`
-      <BsForm @hasValidator={{hasValidator}} @validate={{validateAction}} as |form|>
+      <BsForm @hasValidator={{this.hasValidator}} @validate={{this.validateAction}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -645,7 +645,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return deferredValidateAction.promise;
     });
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} @validate={{validateAction}} @hasValidator={{true}} as |form|>
+      <BsForm @onSubmit={{this.submitAction}} @validate={{this.validateAction}} @hasValidator={{true}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -671,7 +671,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return deferred.promise;
     });
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} @preventConcurrency={{false}} as |form|>
+      <BsForm @onSubmit={{this.submitAction}} @preventConcurrency={{false}} as |form|>
         <div class="state {{if form.isSubmitting "is-submitting"}}"></div>
       </BsForm>
     `);
@@ -826,7 +826,7 @@ module('Integration | Component | bs-form', function (hooks) {
     });
     this.set('model', model);
     await render(hbs`
-      <BsForm @model={{model}} as |form|>
+      <BsForm @model={{this.model}} as |form|>
         <form.element @property="name" />
       </BsForm>
     `);
@@ -858,7 +858,7 @@ module('Integration | Component | bs-form', function (hooks) {
       return resolve();
     });
     await render(hbs`
-      <BsForm @onSubmit={{submitAction}} @onBefore={{beforeAction}} @validate={{validate}} @hasValidator={{true}}></BsForm>
+      <BsForm @onSubmit={{this.submitAction}} @onBefore={{this.beforeAction}} @validate={{this.validate}} @hasValidator={{true}}></BsForm>
     `);
 
     triggerEvent('form', 'submit');
@@ -902,7 +902,7 @@ module('Integration | Component | bs-form', function (hooks) {
     this.set('beforeAction', beforeActionFake);
     this.set('validate', validateFake);
     await render(hbs`
-      <BsForm @preventConcurrency={{false}} @onSubmit={{submitAction}} @onBefore={{beforeAction}} @validate={{validate}} @hasValidator={{true}}>
+      <BsForm @preventConcurrency={{false}} @onSubmit={{this.submitAction}} @onBefore={{this.beforeAction}} @validate={{this.validate}} @hasValidator={{true}}>
       </BsForm>
     `);
 

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('formLayout', 'vertical');
     this.set('controlType', controlType);
     await render(
-      hbs`<BsForm::Element @controlType={{controlType}} @formLayout={{formLayout}} @horizontalLabelGridClass="col-md-4" />`
+      hbs`<BsForm::Element @controlType={{this.controlType}} @formLayout={{this.formLayout}} @horizontalLabelGridClass="col-md-4" />`
     );
 
     formLayouts.forEach((layout) => {
@@ -67,7 +67,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('model', model);
 
     await render(
-      hbs`<BsForm @model={{model}} as |f|><f.element @controlType={{controlType}} @property="prop" /></BsForm>`
+      hbs`<BsForm @model={{this.model}} as |f|><f.element @controlType={{this.controlType}} @property="prop" /></BsForm>`
     );
 
     this.set('model.prop', 'foo');
@@ -93,7 +93,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     });
     this.set('model', model);
     await render(
-      hbs`<BsForm::Element @controlType={{controlType}} @horizontalLabelGridClass="col-md-4" @model={{model}} @property="name" @onChange={{action change}} />`
+      hbs`<BsForm::Element @controlType={{this.controlType}} @horizontalLabelGridClass="col-md-4" @model={{this.model}} @property="name" @onChange={{action this.change}} />`
     );
 
     if (typeof setValueFn === 'function') {
@@ -118,7 +118,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     let model = EmberObject.create();
     this.set('model', model);
     await render(
-      hbs`<BsForm @model={{model}} @formLayout={{formLayout}} as |form|><form.element @controlType={{controlType}} @property="prop" @label="myLabel" /></BsForm>`
+      hbs`<BsForm @model={{this.model}} @formLayout={{this.formLayout}} as |form|><form.element @controlType={{this.controlType}} @property="prop" @label="myLabel" /></BsForm>`
     );
 
     formLayouts.forEach((layout) => {
@@ -177,7 +177,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     test('controlType "radio" is supported', async function (assert) {
       this.set('formLayout', 'vertical');
       await render(
-        hbs`<BsForm::Element @controlType="radio" @formLayout={{formLayout}} @options={{simpleOptions}} @horizontalLabelGridClass="col-md-4" />`
+        hbs`<BsForm::Element @controlType="radio" @formLayout={{this.formLayout}} @options={{this.simpleOptions}} @horizontalLabelGridClass="col-md-4" />`
       );
 
       formLayouts.forEach((layout) => {
@@ -187,7 +187,9 @@ module('Integration | Component | bs-form/element', function (hooks) {
     });
 
     test('it renders simple options', async function (assert) {
-      await render(hbs`<BsForm::Element @controlType="radio" @formLayout="horizontal" @options={{simpleOptions}} />`);
+      await render(
+        hbs`<BsForm::Element @controlType="radio" @formLayout="horizontal" @options={{this.simpleOptions}} />`
+      );
 
       assert.dom('input[type=radio]').exists({ count: 2 });
       assert.dom('label').exists({ count: 2 });
@@ -203,7 +205,9 @@ module('Integration | Component | bs-form/element', function (hooks) {
     });
 
     test('it renders hash options', async function (assert) {
-      await render(hbs`<BsForm::Element @controlType="radio" @options={{hashOptions}} @optionLabelPath="title" />`);
+      await render(
+        hbs`<BsForm::Element @controlType="radio" @options={{this.hashOptions}} @optionLabelPath="title" />`
+      );
 
       assert.dom('input[type=radio]').exists({ count: 2 });
       assert.dom('label').exists({ count: 2 });
@@ -220,7 +224,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
     test('Block mode allows to customize label for each radio input', async function (assert) {
       await render(hbs`
-        <BsForm::Element @controlType="radio" @options={{simpleOptions}} as |Element|>
+        <BsForm::Element @controlType="radio" @options={{this.simpleOptions}} as |Element|>
           <Element.control as |option index|>
             {{index}}: {{option}}
           </Element.control>
@@ -235,7 +239,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       'Block mode allows to customize label for each radio input if used together with inline',
       async function (assert) {
         await render(hbs`
-        <BsForm::Element @controlType="radio" @options={{simpleOptions}} as |Element|>
+        <BsForm::Element @controlType="radio" @options={{this.simpleOptions}} as |Element|>
           <Element.control @inline={{true}} as |option index|>
             {{index}}: {{option}}
           </Element.control>
@@ -248,7 +252,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     );
 
     testBS3('has correct markup', async function (assert) {
-      await render(hbs`<BsForm::Element @controlType="radio" @options={{simpleOptions}} />`);
+      await render(hbs`<BsForm::Element @controlType="radio" @options={{this.simpleOptions}} />`);
 
       assert.dom('.radio').exists({ count: 2 });
       assert.dom('.radio label').exists({ count: 2 });
@@ -257,7 +261,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
     testBS3('supports inline', async function (assert) {
       await render(hbs`
-        <BsForm::Element @controlType="radio" @options={{simpleOptions}} as |Element|>
+        <BsForm::Element @controlType="radio" @options={{this.simpleOptions}} as |Element|>
           <Element.control @inline={{true}} />
         </BsForm::Element>
       `);
@@ -269,7 +273,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
     testBS3('supports inline for hash options', async function (assert) {
       await render(hbs`
-        <BsForm::Element @controlType="radio" @options={{hashOptions}} @optionLabelPath="title" as |Element|>
+        <BsForm::Element @controlType="radio" @options={{this.hashOptions}} @optionLabelPath="title" as |Element|>
           <Element.control @inline={{true}} />
         </BsForm::Element>
       `);
@@ -291,7 +295,9 @@ module('Integration | Component | bs-form/element', function (hooks) {
     });
 
     testBS4('has correct markup', async function (assert) {
-      await render(hbs`<BsForm::Element @controlType="radio" @label="my radio group" @options={{simpleOptions}} />`);
+      await render(
+        hbs`<BsForm::Element @controlType="radio" @label="my radio group" @options={{this.simpleOptions}} />`
+      );
 
       assert.dom('legend').exists({ count: 1 }, 'renders a <legend> instead of a <label> for radio group');
       assert.dom('legend').hasText('my radio group', 'renders value of label argument as text of <legend>');
@@ -305,7 +311,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     testBS4('supports horizontal from layout', async function (assert) {
       await render(hbs`
         <BsForm @formLayout="horizontal" as |form|>
-          <form.element @controlType="radio" @label="my radio group" @options={{simpleOptions}} />
+          <form.element @controlType="radio" @label="my radio group" @options={{this.simpleOptions}} />
         </BsForm>
       `);
 
@@ -316,7 +322,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
     testBS4('supports inline', async function (assert) {
       await render(hbs`
-        <BsForm::Element @controlType="radio" @options={{simpleOptions}} as |Element|>
+        <BsForm::Element @controlType="radio" @options={{this.simpleOptions}} as |Element|>
           <Element.control @inline={{true}} />
         </BsForm::Element>
       `);
@@ -329,7 +335,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       this.set('model', model);
 
       await render(
-        hbs`<BsForm @model={{model}} as |f|><f.element @controlType="radio" @options={{simpleOptions}} @property="prop" /></BsForm>`
+        hbs`<BsForm @model={{this.model}} as |f|><f.element @controlType="radio" @options={{this.simpleOptions}} @property="prop" /></BsForm>`
       );
 
       this.set('model.prop', undefined);
@@ -348,7 +354,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       });
       this.set('model', model);
       await render(
-        hbs`<BsForm::Element @controlType="radio" @options={{simpleOptions}} @model={{model}} @property="name" @onChange={{action change}} />`
+        hbs`<BsForm::Element @controlType="radio" @options={{this.simpleOptions}} @model={{this.model}} @property="name" @onChange={{action this.change}} />`
       );
       await click(this.element.querySelectorAll('input[type=radio]')[1]);
 
@@ -362,7 +368,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       foo: 'bar',
     });
     this.set('model', model);
-    await render(hbs`<BsForm::Element @property="foo" @model={{model}} />`);
+    await render(hbs`<BsForm::Element @property="foo" @model={{this.model}} />`);
 
     assert.dom('input').hasValue('bar', 'input has expected value from model');
 
@@ -373,7 +379,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
   test('Changing formLayout changes markup', async function (assert) {
     this.set('formLayout', 'vertical');
     await render(
-      hbs`<BsForm @horizontalLabelGridClass="col-sm-4" @formLayout={{formLayout}} as |form|><form.element @controlType="text" @label="myLabel" /></BsForm>`
+      hbs`<BsForm @horizontalLabelGridClass="col-sm-4" @formLayout={{this.formLayout}} as |form|><form.element @controlType="text" @label="myLabel" /></BsForm>`
     );
     assert.dom('form > div').hasClass('form-group', 'component has form-group class');
     assert.equal(this.element.querySelector('form > div > :nth-child(1)').tagName, 'LABEL', 'first child is a label');
@@ -399,7 +405,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
     this.set('model', model);
     await render(hbs`
-      <BsForm @model={{model}} as |form|>
+      <BsForm @model={{this.model}} as |form|>
         <form.element
           @controlType="textarea"
           @label="Gender"
@@ -472,8 +478,8 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('errors', A([]));
     this.set('formLayout', 'vertical');
     await render(hbs`
-      <BsForm @formLayout={{formLayout}} as |form|>
-        <form.element @showAllValidations={{true}} @hasValidator={{true}} @errors={{errors}} @label="adjusts validation icon position" class="addon">
+      <BsForm @formLayout={{this.formLayout}} as |form|>
+        <form.element @showAllValidations={{true}} @hasValidator={{true}} @errors={{this.errors}} @label="adjusts validation icon position" class="addon">
           <div class="input-group">
             <input class="form-control">
             <div class="input-group-addon">
@@ -481,7 +487,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
             </div>
           </div>
         </form.element>
-        <form.element @showAllValidations={{true}} @hasValidator={{true}} @errors={{errors}} @label="adjusts validation icon position" class="button">
+        <form.element @showAllValidations={{true}} @hasValidator={{true}} @errors={{this.errors}} @label="adjusts validation icon position" class="button">
           <div class="input-group">
             <input class="form-control">
             <div class="input-group-btn">
@@ -545,7 +551,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       })
     );
     await render(hbs`
-        <BsForm::Element @property="name" @model={{model}} />
+        <BsForm::Element @property="name" @model={{this.model}} />
     `);
     await focus('input');
     await blur('input');
@@ -557,7 +563,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
   test('shows validation success', async function (assert) {
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
-        <BsForm::Element @property="name" @showAllValidations={{true}} @hasValidator={{true}} @model={{model}} />
+        <BsForm::Element @property="name" @showAllValidations={{true}} @hasValidator={{true}} @model={{this.model}} />
     `);
     assert
       .dom(formFeedbackElement())
@@ -568,7 +574,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('errors', A(['Invalid']));
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} />
     `);
     assert
       .dom(formFeedbackElement())
@@ -591,7 +597,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('warnings', A(['Insecure']));
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @warnings={{warnings}} @model={{model}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @warnings={{this.warnings}} @model={{this.model}} />
     `);
     assert
       .dom(formFeedbackElement())
@@ -617,7 +623,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('model', EmberObject.create({ name: null }));
     this.set('error', 'some error');
     await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @customError={{error}} @model={{model}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @customError={{this.error}} @model={{this.model}} />
     `);
     assert.dom(formFeedbackElement()).hasClass(validationErrorClass(), 'custom error is shown immediately');
     assert.dom(`.form-group .${formFeedbackClass()}`).hasText('some error');
@@ -633,7 +639,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('model', EmberObject.create({ name: null }));
     this.set('warning', 'some warning');
     await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @customWarning={{warning}} @model={{model}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @customWarning={{this.warning}} @model={{this.model}} />
     `);
     assert.dom(formFeedbackElement()).hasClass(validationWarningClass(), 'custom warning is shown immediately');
     assert.dom(`.form-group .${formFeedbackClass()}`).hasText('some warning');
@@ -650,7 +656,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('warning', 'some warning');
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{errors}} @customWarning={{warning}} @model={{model}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{this.errors}} @customWarning={{this.warning}} @model={{this.model}} />
     `);
     assert
       .dom(formFeedbackElement())
@@ -684,7 +690,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       this.set('model', EmberObject.create({ name: null }));
       this.set('showValidationOn', ['change']);
       await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} @showValidationOn={{showValidationOn}} />
+        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} @showValidationOn={{this.showValidationOn}} />
     `);
       assert
         .dom(formFeedbackElement())
@@ -708,7 +714,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       this.set('errors', A(['Invalid']));
       this.set('model', EmberObject.create({ name: null }));
       await render(hbs`
-        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} @showValidationOn="change" />
+        <BsForm::Element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} @showValidationOn="change" />
     `);
       assert
         .dom(formFeedbackElement())
@@ -730,7 +736,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
       <BsForm as |form|>
-        <form.element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} as |el|>
+        <form.element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} as |el|>
           <div class="input-group">
             <span class="input-group-btn">
               <button class="btn btn-default" type="button">Button</button>
@@ -751,7 +757,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
     this.set('model', EmberObject.create({ name: null }));
     await render(hbs`
       <BsForm as |form|>
-        <form.element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} as |el|>
+        <form.element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} as |el|>
           <div class="input-group mb-3">
             <div class="input-group-prepend">
               <button class="btn btn-outline-secondary" type="button">Button</button>
@@ -775,7 +781,7 @@ module('Integration | Component | bs-form/element', function (hooks) {
       this.set('model', EmberObject.create({ name: null }));
       await render(hbs`
       <BsForm as |form|>
-        <form.element @property="name" @hasValidator={{true}} @errors={{errors}} @model={{model}} @doNotShowValidationForEventTargets={{doNotShowValidationForEventTargets}} as |el|>
+        <form.element @property="name" @hasValidator={{true}} @errors={{this.errors}} @model={{this.model}} @doNotShowValidationForEventTargets={{this.doNotShowValidationForEventTargets}} as |el|>
           {{el.control}}
           <button type="button" data-trigger-validation="false">Test</button>
         </form.element>

--- a/tests/integration/components/bs-form/element/errors-test.js
+++ b/tests/integration/components/bs-form/element/errors-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | bs form/element/errors', function (hooks) {
   test('is empty by default', async function (assert) {
     this.set('messages', ['foo', 'bar']);
 
-    await render(hbs`<BsForm::Element::Errors @show={{false}} @messages={{messages}} />`);
+    await render(hbs`<BsForm::Element::Errors @show={{false}} @messages={{this.messages}} />`);
 
     assert.dom(`.${formFeedbackClass()}`).doesNotExist();
   });
@@ -21,7 +21,7 @@ module('Integration | Component | bs form/element/errors', function (hooks) {
   test('shows first message', async function (assert) {
     this.set('messages', A(['foo', 'bar']));
 
-    await render(hbs`<BsForm::Element::Errors @show={{true}} @messages={{messages}} />`);
+    await render(hbs`<BsForm::Element::Errors @show={{true}} @messages={{this.messages}} />`);
 
     assert.dom(`.${formFeedbackClass()}`).exists({ count: 1 });
     assert.dom(`.${formFeedbackClass()}`).hasText('foo');
@@ -29,7 +29,9 @@ module('Integration | Component | bs form/element/errors', function (hooks) {
 
   test('shows multiple errors', async function (assert) {
     this.set('messages', A(['foo', 'bar']));
-    await render(hbs`<BsForm::Element::Errors @messages={{messages}} @show={{true}} @showMultipleErrors={{true}} />`);
+    await render(
+      hbs`<BsForm::Element::Errors @messages={{this.messages}} @show={{true}} @showMultipleErrors={{true}} />`
+    );
     assert.dom(`.${formFeedbackClass()}`).exists({ count: 2 });
     assert.dom(`.${formFeedbackClass()}:first-child`).hasText('foo');
     assert.dom(`.${formFeedbackClass()}:last-child`).hasText('bar');

--- a/tests/integration/components/bs-form/group-test.js
+++ b/tests/integration/components/bs-form/group-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | bs-form/group', function (hooks) {
 
   async function testValidationState(assert, state) {
     let validationConfig = validations[state];
-    await render(hbs`<BsForm::Group @validation={{validation}}></BsForm::Group>`);
+    await render(hbs`<BsForm::Group @validation={{this.validation}}></BsForm::Group>`);
     this.set('validation', state);
     validationConfig.formGroupClasses.forEach((className) => {
       assert.dom(`.${className}`).exists(`component has ${className} class`);

--- a/tests/integration/components/bs-modal-simple-test.js
+++ b/tests/integration/components/bs-modal-simple-test.js
@@ -89,7 +89,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test('open property shows modal', async function (assert) {
     this.set('open', false);
     await render(
-      hbs`<BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{open}}>Hello world!</BsModalSimple>`
+      hbs`<BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{this.open}}>Hello world!</BsModalSimple>`
     );
 
     assert.dom('.modal').doesNotExist('Modal is hidden');
@@ -107,7 +107,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
 
   testRequiringTransitions('open property shows modal [fade]', async function (assert) {
     this.set('open', false);
-    await render(hbs`<BsModalSimple @title="Simple Dialog" @open={{open}}>Hello world!</BsModalSimple>`);
+    await render(hbs`<BsModalSimple @title="Simple Dialog" @open={{this.open}}>Hello world!</BsModalSimple>`);
 
     assert.dom('.modal').doesNotExist('Modal is hidden');
     this.set('open', true);
@@ -123,7 +123,9 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
 
   test('closeButton property shows close button', async function (assert) {
     this.set('closeButton', false);
-    await render(hbs`<BsModalSimple @title="Simple Dialog" @closeButton={{closeButton}}>Hello world!</BsModalSimple>`);
+    await render(
+      hbs`<BsModalSimple @title="Simple Dialog" @closeButton={{this.closeButton}}>Hello world!</BsModalSimple>`
+    );
 
     assert.dom('.modal .modal-header .close').doesNotExist('Modal has no close button');
     this.set('closeButton', true);
@@ -132,7 +134,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
 
   test('fade property toggles fade effect', async function (assert) {
     this.set('fade', false);
-    await render(hbs`<BsModalSimple @title="Simple Dialog" @fade={{fade}}>Hello world!</BsModalSimple>`);
+    await render(hbs`<BsModalSimple @title="Simple Dialog" @fade={{this.fade}}>Hello world!</BsModalSimple>`);
     assert.dom('.modal').hasNoClass('fade', 'Modal has no fade class');
     this.set('fade', true);
     assert.dom('.modal').hasClass('fade', 'Modal has fade class');
@@ -212,7 +214,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
     this.actions.openAction = showSpy;
     this.actions.openedAction = shownSpy;
     await render(
-      hbs`<BsModalSimple @title="Simple Dialog" @onShow={{action "openAction"}} @onShown={{action "openedAction"}} @open={{open}} @fade={{false}}>Hello world!</BsModalSimple>`
+      hbs`<BsModalSimple @title="Simple Dialog" @onShow={{action "openAction"}} @onShown={{action "openedAction"}} @open={{this.open}} @fade={{false}}>Hello world!</BsModalSimple>`
     );
 
     this.set('open', true);
@@ -229,7 +231,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
     this.actions.openAction = showSpy;
     this.actions.openedAction = shownSpy;
     await render(
-      hbs`<BsModalSimple @title="Simple Dialog" @onShow={{action "openAction"}} @onShown={{action "openedAction"}} @open={{open}}>Hello world!</BsModalSimple>`
+      hbs`<BsModalSimple @title="Simple Dialog" @onShow={{action "openAction"}} @onShown={{action "openedAction"}} @open={{this.open}}>Hello world!</BsModalSimple>`
     );
 
     this.set('open', true);
@@ -257,7 +259,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
     let hiddenSpy = sinon.spy();
     this.actions.testAction = hiddenSpy;
     await render(
-      hbs`<BsModalSimple @title="Simple Dialog" @onHidden={{action "testAction"}} @open={{open}}>Hello world!</BsModalSimple>`
+      hbs`<BsModalSimple @title="Simple Dialog" @onHidden={{action "testAction"}} @open={{this.open}}>Hello world!</BsModalSimple>`
     );
 
     this.set('open', false);
@@ -308,7 +310,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   testRequiringFocus('autofocus element is focused when present and fade=false', async function (assert) {
     this.set('open', false);
     await render(hbs`
-      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{open}}>
+      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{this.open}}>
         <input data-test-autofocus autofocus="autofocus">
       </BsModalSimple>
     `);
@@ -331,7 +333,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   testRequiringFocus('modal is focused when opened later', async function (assert) {
     this.set('open', false);
     await render(hbs`
-      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{open}}>
+      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{this.open}}>
         Hallo
       </BsModalSimple>
     `);
@@ -372,7 +374,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
     this.set('open', false);
     await render(hbs`
       <button type="button" data-test-button>Open</button>
-      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{open}}>
+      <BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{this.open}}>
         Hallo
       </BsModalSimple>
     `);
@@ -481,7 +483,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test("Renders in wormhole's default destination if renderInPlace is not set", async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`
+      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if this.show}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`
     );
     this.set('show', true);
     await settled();
@@ -493,7 +495,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test('Renders in test container if renderInPlace is not set', async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="wrapper">{{#if show}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}</div>`
+      hbs`<div id="wrapper">{{#if this.show}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}</div>`
     );
     this.set('show', true);
     await settled();
@@ -505,7 +507,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test('Renders in place (no wormhole) if renderInPlace is set', async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}<BsModalSimple @title="Simple Dialog" @renderInPlace={{true}}>Hello world!</BsModalSimple>{{/if}}</div>`
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if this.show}}<BsModalSimple @title="Simple Dialog" @renderInPlace={{true}}>Hello world!</BsModalSimple>{{/if}}</div>`
     );
     this.set('show', true);
 
@@ -514,7 +516,9 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
 
   test('Removes "modal-open" class when component is removed from view', async function (assert) {
     this.set('renderComponent', true);
-    await render(hbs`{{#if renderComponent}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`);
+    await render(
+      hbs`{{#if this.renderComponent}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`
+    );
 
     // wait for fade animation
     await waitUntil(() => this.element.querySelector('.modal').classList.contains(visibilityClass()));
@@ -528,7 +532,9 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test('Resets scroll bar when component is removed from view', async function (assert) {
     document.body.style.paddingRight = '50px';
     this.set('renderComponent', true);
-    await render(hbs`{{#if renderComponent}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`);
+    await render(
+      hbs`{{#if this.renderComponent}}<BsModalSimple @title="Simple Dialog">Hello world!</BsModalSimple>{{/if}}`
+    );
 
     await waitUntil(() => this.element.querySelector('.modal').classList.contains(visibilityClass()));
 
@@ -570,7 +576,7 @@ module('Integration | Component | bs-modal-simple', function (hooks) {
   test('closing modal does not modify public open property', async function (assert) {
     this.set('open', true);
     await render(
-      hbs`<BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{open}}>Hello world!</BsModalSimple>`
+      hbs`<BsModalSimple @title="Simple Dialog" @fade={{false}} @open={{this.open}}>Hello world!</BsModalSimple>`
     );
     await click('.modal .modal-header .close');
     assert.equal(this.open, true, 'DOes not change open property');

--- a/tests/integration/components/bs-modal/footer-test.js
+++ b/tests/integration/components/bs-modal/footer-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | bs-modal/footer', function (hooks) {
 
   test('submitDisabled disables submit button', async function (assert) {
     this.set('disabled', true);
-    await render(hbs`<BsModal::Footer @closeTitle="close" @submitTitle="submit" @submitDisabled={{disabled}} />`);
+    await render(hbs`<BsModal::Footer @closeTitle="close" @submitTitle="submit" @submitDisabled={{this.disabled}} />`);
 
     assert.dom('.modal-footer button').exists({ count: 2 }, 'Modal footer has two button.');
     assert.notOk(

--- a/tests/integration/components/bs-navbar-test.js
+++ b/tests/integration/components/bs-navbar-test.js
@@ -189,7 +189,7 @@ module('Integration | Component | bs-navbar', function (hooks) {
 
     this.set('collapsed', true);
     await render(hbs`
-      {{#bs-navbar as collapsed=collapsed onExpanded=(action "expandedAction") as |navbar|}}
+      {{#bs-navbar collapsed=this.collapsed onExpanded=(action "expandedAction") as |navbar|}}
         <div class="navbar-header">
           {{navbar.toggle}}
           <a class="navbar-brand" href="#">Brand</a>
@@ -214,7 +214,7 @@ module('Integration | Component | bs-navbar', function (hooks) {
 
     this.set('collapsed', false);
     await render(hbs`
-      {{#bs-navbar as collapsed=collapsed onCollapsed=(action "collapsedAction") as |navbar|}}
+      {{#bs-navbar collapsed=this.collapsed onCollapsed=(action "collapsedAction") as |navbar|}}
         <div class="navbar-header">
           {{navbar.toggle}}
           <a class="navbar-brand" href="#">Brand</a>
@@ -242,7 +242,7 @@ module('Integration | Component | bs-navbar', function (hooks) {
     this.actions.expandedAction = expandedAction;
 
     await render(hbs`
-      {{#bs-navbar as collapsed=true onExpand=(action "expandAction") onExpanded=(action "expandedAction") as |navbar|}}
+      {{#bs-navbar collapsed=true onExpand=(action "expandAction") onExpanded=(action "expandedAction") as |navbar|}}
         <div class="navbar-header">
           {{navbar.toggle}}
           <a class="navbar-brand" href="#">Brand</a>
@@ -270,7 +270,7 @@ module('Integration | Component | bs-navbar', function (hooks) {
     this.actions.collapsedAction = collapsedAction;
 
     await render(hbs`
-      {{#bs-navbar as collapsed=false onCollapse=(action "collapseAction") onCollapsed=(action "collapsedAction") as |navbar|}}
+      {{#bs-navbar collapsed=false onCollapse=(action "collapseAction") onCollapsed=(action "collapsedAction") as |navbar|}}
         <div class="navbar-header">
           {{navbar.toggle}}
           <a class="navbar-brand" href="#">Brand</a>
@@ -338,7 +338,7 @@ module('Integration | Component | bs-navbar', function (hooks) {
   test('clicking the toggle does not modify the public collapsed property', async function (assert) {
     this.set('collapsed', true);
     await render(hbs`
-      <BsNavbar @collapsed={{collapsed}} as |navbar|>
+      <BsNavbar @collapsed={{this.collapsed}} as |navbar|>
         <div class="navbar-header">
           {{navbar.toggle}}
           <a class="navbar-brand" href="#">Brand</a>

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -40,7 +40,7 @@ module('Integration | Component | bs-popover', function (hooks) {
     this.set('placement', placements[0]);
     await render(hbs`
       <div id="wrapper">
-        <BsPopover::Element @id="popover-element" @placement={{placement}} @title="dummy title">
+        <BsPopover::Element @id="popover-element" @placement={{this.placement}} @title="dummy title">
           template block text
         </BsPopover::Element>
       </div>
@@ -128,7 +128,7 @@ module('Integration | Component | bs-popover', function (hooks) {
     this.set('hidden', hiddenAction);
     await render(hbs`
       <div id="target">
-        <BsPopover @visible={{true}} @onHide={{action hide}} @onHidden={{action hidden}} as |po|>
+        <BsPopover @visible={{true}} @onHide={{action this.hide}} @onHidden={{action this.hidden}} as |po|>
           <div id="hide" {{action po.close}} role="button">Hide</div>
         </BsPopover>
       </div>
@@ -213,7 +213,7 @@ module('Integration | Component | bs-popover', function (hooks) {
   test("Renders in wormhole's default destination if renderInPlace is not set", async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} />{{/if}}`
+      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if this.show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} />{{/if}}`
     );
     this.set('show', true);
     await settled();
@@ -223,7 +223,7 @@ module('Integration | Component | bs-popover', function (hooks) {
 
   test('Renders in test container if renderInPlace is not set', async function (assert) {
     this.set('show', false);
-    await render(hbs`{{#if show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} />{{/if}}`);
+    await render(hbs`{{#if this.show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} />{{/if}}`);
     this.set('show', true);
     await settled();
 
@@ -234,7 +234,7 @@ module('Integration | Component | bs-popover', function (hooks) {
   test('Renders in place (no wormhole) if renderInPlace is set', async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} @renderInPlace={{true}} />{{/if}}</div>`
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if this.show}}<BsPopover @title="Simple popover" @visible={{true}} @fade={{false}} @renderInPlace={{true}} />{{/if}}</div>`
     );
     this.set('show', true);
     await settled();

--- a/tests/integration/components/bs-progress-test.js
+++ b/tests/integration/components/bs-progress-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | bs-progress', function (hooks) {
     await render(hbs`
       <div class="width-500">
         <BsProgress as |p|>
-          <p.bar @value={{value}} @minValue={{minValue}} @maxValue={{maxValue}} />
+          <p.bar @value={{this.value}} @minValue={{this.minValue}} @maxValue={{this.maxValue}} />
         </BsProgress>
       </div>
     `);

--- a/tests/integration/components/bs-tab-test.js
+++ b/tests/integration/components/bs-tab-test.js
@@ -132,7 +132,7 @@ module('Integration | Component | bs-tab', function (hooks) {
   test('activeId activates tabs', async function (assert) {
     this.set('paneId', 'pane1');
     await render(hbs`
-      <BsTab @fade={{false}} @activeId={{paneId}} as |tab|>
+      <BsTab @fade={{false}} @activeId={{this.paneId}} as |tab|>
         <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
         </tab.pane>
@@ -171,7 +171,7 @@ module('Integration | Component | bs-tab', function (hooks) {
   test('activeId activates tabs [fade]', async function (assert) {
     this.set('paneId', 'pane1');
     await render(hbs`
-      <BsTab @fade={{true}} @activeId={{paneId}} as |tab|>
+      <BsTab @fade={{true}} @activeId={{this.paneId}} as |tab|>
         <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
         </tab.pane>
@@ -309,7 +309,7 @@ module('Integration | Component | bs-tab', function (hooks) {
   test('changing active tab does not change public activeId property (DDAU)', async function (assert) {
     this.set('paneId', 'pane1');
     await render(hbs`
-      <BsTab @fade={{false}} @activeId={{paneId}} as |tab|>
+      <BsTab @fade={{false}} @activeId={{this.paneId}} as |tab|>
         <tab.pane @id="pane1" @title="Tab 1">
           tabcontent 1
         </tab.pane>

--- a/tests/integration/components/bs-tab/pane-test.js
+++ b/tests/integration/components/bs-tab/pane-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | bs-tab/pane', function (hooks) {
   test('it has correct markup when switching active pane and fade=false', async function (assert) {
     this.set('activeId', null);
     await render(hbs`
-      <BsTab::Pane @fade={{false}} @activeId={{activeId}} @id="pane1">
+      <BsTab::Pane @fade={{false}} @activeId={{this.activeId}} @id="pane1">
         template block text
       </BsTab::Pane>
     `);
@@ -47,7 +47,7 @@ module('Integration | Component | bs-tab/pane', function (hooks) {
   testRequiringTransitions('it has correct markup when switching active pane and fade=true', async function (assert) {
     this.set('activeId', null);
     await render(hbs`
-      <BsTab::Pane @fade={{true}} @activeId={{activeId}} @id="pane1">
+      <BsTab::Pane @fade={{true}} @activeId={{this.activeId}} @id="pane1">
         template block text
       </BsTab::Pane>
     `);

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -54,7 +54,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     let placements = ['top', 'left', 'bottom', 'right'];
     this.set('placement', placements[0]);
     await render(hbs`
-      <BsTooltip::Element @id="tooltip-element" @placement={{placement}}>
+      <BsTooltip::Element @id="tooltip-element" @placement={{this.placement}}>
         template block text
       </BsTooltip::Element>
     `);
@@ -243,7 +243,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test("Renders in wormhole's default destination if renderInPlace is not set", async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} />{{/if}}`
+      hbs`<div id="ember-bootstrap-wormhole"></div>{{#if this.show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} />{{/if}}`
     );
     this.set('show', true);
     await settled();
@@ -253,7 +253,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('Renders in test container if renderInPlace is not set', async function (assert) {
     this.set('show', false);
-    await render(hbs`{{#if show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} />{{/if}}`);
+    await render(hbs`{{#if this.show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} />{{/if}}`);
     this.set('show', true);
     await settled();
 
@@ -264,7 +264,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('Renders in place (no wormhole) if renderInPlace is set', async function (assert) {
     this.set('show', false);
     await render(
-      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} @renderInPlace={{true}} />{{/if}}</div>`
+      hbs`<div id="ember-bootstrap-wormhole"></div><div id="wrapper">{{#if this.show}}<BsTooltip @title="Simple Tooltip" @visible={{true}} @fade={{false}} @renderInPlace={{true}} />{{/if}}</div>`
     );
     this.set('show', true);
     await settled();
@@ -295,7 +295,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
     await render(hbs`
       <div id="wrapper">
-        {{#if visible}}
+        {{#if this.visible}}
           <p class="margin-top">
             <a href="#" id="target">
               Hover me<BsTooltip @title="very very very very very very very long tooltip" @fade={{false}} @visible={{true}} />
@@ -318,7 +318,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
       <div id="wrapper">
         <p class="margin-top">
           <a href="#" id="target">
-            Hover me<BsTooltip @title="very very very very very very very long tooltip" @fade={{false}} @visible={{visible}} />
+            Hover me<BsTooltip @title="very very very very very very very long tooltip" @fade={{false}} @visible={{this.visible}} />
           </a>
         </p>
       </div>`);
@@ -468,7 +468,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     this.set('hidden', hiddenAction);
     await render(hbs`
       <div id="target">
-        <BsTooltip @visible={{true}} @onHide={{action hide}} @onHidden={{action hidden}} as |tt|>
+        <BsTooltip @visible={{true}} @onHide={{action this.hide}} @onHidden={{action this.hidden}} as |tt|>
           <div id="hide" {{action tt.close}} role="button">Hide</div>
         </BsTooltip>
       </div>`);


### PR DESCRIPTION
Implicit `this` fallback triggers a deprecation in canary now. We still had many implicit `this` fallbacks in tests. I activated the template lint rule and fixed all of them manually.

I did not touched the documentation app. That one still has many implicit this fallbacks. I decided to skip that one as it does neither affect consumers application nor our tests.

This is not the only deprecation added in canary. Additionally I see this deprecation in CI log:

> Versions of modifier manager capabilities prior to 3.22 have been deprecated. You must update to the 3.22 capabilities.

As it's not related it is better addressed by a separate pull request in my opinion. It needs to be fixed upstream first: https://github.com/ember-modifier/ember-modifier/pull/63