### PR TITLE
Fix deprecations failing the build

### DIFF
--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -4,12 +4,17 @@ import { registerDeprecationHandler } from '@ember/debug';
 let isRegistered = false;
 let deprecations;
 
+// Ignore deprecations that are not caused by our own code, and which we cannot fix easily.
+const ignoredDeprecations = [/Versions of modifier manager capabilities prior to 3\.22 have been deprecated/];
+
 export default function setupNoDeprecations({ beforeEach, afterEach }) {
   beforeEach(function () {
     deprecations = [];
     if (!isRegistered) {
       registerDeprecationHandler((message, options, next) => {
-        deprecations.push(message);
+        if (!ignoredDeprecations.some((regex) => message.match(regex))) {
+          deprecations.push(message);
+        }
         next(message, options);
       });
       isRegistered = true;

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -321,7 +321,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
       <dd.toggle>Dropdown</dd.toggle>
       <dd.menu as |menu|>
         <menu.item>
-          {{menu.link-to "Home" "index"}}
+          <menu.link-to @route="index">Home</menu.link-to>
         </menu.item>
       </dd.menu>
     </BsDropdown>`);

--- a/tests/integration/components/bs-dropdown/menu-test.js
+++ b/tests/integration/components/bs-dropdown/menu-test.js
@@ -58,8 +58,8 @@ module('Integration | Component | bs-dropdown/menu', function (hooks) {
       hbs`
       <BsDropdown as |dd|>
         <dd.menu @toggleElement={{this.element}} @isOpen={{true}} as |ddm|>
-          {{#ddm.link-to "index"}}Link{{/ddm.link-to}}
-          {{#ddm.linkTo "index"}}Link{{/ddm.linkTo}}
+          <ddm.link-to @route="index">Link</ddm.link-to>
+          <ddm.linkTo @route="index">Link</ddm.linkTo>
         </dd.menu>
       </BsDropdown>
     `

--- a/tests/integration/components/bs-dropdown/menu/link-to-test.js
+++ b/tests/integration/components/bs-dropdown/menu/link-to-test.js
@@ -4,13 +4,9 @@ import { render } from '@ember/test-helpers';
 import { testBS3, testBS4 } from '../../../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
-
-const supportsAngleBracketsLinkTo = hasEmberVersion(3, 10);
 
 module('Integration | Component | bs-dropdown/menu/link-to', function (hooks) {
   setupRenderingTest(hooks);
-  setupNoDeprecations(hooks);
   hooks.beforeEach(function () {
     this.owner.setupRouter();
   });
@@ -64,32 +60,30 @@ module('Integration | Component | bs-dropdown/menu/link-to', function (hooks) {
     });
   });
 
-  if (supportsAngleBracketsLinkTo) {
-    module('<LinkTo> properties', function () {
-      test('simple route link', async function (assert) {
-        await render(hbs`<BsDropdown::menu::link-to @route="index">Link</BsDropdown::menu::link-to>`);
+  module('<LinkTo> properties', function (hooks) {
+    setupNoDeprecations(hooks);
 
-        assert.dom('a').exists({ count: 1 });
-        assert.dom('a').hasText('Link');
-        assert.dom('a').hasAttribute('href', '/');
-      });
+    test('simple route link', async function (assert) {
+      await render(hbs`<BsDropdown::menu::link-to @route="index">Link</BsDropdown::menu::link-to>`);
 
-      test('link with model', async function (assert) {
-        await render(
-          hbs`<BsDropdown::menu::link-to @route="acceptance.link" @model="1" @query={{hash foo="bar"}}>Link</BsDropdown::menu::link-to>`
-        );
-
-        assert.dom('a').exists({ count: 1 });
-        assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
-      });
-
-      test('disabled link', async function (assert) {
-        await render(
-          hbs`<BsDropdown::menu::link-to @route="index" @disabled={{true}}>Link</BsDropdown::menu::link-to>`
-        );
-
-        assert.dom('a').hasClass('disabled');
-      });
+      assert.dom('a').exists({ count: 1 });
+      assert.dom('a').hasText('Link');
+      assert.dom('a').hasAttribute('href', '/');
     });
-  }
+
+    test('link with model', async function (assert) {
+      await render(
+        hbs`<BsDropdown::menu::link-to @route="acceptance.link" @model="1" @query={{hash foo="bar"}}>Link</BsDropdown::menu::link-to>`
+      );
+
+      assert.dom('a').exists({ count: 1 });
+      assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
+    });
+
+    test('disabled link', async function (assert) {
+      await render(hbs`<BsDropdown::menu::link-to @route="index" @disabled={{true}}>Link</BsDropdown::menu::link-to>`);
+
+      assert.dom('a').hasClass('disabled');
+    });
+  });
 });

--- a/tests/integration/components/bs-nav-test.js
+++ b/tests/integration/components/bs-nav-test.js
@@ -52,10 +52,10 @@ module('Integration | Component | bs-nav', function (hooks) {
     await render(hbs`
       <BsNav as |nav|>
         <nav.item>
-          {{#nav.link-to "application"}}Dummy{{/nav.link-to}}
+          <nav.link-to @route="application">Dummy</nav.link-to>
         </nav.item>
         <nav.item>
-          {{#nav.linkTo "application"}}Dummy{{/nav.linkTo}}
+          <nav.linkTo @route="application">Dummy</nav.linkTo>
         </nav.item>
         <nav.dropdown as |dd|>
           <dd.toggle>Dropdown <span class="caret"></span></dd.toggle>
@@ -76,10 +76,10 @@ module('Integration | Component | bs-nav', function (hooks) {
     await render(hbs`
       <BsNav as |nav|>
         <nav.item>
-          {{#nav.link-to "application"}}Dummy{{/nav.link-to}}
+          <nav.link-to @route="application">Dummy</nav.link-to>
         </nav.item>
         <nav.item>
-          {{#nav.linkTo "application"}}Dummy{{/nav.linkTo}}
+          <nav.linkTo @route="application">Dummy</nav.linkTo>
         </nav.item>
         <nav.dropdown as |dd|>
           <dd.toggle>Dropdown <span class="caret"></span></dd.toggle>

--- a/tests/integration/components/bs-nav/link-to-test.js
+++ b/tests/integration/components/bs-nav/link-to-test.js
@@ -4,13 +4,9 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import { testBS4 } from '../../../helpers/bootstrap';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
-
-const supportsAngleBracketsLinkTo = hasEmberVersion(3, 10);
 
 module('Integration | Component | bs-nav/link-to', function (hooks) {
   setupRenderingTest(hooks);
-  setupNoDeprecations(hooks);
   hooks.beforeEach(function () {
     this.owner.setupRouter();
   });
@@ -44,36 +40,36 @@ module('Integration | Component | bs-nav/link-to', function (hooks) {
     });
   });
 
-  if (supportsAngleBracketsLinkTo) {
-    module('<LinkTo> properties', function () {
-      test('simple route link', async function (assert) {
-        await render(hbs`<BsNav::link-to @route="index">Link</BsNav::link-to>`);
+  module('<LinkTo> properties', function (hooks) {
+    setupNoDeprecations(hooks);
 
-        assert.dom('a').exists({ count: 1 });
-        assert.dom('a').hasText('Link');
-        assert.dom('a').hasAttribute('href', '/');
-      });
+    test('simple route link', async function (assert) {
+      await render(hbs`<BsNav::link-to @route="index">Link</BsNav::link-to>`);
 
-      test('link with model', async function (assert) {
-        await render(
-          hbs`<BsNav::link-to @route="acceptance.link" @model="1" @query={{hash foo="bar"}}>Link</BsNav::link-to>`
-        );
-
-        assert.dom('a').exists({ count: 1 });
-        assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
-      });
-
-      testBS4('link has nav-link class', async function (assert) {
-        await render(hbs`<BsNav::link-to @route="index">Link</BsNav::link-to>`);
-
-        assert.dom('a').hasClass('nav-link');
-      });
-
-      test('disabled link', async function (assert) {
-        await render(hbs`<BsNav::link-to @route="index" @disabled={{true}}>Link</BsNav::link-to>`);
-
-        assert.dom('a').hasClass('disabled');
-      });
+      assert.dom('a').exists({ count: 1 });
+      assert.dom('a').hasText('Link');
+      assert.dom('a').hasAttribute('href', '/');
     });
-  }
+
+    test('link with model', async function (assert) {
+      await render(
+        hbs`<BsNav::link-to @route="acceptance.link" @model="1" @query={{hash foo="bar"}}>Link</BsNav::link-to>`
+      );
+
+      assert.dom('a').exists({ count: 1 });
+      assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
+    });
+
+    testBS4('link has nav-link class', async function (assert) {
+      await render(hbs`<BsNav::link-to @route="index">Link</BsNav::link-to>`);
+
+      assert.dom('a').hasClass('nav-link');
+    });
+
+    test('disabled link', async function (assert) {
+      await render(hbs`<BsNav::link-to @route="index" @disabled={{true}}>Link</BsNav::link-to>`);
+
+      assert.dom('a').hasClass('disabled');
+    });
+  });
 });


### PR DESCRIPTION
* ignore upstream deprecations we cannot influence here (modifier-manager)
* don't setup deprecation tracking for tests that test positional params in our `<LinkTo>` subclasses, as we have those tests for compatibility with that legacy API (positional params), but can regard that as deprecated from our side as well