### PR TITLE
Add @manualCloseOnly property to dropdown to permit blocking click outside closing

### DIFF
--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -197,6 +197,18 @@ export default class Dropdown extends Component {
   isOpen = false;
 
   /**
+   * By default clicking outside a menu, tab or esc keypress will close it. Set this property to true for the menu to stay open.
+   * Use of this override will require calling the closeDropdown method in the menu to close it.
+   *
+   * @property manualCloseOnly
+   * @default false
+   * @type boolean
+   * @public
+   */
+  @defaultValue
+  manualCloseOnly = false;
+
+  /**
    * By default clicking on an open dropdown menu will close it. Set this property to false for the menu to stay open.
    *
    * @property closeOnMenuClick
@@ -311,6 +323,8 @@ export default class Dropdown extends Component {
    */
   @action
   closeHandler(e) {
+    if (this.manualCloseOnly) return;
+
     let { target } = e;
     let { toggleElement, menuElement } = this;
 
@@ -353,7 +367,7 @@ export default class Dropdown extends Component {
       this.openDropdown();
       return;
     } else if (event.which === ESCAPE_KEYCODE || event.which === SPACE_KEYCODE) {
-      this.closeDropdown();
+      if (!this.manualCloseOnly) this.closeDropdown();
       this.toggleElement.focus();
       return;
     }

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -118,6 +118,18 @@ module('Integration | Component | bs-dropdown', function (hooks) {
     assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
   });
 
+  test('opened dropdown will not close on outside click if manualCloseOnly set to true', async function (assert) {
+    await render(
+      hbs`<BsDropdown @manualCloseOnly={{true}} as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
+    );
+
+    await click('a.dropdown-toggle');
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('*');
+    assert.dom('.dropdown-menu').exists('Dropdown is not closed');
+  });
+
   test('clicking dropdown menu will close it', async function (assert) {
     await render(
       hbs`<BsDropdown as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
@@ -128,6 +140,18 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
     await click('.dropdown-menu a');
     assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
+  });
+
+  test('clicking dropdown menu will not close it if manualCloseOnly is set to true', async function (assert) {
+    await render(
+      hbs`<BsDropdown @manualCloseOnly={{true}} as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
+    );
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('.dropdown-menu a');
+    assert.dom('.dropdown-menu').exists('Dropdown is not closed');
   });
 
   test('dropdown will close on click, when default is prevented, propagation is stopped', async function (assert) {


### PR DESCRIPTION
We have several use cases that would benefit from being able to disable closing of the dropdown menu when there is a click outside.

For example, when we have a small form inside of the dropdown. 
If a user enters some information and accidentally clicks outside the menu, or tabs past a submit button to the other elements on the page, the dropdown is closed and information entered is lost since the child component is destroyed.

What would you think about something like this to allow an override?

Happy to reconsider naming of the override, elaborate on test, whatever works.

Thanks again for the great library!