### PR TITLE
forward arguments in <BsNavbar::LinkTo> to <BsLinkTo>

### DIFF
--- a/addon/components/bs-navbar/link-to.hbs
+++ b/addon/components/bs-navbar/link-to.hbs
@@ -1,11 +1,11 @@
 <BsLinkTo
-  @route={{this.route}}
-  @model={{this.model}}
-  @models={{this.models}}
-  @query={{this.query}}
+  @route={{@route}}
+  @model={{@model}}
+  @models={{@models}}
+  @query={{@query}}
   @disabled={{@disabled}}
-  {{on "click" this.onClick}}
   ...attributes
+  {{on 'click' this.onClick}}
 >
   {{yield}}
 </BsLinkTo>

--- a/addon/components/bs-navbar/link-to.hbs
+++ b/addon/components/bs-navbar/link-to.hbs
@@ -4,8 +4,8 @@
   @models={{@models}}
   @query={{@query}}
   @disabled={{@disabled}}
-  ...attributes
   {{on 'click' this.onClick}}
+  ...attributes
 >
   {{yield}}
 </BsLinkTo>

--- a/tests/integration/components/bs-navbar-test.js
+++ b/tests/integration/components/bs-navbar-test.js
@@ -402,6 +402,8 @@ module('Integration | Component | bs-navbar', function (hooks) {
     let collapseAction = sinon.spy();
     this.actions.collapseAction = collapseAction;
 
+    this.owner.setupRouter();
+
     await render(hbs`
       <BsNavbar @collapsed={{false}} @onCollapse={{action "collapseAction"}} as |navbar|>
         <div class="navbar-header">
@@ -421,6 +423,8 @@ module('Integration | Component | bs-navbar', function (hooks) {
   });
 
   test('it passes accessibility checks', async function (assert) {
+    this.owner.setupRouter();
+
     await render(hbs`
       <BsNavbar as |navbar|>
         <div class="navbar-header">


### PR DESCRIPTION
Due to this bug `<BsNavbar>` was basically unusable. It was introduced in #1455, which has not been released yet. I have only noticed accidentally when trying to fix the docs app.

The bug uncovers a lack in our test coverage. I think we could cover at least some cases by tests if asserting for `href` attribute in an integration test or by using an acceptance test. Will try to investigate that one later.

I think we should add tests before merging. But feel free to merge without tests if it blocks a release otherwise.