### PR TITLE
Allow template only imports to resolve correctly

### DIFF
--- a/addon/components/bs-modal-simple.js
+++ b/addon/components/bs-modal-simple.js
@@ -277,5 +277,5 @@
  * @default null
  * @public
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal-simple.js
+++ b/addon/components/bs-modal-simple.js
@@ -277,3 +277,5 @@
  * @default null
  * @public
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();

--- a/addon/components/bs-modal/body.js
+++ b/addon/components/bs-modal/body.js
@@ -7,3 +7,5 @@
  @extends Glimmer.Component
  @public
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();

--- a/addon/components/bs-modal/body.js
+++ b/addon/components/bs-modal/body.js
@@ -7,5 +7,5 @@
  @extends Glimmer.Component
  @public
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal/footer.js
+++ b/addon/components/bs-modal/footer.js
@@ -64,5 +64,5 @@
  * @event onClose
  * @public
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal/footer.js
+++ b/addon/components/bs-modal/footer.js
@@ -64,3 +64,5 @@
  * @event onClose
  * @public
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();

--- a/addon/components/bs-modal/header.js
+++ b/addon/components/bs-modal/header.js
@@ -42,5 +42,5 @@
  * @event onClose
  * @public
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal/header.js
+++ b/addon/components/bs-modal/header.js
@@ -42,3 +42,5 @@
  * @event onClose
  * @public
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();

--- a/addon/components/bs-modal/header/close.js
+++ b/addon/components/bs-modal/header/close.js
@@ -10,3 +10,5 @@
  * @event onClick
  * @public
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();

--- a/addon/components/bs-modal/header/close.js
+++ b/addon/components/bs-modal/header/close.js
@@ -10,5 +10,5 @@
  * @event onClick
  * @public
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal/header/title.js
+++ b/addon/components/bs-modal/header/title.js
@@ -5,5 +5,5 @@
  @extends Glimmer.Component
  @private
  */
- import templateOnly from '@ember/component/template-only';
- export default templateOnly();
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-modal/header/title.js
+++ b/addon/components/bs-modal/header/title.js
@@ -5,3 +5,5 @@
  @extends Glimmer.Component
  @private
  */
+ import templateOnly from '@ember/component/template-only';
+ export default templateOnly();


### PR DESCRIPTION
While adding `@embroider/test-setup` to ember-cp-validation ran into an issue: 

```
Build Error (PackagerRunner) in components/bs-modal-simple.js

Module not found: Error: Can't resolve '../../../node_modules/ember-bootstrap/components/bs-modal-simple' in '$TMPDIR/embroider/02a8a6/tests/dummy/components/bs-modal-simple.js'
```

This PR connects the components inside of app so that the addon namespace template only components can resolve correctly.

CC: @rwjblue 