### PR TITLE
harmonize code paths used in FastBoot and non-FastBoot of <BsModal>

### DIFF
--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -417,8 +417,10 @@ export default class Modal extends Component {
       return;
     }
 
-    this.checkScrollbar();
-    this.setScrollbar();
+    if (!isFastBoot(this)) {
+      this.checkScrollbar();
+      this.setScrollbar();
+    }
 
     await afterRender();
 
@@ -427,8 +429,11 @@ export default class Modal extends Component {
       return;
     }
 
-    modalElement.scrollTop = 0;
-    this.adjustDialog();
+    if (!isFastBoot(this)) {
+      modalElement.scrollTop = 0;
+      this.adjustDialog();
+    }
+
     this.showModal = true;
     this.args.onShow?.();
 
@@ -474,8 +479,12 @@ export default class Modal extends Component {
     await this.hideBackdrop();
 
     this.removeBodyClass();
-    this.resetAdjustments();
-    this.resetScrollbar();
+
+    if (!isFastBoot(this)) {
+      this.resetAdjustments();
+      this.resetScrollbar();
+    }
+
     this.inDom = false;
     this.args.onHidden?.();
   }
@@ -534,12 +543,6 @@ export default class Modal extends Component {
    */
   @action
   adjustDialog() {
-    if (isFastBoot(this)) {
-      // document height is unknown if running in FastBoot
-      // therefore can not adjust dialog to fit into it
-      return;
-    }
-
     let modalIsOverflowing = this.modalElement.scrollHeight > document.documentElement.clientHeight;
     this.paddingLeft = !this.bodyIsOverflowing && modalIsOverflowing ? this.scrollbarWidth : undefined;
     this.paddingRight = this.bodyIsOverflowing && !modalIsOverflowing ? this.scrollbarWidth : undefined;
@@ -559,12 +562,6 @@ export default class Modal extends Component {
    * @private
    */
   checkScrollbar() {
-    if (isFastBoot(this)) {
-      // window height of client is unknown when running in FastBoot
-      // can not detect if scrollbars will be used in client or not
-      return;
-    }
-
     const fullWindowWidth = window.innerWidth;
     this.bodyIsOverflowing = document.body.clientWidth < fullWindowWidth;
   }
@@ -574,12 +571,6 @@ export default class Modal extends Component {
    * @private
    */
   setScrollbar() {
-    if (isFastBoot(this)) {
-      // can not detect if scrollbars will be used in client or not
-      // if running in FastBoot
-      return;
-    }
-
     let bodyPad = parseInt(document.body.style.paddingRight || 0, 10);
     this._originalBodyPad = document.body.style.paddingRight || '';
     if (this.bodyIsOverflowing) {
@@ -592,11 +583,6 @@ export default class Modal extends Component {
    * @private
    */
   resetScrollbar() {
-    if (isFastBoot(this)) {
-      // no need for FastBoot support here
-      return;
-    }
-
     document.body.style.paddingRight = this._originalBodyPad;
   }
 
@@ -645,7 +631,10 @@ export default class Modal extends Component {
     super.willDestroy(...arguments);
 
     this.removeBodyClass();
-    this.resetScrollbar();
+
+    if (!isFastBoot(this)) {
+      this.resetScrollbar();
+    }
   }
 
   @action

--- a/addon/components/bs-modal.js
+++ b/addon/components/bs-modal.js
@@ -534,6 +534,12 @@ export default class Modal extends Component {
    */
   @action
   adjustDialog() {
+    if (isFastBoot(this)) {
+      // document height is unknown if running in FastBoot
+      // therefore can not adjust dialog to fit into it
+      return;
+    }
+
     let modalIsOverflowing = this.modalElement.scrollHeight > document.documentElement.clientHeight;
     this.paddingLeft = !this.bodyIsOverflowing && modalIsOverflowing ? this.scrollbarWidth : undefined;
     this.paddingRight = this.bodyIsOverflowing && !modalIsOverflowing ? this.scrollbarWidth : undefined;
@@ -553,13 +559,13 @@ export default class Modal extends Component {
    * @private
    */
   checkScrollbar() {
-    let fullWindowWidth = window.innerWidth;
-    if (!fullWindowWidth) {
-      // workaround for missing window.innerWidth in IE8
-      let documentElementRect = document.documentElement.getBoundingClientRect();
-      fullWindowWidth = documentElementRect.right - Math.abs(documentElementRect.left);
+    if (isFastBoot(this)) {
+      // window height of client is unknown when running in FastBoot
+      // can not detect if scrollbars will be used in client or not
+      return;
     }
 
+    const fullWindowWidth = window.innerWidth;
     this.bodyIsOverflowing = document.body.clientWidth < fullWindowWidth;
   }
 
@@ -568,6 +574,12 @@ export default class Modal extends Component {
    * @private
    */
   setScrollbar() {
+    if (isFastBoot(this)) {
+      // can not detect if scrollbars will be used in client or not
+      // if running in FastBoot
+      return;
+    }
+
     let bodyPad = parseInt(document.body.style.paddingRight || 0, 10);
     this._originalBodyPad = document.body.style.paddingRight || '';
     if (this.bodyIsOverflowing) {
@@ -580,6 +592,11 @@ export default class Modal extends Component {
    * @private
    */
   resetScrollbar() {
+    if (isFastBoot(this)) {
+      // no need for FastBoot support here
+      return;
+    }
+
     document.body.style.paddingRight = this._originalBodyPad;
   }
 
@@ -599,7 +616,11 @@ export default class Modal extends Component {
   }
 
   removeBodyClass() {
-    // no need for FastBoot support here
+    if (isFastBoot(this)) {
+      // no need for FastBoot support here
+      return;
+    }
+
     document.body.classList.remove('modal-open');
   }
 
@@ -623,19 +644,12 @@ export default class Modal extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
 
-    if (typeof FastBoot === 'undefined') {
-      this.removeBodyClass();
-      this.resetScrollbar();
-    }
+    this.removeBodyClass();
+    this.resetScrollbar();
   }
 
   @action
   handleVisibilityChanges() {
-    if (isFastBoot(this)) {
-      this.addBodyClass();
-      return;
-    }
-
     if (this.args.open !== false) {
       this.show();
     } else {


### PR DESCRIPTION
Running same code paths in FastBoot as in "regular" environment reduces the risk of bugs. To do so I moved the guards for FastBoot as close as possible to the places in code, which access `document` or `window`. Tests are passing and I manually verified that `/fastboot/modal` URL of dummy app shows the modal even with JavaScript being disabled. Not sure if additional manual tests are required.

Another small refactoring pulled out of #1402.