### PR TITLE
Add Bootstrap v5 support for ButtonGroup

### DIFF
--- a/addon/components/bs-button-group/button.hbs
+++ b/addon/components/bs-button-group/button.hbs
@@ -1,17 +1,51 @@
-<button
-  disabled={{this.__disabled}}
-  type={{this.buttonType}}
-  class="btn {{if this.active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
-  ...attributes
-  {{on "click" this.handleClick}}
-  {{did-update this.resetState @reset}}
->
-  {{#if this.icon}}<i class={{this.icon}}></i> {{/if}}{{this.text}}{{yield
-    (hash
-      isFulfilled=this.isFulfilled
-      isPending=this.isPending
-      isRejected=this.isRejected
-      isSettled=this.isSettled
-    )
-  }}
-</button>
+{{#if this.isBS5ToggleButton}}
+  <input
+    type={{@buttonGroupType}}
+    class="btn-check"
+    id={{this.formId}}
+    autocomplete="off"
+    checked={{this.active}}
+    ...attributes
+    {{on "click" this.handleClick}}
+    {{did-update this.resetState @reset}}
+  >
+  <label
+    class="btn {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default="secondary" outline=@outline}}"
+    for={{this.formId}}
+  >
+    {{#if this.icon}}
+      <i class={{this.icon}}></i>
+    {{/if}}
+    {{this.text}}
+    {{yield
+      (hash
+        isFulfilled=this.isFulfilled
+        isPending=this.isPending
+        isRejected=this.isRejected
+        isSettled=this.isSettled
+      )
+    }}
+  </label>
+{{else}}
+  <button
+    disabled={{this.__disabled}}
+    type={{this.buttonType}}
+    class="btn {{if this.active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
+    ...attributes
+    {{on "click" this.handleClick}}
+    {{did-update this.resetState @reset}}
+  >
+    {{#if this.icon}}
+      <i class={{this.icon}}></i>
+    {{/if}}
+    {{this.text}}
+    {{yield
+      (hash
+        isFulfilled=this.isFulfilled
+        isPending=this.isPending
+        isRejected=this.isRejected
+        isSettled=this.isSettled
+      )
+    }}
+  </button>
+{{/if}}

--- a/addon/components/bs-button-group/button.js
+++ b/addon/components/bs-button-group/button.js
@@ -1,5 +1,7 @@
 import { isArray } from '@ember/array';
 import Button from 'ember-bootstrap/components/bs-button';
+import { guidFor } from '@ember/object/internals';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 
 /**
  Internal component for button-group buttons
@@ -11,6 +13,8 @@ import Button from 'ember-bootstrap/components/bs-button';
  */
 export default class ButtonGroupButton extends Button {
   '__ember-bootstrap_subclass' = true;
+
+  formId = guidFor(this);
 
   /**
    * @property groupValue
@@ -39,5 +43,13 @@ export default class ButtonGroupButton extends Button {
       }
     }
     return false;
+  }
+
+  get isBS5ToggleButton() {
+    if (macroCondition(getOwnConfig().isBS5)) {
+      return this.args.buttonGroupType === 'radio' || this.args.buttonGroupType === 'checkbox';
+    } else {
+      return false;
+    }
   }
 }

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -343,7 +343,7 @@ export default class Button extends Component {
   /**
    * Property to create outline buttons (BS4+ only)
    *
-   * @property disabled
+   * @property outline
    * @type boolean
    * @default false
    * @public


### PR DESCRIPTION
Checkbox and radio button groups are actually not buttons (referring to markup) anymore, but inputs (with `.btn` on the label): https://getbootstrap.com/docs/5.0/components/button-group/#checkbox-and-radio-button-groups. When they are neither of those, i.e. just grouped buttons, then they remain real `<button>`, even in BS5.

So this required some bigger changes. As our API stills exposes the "buttons" yielded from `<BsButtonGroup>` as instances of `<BsButton>`, we need to keep that API in place, i.e. support its arguments like `@type` and `@size` (which are fully supported on toggle buttons in BS5, even when they are technically no buttons anymore) but also our more exotic ones like `@defaultText`. So the yielded buttons still are subclasses of BsButton, however when they are radios/checkboxes in BS5, then the markup is just different (inputs vs. buttons).

I briefly considered making `<BsButtonGroup::Button>` not extend BsButton, but just a light wrapper that *uses* it, but that would make supporting all the button APIs for these input-based buttons way harder, would basically have to duplicate all the button API for those. So I think this is a reasonable solution, even if it might look a bit confusing at first (for us maintainers, not users).