### PR TITLE
Permit blocking of dropdown close if onHide returns false

### DIFF
--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -274,6 +274,7 @@ export default class Dropdown extends Component {
 
   /**
    * Action is called when dropdown is about to be hidden
+   * Returning `false` will block closing the dropdown
    *
    * @event onHide
    * @param {*} value
@@ -298,8 +299,9 @@ export default class Dropdown extends Component {
 
   @action
   closeDropdown() {
+    if (this.onHide() === false) return;
+
     this.set('isOpen', false);
-    this.onHide();
   }
 
   /**

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -111,6 +111,21 @@ module('Integration | Component | bs-dropdown', function (hooks) {
     assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
   });
 
+  test('opened dropdown will not close on outside click if onHide returns false', async function (assert) {
+    this.set('onHide', () => {
+      return false;
+    });
+    await render(
+      hbs`<BsDropdown @onHide={{this.onHide}} as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
+    );
+
+    await click('a.dropdown-toggle');
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('*');
+    assert.dom('.dropdown-menu').exists('Dropdown remains open');
+  });
+
   test('clicking dropdown menu will close it', async function (assert) {
     await render(
       hbs`<BsDropdown as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
@@ -121,6 +136,21 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
     await click('.dropdown-menu a');
     assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
+  });
+
+  test('clicking dropdown menu will not close it if onHide returns false', async function (assert) {
+    this.set('onHide', () => {
+      return false;
+    });
+    await render(
+      hbs`<BsDropdown @onHide={{this.onHide}} as |dd|><dd.toggle>Dropdown <span class="caret"></span></dd.toggle><dd.menu><li><a href="#">Something</a></li></dd.menu></BsDropdown>`
+    );
+    await click('a.dropdown-toggle');
+    assert.dom('.dropdown-menu').exists();
+    assert.dom(dropdownVisibilityElementSelector()).hasClass(openClass(), 'Dropdown is open');
+
+    await click('.dropdown-menu a');
+    assert.dom('.dropdown-menu').exists('Dropdown remains open');
   });
 
   test('dropdown will close on click, when default is prevented, propagation is stopped', async function (assert) {


### PR DESCRIPTION
Originally: https://github.com/kaliber5/ember-bootstrap/pull/1580

We have several use cases that would benefit from being able to disable closing of the dropdown menu when there is a click outside.

For example, when we have a small form inside of the dropdown.
If a user enters some information and accidentally clicks outside the menu, or tabs past a submit button to the other elements on the page, the dropdown is closed and information entered is lost since the child component is destroyed.

Note: The syntax here is different than in the bs-modal because the bs-dropdown component is not using `this.args`. I'd assume this would refactor when the whole bs-dropdown component is updated in the future.