### PR TITLE
Fix CI for running Firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn test:ember
 
   test-try:
-    name: Scenario Tests
+    name: Scenario ${{ matrix.scenario }}, BS${{ matrix.bootstrap }}, ${{ matrix.browser}}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failure || false }}
     needs:
@@ -71,9 +71,15 @@ jobs:
           - 3
           - 4
           - 5
+        browser:
+          - Chrome
         include:
           - scenario: ember-release
-            command: ember test --launch Firefox
+            browser: Firefox
+            bootstrap: 4
+          - scenario: ember-release
+            browser: Firefox
+            bootstrap: 5
           - scenario: node-tests
 #          - scenario: embroider-safe
 #            allow-failure: true
@@ -89,7 +95,7 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Test
-        run: yarn ember try:one ${{ matrix.scenario }} --- ${{ matrix.command }}
+        run: yarn ember try:one ${{ matrix.scenario }} --- ember test --launch ${{ matrix.browser }}
         env:
           BOOTSTRAPVERSION: ${{ matrix.bootstrap }}
 


### PR DESCRIPTION
Previously the explicit scenario for Firefox w/ ember-release in `included` would override the default ember-release scenario, i.e. ember-release would not run in Chrome.