### PR TITLE
Show validation errors added by onSubmit

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -454,7 +454,10 @@ export default class Form extends Component {
                 return;
               }
 
-              this.set('isRejected', true);
+              this.setProperties({
+                showAllValidations: true,
+                isRejected: true,
+              });
 
               throw error;
             })


### PR DESCRIPTION
The `onSubmit` action may set additional validation errors
(typically errors received from a backend server).
This change makes these errors visible.