### PR TITLE
remove trailing bracket in <BsModal::Header>

### DIFF
--- a/addon/components/bs-modal/header.hbs
+++ b/addon/components/bs-modal/header.hbs
@@ -16,7 +16,7 @@ as |Title Close|
         {{#if (has-block)}}
           {{yield}}
         {{else}}
-          <Title>{{@title}}</Title>>
+          <Title>{{@title}}</Title>
         {{/if}}
         {{#if (bs-default @closeButton true)}}
           <Close/>
@@ -29,7 +29,7 @@ as |Title Close|
         {{#if (has-block)}}
           {{yield}}
         {{else}}
-          <Title>{{@title}}</Title>>
+          <Title>{{@title}}</Title>
         {{/if}}
       {{/if}}
     {{/if}}


### PR DESCRIPTION
Got introduced in #1341, which was released in v4.8.0 a few hours ago.