### PR TITLE
refactor to async/await instead of callbacks in BsModal

### DIFF
--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -12,6 +12,10 @@ import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 import arg from '../utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
 
+function nextRunloop() {
+  return new Promise((resolve) => next(resolve));
+}
+
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with custom markup.
 
@@ -416,7 +420,7 @@ export default class Modal extends Component {
    * @method show
    * @private
    */
-  show() {
+  async show() {
     if (this._isOpen) {
       return;
     }
@@ -425,36 +429,34 @@ export default class Modal extends Component {
     this.addBodyClass();
     this.resize();
 
-    let callback = () => {
-      if (this.isDestroyed) {
+    this.inDom = true;
+
+    await this.handleBackdrop();
+
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.checkScrollbar();
+    this.setScrollbar();
+
+    schedule('afterRender', async () => {
+      let modalEl = this.modalElement;
+      if (!modalEl) {
         return;
       }
 
-      this.checkScrollbar();
-      this.setScrollbar();
+      modalEl.scrollTop = 0;
+      this.adjustDialog();
+      this.showModal = true;
+      this.args.onShow?.();
 
-      schedule('afterRender', () => {
-        let modalEl = this.modalElement;
-        if (!modalEl) {
-          return;
-        }
+      if (this.usesTransition) {
+        await transitionEnd(this.modalElement, this.transitionDuration);
+      }
 
-        modalEl.scrollTop = 0;
-        this.adjustDialog();
-        this.showModal = true;
-        this.args.onShow?.();
-
-        if (this.usesTransition) {
-          transitionEnd(this.modalElement, this.transitionDuration).then(() => {
-            this.args.onShown?.();
-          });
-        } else {
-          this.args.onShown?.();
-        }
-      });
-    };
-    this.inDom = true;
-    this.handleBackdrop(callback);
+      this.args.onShown?.();
+    });
   }
 
   /**
@@ -463,7 +465,7 @@ export default class Modal extends Component {
    * @method hide
    * @private
    */
-  hide() {
+  async hide() {
     if (!this._isOpen) {
       return;
     }
@@ -473,10 +475,10 @@ export default class Modal extends Component {
     this.showModal = false;
 
     if (this.usesTransition) {
-      transitionEnd(this.modalElement, this.transitionDuration).then(() => this.hideModal());
-    } else {
-      this.hideModal();
+      await transitionEnd(this.modalElement, this.transitionDuration);
     }
+
+    this.hideModal();
   }
 
   /**
@@ -485,18 +487,18 @@ export default class Modal extends Component {
    * @method hideModal
    * @private
    */
-  hideModal() {
+  async hideModal() {
     if (this.isDestroyed) {
       return;
     }
 
-    this.handleBackdrop(() => {
-      this.removeBodyClass();
-      this.resetAdjustments();
-      this.resetScrollbar();
-      this.inDom = false;
-      this.args.onHidden?.();
-    });
+    await this.handleBackdrop();
+
+    this.removeBodyClass();
+    this.resetAdjustments();
+    this.resetScrollbar();
+    this.inDom = false;
+    this.args.onHidden?.();
   }
 
   /**
@@ -506,45 +508,33 @@ export default class Modal extends Component {
    * @param callback
    * @private
    */
-  handleBackdrop(callback) {
-    let doAnimate = this.usesTransition;
+  async handleBackdrop() {
+    const { usesTransition } = this;
 
     if (this.open && this.backdrop) {
       this.showBackdrop = true;
 
-      if (!callback) {
+      await nextRunloop();
+
+      if (usesTransition) {
+        const { backdropElement } = this;
+        assert('Backdrop element should be in DOM', backdropElement);
+
+        await transitionEnd(backdropElement, this.backdropTransitionDuration);
+      }
+    } else if (!this.open && this.backdrop) {
+      if (usesTransition) {
+        const { backdropElement } = this;
+        assert('Backdrop element should be in DOM', backdropElement);
+
+        await transitionEnd(backdropElement, this.backdropTransitionDuration);
+      }
+
+      if (this.isDestroyed) {
         return;
       }
 
-      next(() => {
-        let backdrop = this.backdropElement;
-        assert('Backdrop element should be in DOM', backdrop);
-        if (doAnimate) {
-          transitionEnd(backdrop, this.backdropTransitionDuration).then(callback);
-        } else {
-          callback();
-        }
-      });
-    } else if (!this.open && this.backdrop) {
-      let backdrop = this.backdropElement;
-      assert('Backdrop element should be in DOM', backdrop);
-
-      let callbackRemove = () => {
-        if (this.isDestroyed) {
-          return;
-        }
-        this.showBackdrop = false;
-        if (callback) {
-          callback.call(this);
-        }
-      };
-      if (doAnimate) {
-        transitionEnd(backdrop, this.backdropTransitionDuration).then(callbackRemove);
-      } else {
-        callbackRemove();
-      }
-    } else if (callback) {
-      next(this, callback);
+      this.showBackdrop = false;
     }
   }
 

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -16,6 +16,10 @@ function nextRunloop() {
   return new Promise((resolve) => next(resolve));
 }
 
+function afterRender() {
+  return new Promise((resolve) => schedule('afterRender', resolve));
+}
+
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with custom markup.
 
@@ -440,23 +444,23 @@ export default class Modal extends Component {
     this.checkScrollbar();
     this.setScrollbar();
 
-    schedule('afterRender', async () => {
-      let modalEl = this.modalElement;
-      if (!modalEl) {
-        return;
-      }
+    await afterRender();
 
-      modalEl.scrollTop = 0;
-      this.adjustDialog();
-      this.showModal = true;
-      this.args.onShow?.();
+    const { modalElement } = this;
+    if (!modalElement) {
+      return;
+    }
 
-      if (this.usesTransition) {
-        await transitionEnd(this.modalElement, this.transitionDuration);
-      }
+    modalElement.scrollTop = 0;
+    this.adjustDialog();
+    this.showModal = true;
+    this.args.onShow?.();
 
-      this.args.onShown?.();
-    });
+    if (this.usesTransition) {
+      await transitionEnd(modalElement, this.transitionDuration);
+    }
+
+    this.args.onShown?.();
   }
 
   /**
@@ -478,7 +482,7 @@ export default class Modal extends Component {
       await transitionEnd(this.modalElement, this.transitionDuration);
     }
 
-    this.hideModal();
+    await this.hideModal();
   }
 
   /**


### PR DESCRIPTION
`<BsModal>` was heavily using callbacks in logic to show and hide a modal. The resulting code was hard to read. This pull requests refactors it to `async`/`await`.

Pulled this change out of #1402, which got way too big.