### PR TITLE
Add test coverage for modal animation

### DIFF
--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find, triggerEvent, settled, waitFor, waitUntil } from '@ember/test-helpers';
-import { test, visibilityClass } from '../../helpers/bootstrap';
+import { test, testBS3, testBS4, visibilityClass } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
@@ -247,7 +247,30 @@ module('Integration | Component | bs-modal', function (hooks) {
     assert.dom('.modal').isVisible('Modal is visible again');
   });
 
-  test('it animates opening and closing the modal', async function (assert) {
+  testBS3('it animates opening and closing the modal', async function (assert) {
+    this.set('open', false);
+    await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
+
+    this.set('open', true);
+    await waitFor('.modal.show');
+    assert.dom('.modal').hasClass('show');
+
+    await settled();
+    assert.dom('.modal').hasClass('show');
+    assert.dom('.modal').hasClass('in');
+
+    this.set('open', false);
+    await waitUntil(() => {
+      return !find('.modal').classList.contains('in');
+    });
+    assert.dom('.modal').hasClass('show');
+    assert.dom('.modal').doesNotHaveClass('in');
+
+    await settled();
+    assert.dom('.modal').doesNotExist();
+  });
+
+  testBS4('it animates opening and closing the modal', async function (assert) {
     this.set('open', false);
     await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
 

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -253,7 +253,6 @@ module('Integration | Component | bs-modal', function (hooks) {
 
     this.set('open', true);
     await waitFor('.modal.show');
-    assert.dom('.modal').hasClass('show');
     assert.dom('.modal').hasStyle({ display: 'block' });
 
     await waitUntil(() => {
@@ -282,16 +281,12 @@ module('Integration | Component | bs-modal', function (hooks) {
         .map((animation) => animation.finished)
     );
 
-    // keep reference to modal element to compare with event target after modal has been destroyed
-    const modalEl = find('.modal');
-
     // close modal
     click('button');
 
     await waitUntil(() => {
-      return !modalEl.classList.contains(visibilityClass());
+      return !find('.modal').classList.contains(visibilityClass());
     });
-    assert.dom('.modal').doesNotHaveClass(visibilityClass);
     assert.dom('.modal').hasStyle({ display: 'block' });
 
     await waitUntil(() => {

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -301,5 +301,20 @@ module('Integration | Component | bs-modal', function (hooks) {
 
     await settled();
     assert.dom('.modal').doesNotExist();
+
+    await waitUntil(
+      () => {
+        return transitionEvents.find((event) => event.target === find('.modal') && event.propertyName === 'opacity');
+      },
+      {
+        timeoutMessage: 'awaiting modal closing transition timed out',
+      }
+    );
+    assert.ok(
+      // waitUntil condition already implicitly asserted that modal closing transition has run
+      // adding an explicit assertion to ease reading test log
+      true,
+      'modal closing was animated'
+    );
   });
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -251,13 +251,28 @@ module('Integration | Component | bs-modal', function (hooks) {
     this.set('open', false);
     await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
 
+    // record all transition events to assert against later
+    let transitionEvents = [];
+    this.element.addEventListener('transitionrun', (event) => {
+      transitionEvents.push(event);
+    });
+
     this.set('open', true);
-    await waitFor('.modal.show');
+    await waitFor('.modal');
     assert.dom('.modal').hasClass('show');
 
     await settled();
     assert.dom('.modal').hasClass('show');
     assert.dom('.modal').hasClass('in');
+
+    await waitUntil(
+      () => {
+        return transitionEvents.find((event) => event.target === find('.modal') && event.propertyName === 'opacity');
+      },
+      {
+        timeoutMessage: 'awaiting modal opening transition timed out',
+      }
+    );
 
     this.set('open', false);
     await waitUntil(() => {
@@ -274,14 +289,25 @@ module('Integration | Component | bs-modal', function (hooks) {
     this.set('open', false);
     await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
 
+    // record all transition events to assert against later
+    let transitionEvents = [];
+    this.element.addEventListener('transitionrun', (event) => {
+      transitionEvents.push(event);
+    });
+
     this.set('open', true);
     await waitFor('.modal.show');
     assert.dom('.modal').hasClass('show');
     assert.dom('.modal').hasStyle({ display: 'block' });
 
-    await settled();
-    assert.dom('.modal').hasClass('show');
-    assert.dom('.modal').hasStyle({ display: 'block' });
+    await waitUntil(
+      () => {
+        return transitionEvents.find((event) => event.target === find('.modal') && event.propertyName === 'opacity');
+      },
+      {
+        timeoutMessage: 'awaiting modal opening transition timed out',
+      }
+    );
 
     this.set('open', false);
     await waitUntil(() => {

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerEvent, settled } from '@ember/test-helpers';
+import { render, click, find, triggerEvent, settled, waitFor, waitUntil } from '@ember/test-helpers';
 import { test, visibilityClass } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -245,5 +245,29 @@ module('Integration | Component | bs-modal', function (hooks) {
     await settled();
 
     assert.dom('.modal').isVisible('Modal is visible again');
+  });
+
+  test('it animates opening and closing the modal', async function (assert) {
+    this.set('open', false);
+    await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
+
+    this.set('open', true);
+    await waitFor('.modal.show');
+    assert.dom('.modal').hasClass('show');
+    assert.dom('.modal').hasStyle({ display: 'block' });
+
+    await settled();
+    assert.dom('.modal').hasClass('show');
+    assert.dom('.modal').hasStyle({ display: 'block' });
+
+    this.set('open', false);
+    await waitUntil(() => {
+      return !find('.modal').classList.contains('show');
+    });
+    assert.dom('.modal').doesNotHaveClass('show');
+    assert.dom('.modal').hasStyle({ display: 'block' });
+
+    await settled();
+    assert.dom('.modal').doesNotExist();
   });
 });

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find, triggerEvent, settled, waitFor, waitUntil } from '@ember/test-helpers';
-import { isBootstrap, test, visibilityClass } from '../../helpers/bootstrap';
+import { isBootstrap, test, testNotBS3, visibilityClass } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
@@ -247,7 +247,7 @@ module('Integration | Component | bs-modal', function (hooks) {
     assert.dom('.modal').isVisible('Modal is visible again');
   });
 
-  test('it animates opening the modal', async function (assert) {
+  testNotBS3('it animates opening the modal', async function (assert) {
     this.set('open', false);
     await render(hbs`<BsModal @open={{this.open}}>Hello world!</BsModal>`);
 
@@ -272,7 +272,7 @@ module('Integration | Component | bs-modal', function (hooks) {
     );
   });
 
-  test('it animates closing the modal', async function (assert) {
+  testNotBS3('it animates closing the modal', async function (assert) {
     await render(hbs`
       <BsModal as |modal|>
         <button {{on "click" modal.close}} type="button">close</button>

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find, triggerEvent, settled, waitFor, waitUntil } from '@ember/test-helpers';
-import { isBootstrap, test, testNotBS3, visibilityClass } from '../../helpers/bootstrap';
+import { test, testNotBS3, visibilityClass } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
@@ -254,12 +254,7 @@ module('Integration | Component | bs-modal', function (hooks) {
     this.set('open', true);
     await waitFor('.modal.show');
     assert.dom('.modal').hasClass('show');
-    if (isBootstrap(3)) {
-      assert.dom('.modal').hasClass('in');
-    }
-    if (isBootstrap(4)) {
-      assert.dom('.modal').hasStyle({ display: 'block' });
-    }
+    assert.dom('.modal').hasStyle({ display: 'block' });
 
     await waitUntil(() => {
       return find('.modal').getAnimations().length > 0;
@@ -297,12 +292,7 @@ module('Integration | Component | bs-modal', function (hooks) {
       return !modalEl.classList.contains(visibilityClass());
     });
     assert.dom('.modal').doesNotHaveClass(visibilityClass);
-    if (isBootstrap(3)) {
-      assert.dom('.modal').hasClass('show');
-    }
-    if (isBootstrap(4)) {
-      assert.dom('.modal').hasStyle({ display: 'block' });
-    }
+    assert.dom('.modal').hasStyle({ display: 'block' });
 
     await waitUntil(() => {
       return find('.modal').getAnimations().length > 0;


### PR DESCRIPTION
This adds test coverage for modal animation. It encodes the results of my investigation on the topic documented in https://github.com/kaliber5/ember-bootstrap/pull/1402/files#r605945018. I thought it might be helpful to get this in before #1402. And maybe even if I don't find the time to finish that one.