### PR TITLE
Re-add broken fade arg to BsAlert component

### DIFF
--- a/addon/components/bs-alert.js
+++ b/addon/components/bs-alert.js
@@ -104,6 +104,8 @@ export default class Alert extends Component {
    * @default true
    * @public
    */
+  @arg
+  fade = true;
 
   get showAlert() {
     return this._visible && this.args.fade !== false;


### PR DESCRIPTION
Looks like [this PR](https://github.com/kaliber5/ember-bootstrap/pull/1224/files#diff-70e754d719d2e6b45827cb320ec7224ae80cae42862141739894b6be65c1f24bL99) removed the `fade` property from the bs-alert component. In the current version, whatever you set `fade` to, it will always be false and the 'fade' class is never added.

The alt approach to fix this is to just change `this.fade` to `this.args.fade` in the template, but I went this way because of the documented default of true that is still in the js file.