### PR TITLE
Shadow DOM compatibility

### DIFF
--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { guidFor } from '@ember/object/internals';
 import { isArray } from '@ember/array';
 import { action } from '@ember/object';
 import { cancel, later, next, schedule } from '@ember/runloop';
@@ -11,6 +10,7 @@ import Ember from 'ember';
 import arg from '../utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
 import { getParentView } from '../utils/dom';
+import { ref } from 'ember-ref-bucket';
 
 const HOVERSTATE_NONE = 'none';
 const HOVERSTATE_IN = 'in';
@@ -179,16 +179,6 @@ export default class ContextualHelp extends Component {
   viewportPadding = 0;
 
   _parentFinder = self.document ? self.document.createTextNode('') : '';
-
-  /**
-   * The id of the overlay element.
-   *
-   * @property overlayId
-   * @type string
-   * @readonly
-   * @private
-   */
-  overlayId = `overlay-${guidFor(this)}`;
 
   /**
    * The DOM element of the arrow element.
@@ -360,9 +350,7 @@ export default class ContextualHelp extends Component {
    * @readonly
    * @private
    */
-  get overlayElement() {
-    return document.getElementById(this.overlayId);
-  }
+  @ref('overlayElement') overlayElement;
 
   /**
    * This action is called immediately when the tooltip/popover is about to be shown.

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -5,6 +5,7 @@ import { scheduleOnce } from '@ember/runloop';
 import arg from 'ember-bootstrap/utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
 import { getOwnConfig, macroCondition } from '@embroider/macros';
+import { trackedRef } from 'ember-ref-bucket';
 
 /**
  Internal (abstract) component for contextual help markup. Should not be used directly.
@@ -96,6 +97,8 @@ export default class ContextualHelpElement extends Component {
 
   offset = [0, 0];
 
+  @trackedRef('popperElement') popperElement;
+
   /**
    * popper.js modifier config
    *
@@ -104,15 +107,19 @@ export default class ContextualHelpElement extends Component {
    * @private
    */
   get popperModifiers() {
-    let id = this.args.id;
+    const context = this;
+
+    // We need popeerElement, so we wait for this getter to recompute once it's available
+    if (!this.popperElement) return {};
+
     return {
       arrow: {
-        element: `.${this.arrowClass}`,
+        element: this.popperElement.querySelector(`.${this.arrowClass}`),
       },
       offset: {
         offset: this.offset.join(','),
         fn(data) {
-          let tip = document.getElementById(id);
+          let tip = context.popperElement;
           assert('Contextual help element needs existing popper element', tip);
 
           // manually read margins because getBoundingClientRect includes difference

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -111,10 +111,8 @@ export default class ContextualHelpElement extends Component {
 
     // We need popeerElement, so we wait for this getter to recompute once it's available
     if (!this.popperElement) {
-      console.log('empty!');
       return {};
     }
-    console.log('not empty!');
 
     return {
       arrow: {

--- a/addon/components/bs-contextual-help/element.js
+++ b/addon/components/bs-contextual-help/element.js
@@ -110,7 +110,11 @@ export default class ContextualHelpElement extends Component {
     const context = this;
 
     // We need popeerElement, so we wait for this getter to recompute once it's available
-    if (!this.popperElement) return {};
+    if (!this.popperElement) {
+      console.log('empty!');
+      return {};
+    }
+    console.log('not empty!');
 
     return {
       arrow: {

--- a/addon/components/bs-modal.hbs
+++ b/addon/components/bs-modal.hbs
@@ -17,7 +17,7 @@
     {{#if this._renderInPlace}}
       <Dialog
         class={{@class}}
-        id={{this.modalId}}
+        {{create-ref "modalElement"}}
         ...attributes
       >
         {{yield
@@ -32,14 +32,14 @@
       </Dialog>
       <div>
         {{#if this.showBackdrop}}
-          <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isNotBS3")) "show" "in")}}" id={{this.backdropId}}></div>
+          <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isNotBS3")) "show" "in")}}" {{create-ref "backdropElement"}}></div>
         {{/if}}
       </div>
     {{else}}
       {{#in-element this.destinationElement insertBefore=null}}
         <Dialog
           class={{@class}}
-          id={{this.modalId}}
+          {{create-ref "modalElement"}}
           ...attributes
         >
           {{yield
@@ -54,7 +54,7 @@
         </Dialog>
         <div>
           {{#if this.showBackdrop}}
-            <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isNotBS3")) "show" "in")}}" id={{this.backdropId}}></div>
+            <div class="modal-backdrop {{if this._fade "fade"}} {{if this.showModal (if (macroCondition (macroGetOwnConfig "isNotBS3")) "show" "in")}}" {{create-ref "backdropElement"}}></div>
           {{/if}}
         </div>
       {{/in-element}}

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -5,12 +5,12 @@ import { next, schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import { getDestinationElement } from 'ember-bootstrap/utils/dom';
-import { guidFor } from '@ember/object/internals';
 import usesTransition from 'ember-bootstrap/utils/decorators/uses-transition';
 import isFastBoot from 'ember-bootstrap/utils/is-fastboot';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 import arg from '../utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
+import { ref } from 'ember-ref-bucket';
 
 /**
   Component for creating [Bootstrap modals](http://getbootstrap.com/javascript/#modals) with custom markup.
@@ -210,30 +210,6 @@ export default class Modal extends Component {
    */
 
   /**
-   * The id of the `.modal` element.
-   *
-   * @property modalId
-   * @type string
-   * @readonly
-   * @private
-   */
-  get modalId() {
-    return `${guidFor(this)}-modal`;
-  }
-
-  /**
-   * The id of the backdrop element.
-   *
-   * @property backdropId
-   * @type string
-   * @readonly
-   * @private
-   */
-  get backdropId() {
-    return `${guidFor(this)}-backdrop`;
-  }
-
-  /**
    * Property for size styling, set to null (default), 'lg' or 'sm'
    *
    * Also see the [Bootstrap docs](http://getbootstrap.com/javascript/#modals-sizes)
@@ -313,25 +289,21 @@ export default class Modal extends Component {
    * The DOM element of the `.modal` element.
    *
    * @property modalElement
-   * @type object
+   * @type HTMLElement
    * @readonly
    * @private
    */
-  get modalElement() {
-    return document.getElementById(this.modalId);
-  }
+  @ref('modalElement') modalElement;
 
   /**
    * The DOM element of the backdrop element.
    *
    * @property backdropElement
-   * @type object
+   * @type HTMLElement
    * @readonly
    * @private
    */
-  get backdropElement() {
-    return document.getElementById(this.backdropId);
-  }
+  @ref('backdropElement') backdropElement;
 
   /**
    * The action to be sent when the modal footer's submit button (if present) is pressed.
@@ -396,9 +368,7 @@ export default class Modal extends Component {
 
   @action
   doSubmit() {
-    // replace modalId by :scope selector if supported by all target browsers
-    let modalId = this.modalId;
-    let forms = this.modalElement.querySelectorAll(`#${modalId} .modal-body form`);
+    let forms = this.modalElement.querySelectorAll('.modal-body form');
     if (forms.length > 0) {
       // trigger submit event on body forms
       let event = document.createEvent('Events');

--- a/addon/components/bs-popover.hbs
+++ b/addon/components/bs-popover.hbs
@@ -13,8 +13,9 @@
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}
       @viewportPadding={{this.viewportPadding}}
-      @id={{this.overlayId}}
       @class={{@class}}
+
+      {{create-tracked-ref "overlayElement"}}
       ...attributes
     >
       {{yield

--- a/addon/components/bs-popover.hbs
+++ b/addon/components/bs-popover.hbs
@@ -15,7 +15,7 @@
       @viewportPadding={{this.viewportPadding}}
       @class={{@class}}
 
-      {{create-tracked-ref "overlayElement"}}
+      {{create-ref "overlayElement"}}
       ...attributes
     >
       {{yield

--- a/addon/components/bs-popover/element.hbs
+++ b/addon/components/bs-popover/element.hbs
@@ -7,8 +7,9 @@
   @popperContainer={{@destinationElement}}
   @onCreate={{this.updatePlacement}}
   @onUpdate={{this.updatePlacement}}
-  @id={{@id}}
   @class="popover {{@class}} {{if this.fade "fade"}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) this.actualPlacementClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.actualPlacement}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) (if this.showHelp "show")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.showHelp "in")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "ember-bootstrap-popover"}}"
+
+  {{create-ref "popperElement"}}
   ...attributes
 >
   <div class={{this.arrowClass}}></div>

--- a/addon/components/bs-tooltip.hbs
+++ b/addon/components/bs-tooltip.hbs
@@ -12,8 +12,9 @@
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}
       @viewportPadding={{this.viewportPadding}}
-      @id={{this.overlayId}}
       @class={{@class}}
+
+      {{create-ref "overlayElement"}}
       ...attributes
     >
       {{#if (has-block)}}

--- a/addon/components/bs-tooltip/element.hbs
+++ b/addon/components/bs-tooltip/element.hbs
@@ -7,8 +7,9 @@
   @popperContainer={{@destinationElement}}
   @onCreate={{this.updatePlacement}}
   @onUpdate={{this.updatePlacement}}
-  @id={{@id}}
   @class="tooltip {{@class}} {{if this.fade "fade"}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) this.actualPlacementClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.actualPlacement}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) (if this.showHelp "show")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.showHelp "in")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "ember-bootstrap-tooltip"}}"
+
+  {{create-tracked-ref "popperElement"}}
   ...attributes
 >
   <div class={{this.arrowClass}}></div>

--- a/addon/components/bs-tooltip/element.hbs
+++ b/addon/components/bs-tooltip/element.hbs
@@ -9,7 +9,7 @@
   @onUpdate={{this.updatePlacement}}
   @class="tooltip {{@class}} {{if this.fade "fade"}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) this.actualPlacementClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) this.actualPlacement}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) (if this.showHelp "show")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) (if this.showHelp "in")}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "ember-bootstrap-tooltip"}}"
 
-  {{create-tracked-ref "popperElement"}}
+  {{create-ref "popperElement"}}
   ...attributes
 >
   <div class={{this.arrowClass}}></div>

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -76,7 +76,10 @@ function closest(el, selector) {
 
 export function getDestinationElement(context) {
   let dom = getDOM(context);
-  let destinationElement = findElementById(dom, 'ember-bootstrap-wormhole');
+  const id = 'ember-bootstrap-wormhole';
+  console.log('dom', dom);
+  let destinationElement = findElementById(dom, id) || findElemementByIdInShadowDom(context, id);
+  // AFJLAJLSFJ AFJ LJ
 
   if (DEBUG && !destinationElement) {
     let config = getOwner(context).resolveRegistration('config:environment');
@@ -103,4 +106,9 @@ export function getDestinationElement(context) {
   }
 
   return destinationElement;
+}
+
+export function findElemementByIdInShadowDom(context, id) {
+  const owner = getOwner(context);
+  return owner.rootElement.querySelector && owner.rootElement.querySelector(`[id="${id}"]`);
 }

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -77,9 +77,7 @@ function closest(el, selector) {
 export function getDestinationElement(context) {
   let dom = getDOM(context);
   const id = 'ember-bootstrap-wormhole';
-  console.log('dom', dom);
   let destinationElement = findElementById(dom, id) || findElemementByIdInShadowDom(context, id);
-  // AFJLAJLSFJ AFJ LJ
 
   if (DEBUG && !destinationElement) {
     let config = getOwner(context).resolveRegistration('config:environment');


### PR DESCRIPTION
This PR avoids looking up elements via `document` and id, because such method is unable to pass through the Shadow DOM border.

Instead, it uses https://github.com/lifeart/ember-ref-bucket by @lifeart to reference elements directly.