### PR TITLE
Add Bootstrap v5 support for accordions

### DIFF
--- a/addon/components/bs-accordion/item.hbs
+++ b/addon/components/bs-accordion/item.hbs
@@ -4,7 +4,7 @@
 as |Title Body|
 }}
   <div
-    class="{{if @disabled "disabled"}} {{this.typeClass}} {{if (macroCondition (macroGetOwnConfig "isNotBS3")) "card"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "panel"}}"
+    class="{{if @disabled "disabled"}} {{this.typeClass}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "panel"}} {{if (macroCondition (macroGetOwnConfig "isBS4")) "card"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-item"}}"
     ...attributes
   >
     {{#if (has-block-params)}}

--- a/addon/components/bs-accordion/item/body.hbs
+++ b/addon/components/bs-accordion/item/body.hbs
@@ -1,5 +1,5 @@
 <BsCollapse @collapsed={{@collapsed}} class={{if (macroCondition (macroGetOwnConfig "isBS3")) "panel-collapse"}} role="tabpanel">
-  <div class="{{if (macroCondition (macroGetOwnConfig "isNotBS3")) "card-body"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "panel-body"}} {{@class}}">
+  <div class="{{if (macroCondition (macroGetOwnConfig "isBS3")) "panel-body"}} {{if (macroCondition (macroGetOwnConfig "isBS4")) "card-body"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-body"}} {{@class}}">
     {{yield}}
   </div>
 </BsCollapse>

--- a/addon/components/bs-accordion/item/body.js
+++ b/addon/components/bs-accordion/item/body.js
@@ -14,3 +14,5 @@
  * @type boolean
  * @public
  */
+import templateOnly from '@ember/component/template-only';
+export default templateOnly();

--- a/addon/components/bs-accordion/item/title.hbs
+++ b/addon/components/bs-accordion/item/title.hbs
@@ -31,7 +31,7 @@
     {{/if}}
     {{#if (macroCondition (macroGetOwnConfig "isBS3"))}}
       <h4 class="panel-title">
-        <a href="#" class="{{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" disabled={{@disabled}}>
+        <a href="#" class="{{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}">
           {{yield}}
         </a>
       </h4>

--- a/addon/components/bs-accordion/item/title.hbs
+++ b/addon/components/bs-accordion/item/title.hbs
@@ -1,23 +1,40 @@
 {{!-- template-lint-disable no-nested-interactive --}}
 {{!-- @todo fix this, see https://github.com/kaliber5/ember-bootstrap/issues/999 --}}
-<div
-  class="{{if (macroCondition (macroGetOwnConfig "isNotBS3")) "card-header"}} {{if (macroCondition (macroGetOwnConfig "isBS3")) "panel-heading"}}"
-  role="tab"
-  ...attributes
-  {{on "click" this.handleClick}}
->
-  {{#if (macroCondition (macroGetOwnConfig "isNotBS3"))}}
-    <h5 class="mb-0">
-      <button class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" type="button" disabled={{@disabled}}>
-        {{yield}}
-      </button>
-    </h5>
-  {{/if}}
-  {{#if (macroCondition (macroGetOwnConfig "isBS3"))}}
-    <h4 class="panel-title">
-      <a href="#" class="{{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" >
-        {{yield}}
-      </a>
-    </h4>
-  {{/if}}
-</div>
+{{#if (macroCondition (macroGetOwnConfig "isBS5"))}}
+  <h2
+    class="accordion-header"
+    role="tab"
+    ...attributes
+  >
+    <button
+      class="accordion-button {{if @disabled "disabled"}} {{if @collapsed "collapsed"}}"
+      type="button"
+      disabled={{@disabled}}
+      {{on "click" this.handleClick}}
+    >
+      {{yield}}
+    </button>
+  </h2>
+{{else}}
+  <div
+    class="{{if (macroCondition (macroGetOwnConfig "isBS3")) "panel-heading"}} {{if (macroCondition (macroGetOwnConfig "isBS4")) "card-header"}}"
+    role="tab"
+    ...attributes
+    {{on "click" this.handleClick}}
+  >
+    {{#if (macroCondition (macroGetOwnConfig "isBS4"))}}
+      <h5 class="mb-0">
+        <button class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" type="button" disabled={{@disabled}}>
+          {{yield}}
+        </button>
+      </h5>
+    {{/if}}
+    {{#if (macroCondition (macroGetOwnConfig "isBS3"))}}
+      <h4 class="panel-title">
+        <a href="#" class="{{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" disabled={{@disabled}}>
+          {{yield}}
+        </a>
+      </h4>
+    {{/if}}
+  </div>
+{{/if}}

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -96,11 +96,11 @@ export function formHelpTextClass() {
 }
 
 export function accordionClass() {
-  return versionDependent('panel-group', 'accordion');
+  return versionDependent('panel-group', 'accordion', 'accordion');
 }
 
 export function accordionItemClass() {
-  return versionDependent('panel', 'card');
+  return versionDependent('panel', 'card', 'accordion-item');
 }
 
 export function accordionClassFor(type) {
@@ -109,15 +109,15 @@ export function accordionClassFor(type) {
 }
 
 export function accordionTitleSelector() {
-  return versionDependent('.panel-title', 'h5');
+  return versionDependent('.panel-title', 'h5', 'h2.accordion-header');
 }
 
 export function accordionItemHeadClass() {
-  return versionDependent('panel-heading', 'card-header');
+  return versionDependent('panel-heading', 'card-header', 'accordion-header');
 }
 
 export function accordionItemClickableSelector() {
-  return versionDependent('.panel-title a', 'h5 button');
+  return versionDependent('.panel-title a', 'h5 button', '.accordion-header button');
 }
 
 export function dropdownVisibilityElementSelector() {
@@ -125,7 +125,7 @@ export function dropdownVisibilityElementSelector() {
 }
 
 export function accordionItemBodyClass() {
-  return versionDependent('panel-body', 'card-body');
+  return versionDependent('panel-body', 'card-body', 'accordion-body');
 }
 
 export function tooltipPositionClass(pos) {


### PR DESCRIPTION
Had to refactor the tests (selectors) a bit, as they were not *quite* right, and failed for BS5 (e.g. assumed you were clicking on the heading, instead of the button contained within it).

Didn't touch the a11y markup (yet), needs to be fixed separately, see #999.