### PR TITLE
Update to `@ember/render-modifiers` v2

### DIFF
--- a/addon/components/bs-alert.js
+++ b/addon/components/bs-alert.js
@@ -75,6 +75,12 @@ export default class Alert extends Component {
   hidden = !this.visible;
 
   /**
+   * This is an unfortunate duplication of the previous property, but this is untracked to avoid causing the dreaded "same computation" assertion in GlimmerVM when reading a tracked property before setting it.
+   * @private
+   */
+  _hidden = !this.visible;
+
+  /**
    * This property controls if the alert should be visible. If false it might still be in the DOM until the fade animation
    * has completed.
    *
@@ -174,7 +180,7 @@ export default class Alert extends Component {
    * @private
    */
   show() {
-    this.hidden = false;
+    this.hidden = this._hidden = false;
   }
 
   /**
@@ -185,7 +191,7 @@ export default class Alert extends Component {
    * @private
    */
   hide() {
-    if (this.hidden) {
+    if (this._hidden) {
       return;
     }
 
@@ -194,14 +200,14 @@ export default class Alert extends Component {
         this,
         function () {
           if (!this.isDestroyed) {
-            this.hidden = true;
+            this.hidden = this._hidden = true;
             this.args.onDismissed?.();
           }
         },
         this.fadeDuration
       );
     } else {
-      this.hidden = true;
+      this.hidden = this._hidden = true;
       this.args.onDismissed?.();
     }
   }

--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -56,7 +56,6 @@ export default class Collapse extends Component {
    * @property active
    * @private
    */
-  @tracked
   active = !this.collapsed;
 
   get collapse() {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ip-regex": "^2.1.0"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^1.0.2",
+    "@ember/render-modifiers": "^2.0.0",
     "@embroider/macros": "^0.47.0",
     "@embroider/util": "^0.47.0",
     "@glimmer/component": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,13 +1030,14 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/render-modifiers@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
-  integrity sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==
+"@ember/render-modifiers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.0.0.tgz#7106928078c6463bc6ee3cbffb6d71dbb8602145"
+  integrity sha512-FbvowKEnYx102MaNMrePBC7RCmuf3BaqPKbp6QP7S6oJaDMuLrGblXW4TxOrE93C6II+6D4QNB4WFGuPeQ3ZBg==
   dependencies:
-    ember-cli-babel "^7.10.0"
-    ember-modifier-manager-polyfill "^1.1.0"
+    ember-cli-babel "^7.26.6"
+    ember-compatibility-helpers "^1.2.5"
+    ember-modifier-manager-polyfill "^1.2.0"
 
 "@ember/test-helpers@2.5.0":
   version "2.5.0"
@@ -6057,7 +6058,7 @@ ember-load-initializers@2.1.2:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
+ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
   integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==


### PR DESCRIPTION
The preceding renovate PR #1656 failed. The changes in https://github.com/emberjs/ember-render-modifiers/pull/42/files#diff-858a7ab2792f6dd402c28b973894abf3472e1119c6ad45b4e356626cf84c44c5 regarding autotracking seem to have caused the known GlimmerVM "same computation" assertion in `<BsCollape>` (and thus in others using it like `<BsAccordion>`) as well as `<BsAlert>`.

Ideally the `{{did-update}}` should probably be refactored to something else (resources maybe?), so this is just the short-term fix.