### PR TITLE
Remove `.btn-block` support for Bootstrap 5

### DIFF
--- a/addon/components/bs-button.hbs
+++ b/addon/components/bs-button.hbs
@@ -1,7 +1,7 @@
 <button
   disabled={{this.__disabled}}
   type={{this.buttonType}}
-  class="btn {{if @active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
+  class="btn {{if @active "active"}} {{if (macroCondition (macroGetOwnConfig "isNotBS5")) (if this.block "btn-block")}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
   ...attributes
   {{on "click" this.handleClick}}
   {{did-update this.resetState @reset}}

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -174,7 +174,7 @@ export default class Button extends Component {
    */
 
   /**
-   * Property for block level buttons
+   * Property for block level buttons (BS3 and BS4 only!)
    *
    * See the [Bootstrap docs](http://getbootstrap.com/css/#buttons-sizes)
    * @property block

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -3,7 +3,7 @@ import { defer, reject, resolve } from 'rsvp';
 import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, click, settled, waitUntil } from '@ember/test-helpers';
-import { test, testNotBS3, defaultButtonClass } from '../../helpers/bootstrap';
+import { test, testNotBS3, defaultButtonClass, testForBootstrap } from '../../helpers/bootstrap';
 import { gte } from 'ember-compatibility-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -46,7 +46,7 @@ module('Integration | Component | bs-button', function (hooks) {
     assert.dom('button').hasClass('active', 'button has active class');
   });
 
-  test('button can be block', async function (assert) {
+  testForBootstrap([3, 4], 'button can be block', async function (assert) {
     await render(hbs`<BsButton @block={{true}}>Test</BsButton>`);
 
     assert.dom('button').hasClass('btn-block', 'button has block class');


### PR DESCRIPTION
See https://getbootstrap.com/docs/5.0/migration/#buttons