### PR TITLE
Remove use of curly component invocation for link components

### DIFF
--- a/tests/integration/components/bs-dropdown/menu/link-to-test.js
+++ b/tests/integration/components/bs-dropdown/menu/link-to-test.js
@@ -26,54 +26,6 @@ module('Integration | Component | bs-dropdown/menu/link-to', function (hooks) {
     assert.dom('a.dropdown-item').exists({ count: 1 }, 'renders as plain element with dropdown item class');
   });
 
-  module('positional params', function (hooks) {
-    hooks.afterEach(function (assert) {
-      assert.deprecationsInclude(`Positional arguments for ember-bootstrap's link-to components are deprecated.`);
-      assert.deprecations();
-    });
-    test('simple route link', async function (assert) {
-      await render(hbs`
-        <BsDropdown as |dd|>
-          <dd.button>Dropdown</dd.button>
-          <dd.menu as |menu|>
-            <menu.item>{{#menu.link-to "index"}}Link{{/menu.link-to}}</menu.item>
-          </dd.menu>
-        </BsDropdown>`);
-      await click('button');
-
-      assert.dom('a').exists({ count: 1 });
-      assert.dom('a').hasText('Link');
-      assert.dom('a').hasAttribute('href', '/');
-    });
-
-    test('link with model', async function (assert) {
-      await render(hbs`
-        <BsDropdown as |dd|>
-          <dd.button>Dropdown</dd.button>
-          <dd.menu as |menu|>
-            <menu.item>{{#menu.link-to "acceptance.link" "1" (query-params foo="bar")}}Link{{/menu.link-to}}</menu.item>
-          </dd.menu>
-        </BsDropdown>`);
-      await click('button');
-
-      assert.dom('a').exists({ count: 1 });
-      assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
-    });
-
-    test('disabled link', async function (assert) {
-      await render(hbs`
-        <BsDropdown as |dd|>
-          <dd.button>Dropdown</dd.button>
-          <dd.menu as |menu|>
-            <menu.item>{{#menu.link-to "index" disabled=true}}Link{{/menu.link-to}}</menu.item>
-          </dd.menu>
-        </BsDropdown>`);
-      await click('button');
-
-      assert.dom('a').hasClass('disabled');
-    });
-  });
-
   module('<LinkTo> properties', function () {
     test('simple route link', async function (assert) {
       await render(hbs`

--- a/tests/integration/components/bs-nav/link-to-test.js
+++ b/tests/integration/components/bs-nav/link-to-test.js
@@ -11,61 +11,6 @@ module('Integration | Component | bs-nav/link-to', function (hooks) {
     this.owner.setupRouter();
   });
 
-  module('positional params', function (hooks) {
-    hooks.afterEach(function (assert) {
-      assert.deprecationsInclude(`Positional arguments for ember-bootstrap's link-to components are deprecated.`);
-      assert.deprecations();
-    });
-    test('simple route link', async function (assert) {
-      await render(hbs`
-        <BsNav as |nav|>
-          <nav.item>
-            {{#nav.link-to "index"}}Link{{/nav.link-to}}
-          </nav.item>
-        </BsNav>
-      `);
-
-      assert.dom('a').exists({ count: 1 });
-      assert.dom('a').hasText('Link');
-      assert.dom('a').hasAttribute('href', '/');
-    });
-
-    test('link with model', async function (assert) {
-      await render(hbs`
-        <BsNav as |nav|>
-          <nav.item>
-            {{#nav.link-to "acceptance.link" "1" (query-params foo="bar")}}Link{{/nav.link-to}}
-          </nav.item>
-        </BsNav>
-      `);
-
-      assert.dom('a').exists({ count: 1 });
-      assert.dom('a').hasAttribute('href', '/acceptance/link/1?foo=bar');
-    });
-
-    test('link has nav-link class', async function (assert) {
-      await render(hbs`
-        <BsNav as |nav|>
-          <nav.item>
-            {{#nav.link-to "index"}}Link{{/nav.link-to}}
-          </nav.item>
-        </BsNav>
-      `);
-      assert.dom('a').hasClass('nav-link');
-    });
-
-    test('disabled link', async function (assert) {
-      await render(hbs`
-        <BsNav as |nav|>
-          <nav.item>
-            {{#nav.link-to "index" disabled=true}}Link{{/nav.link-to}}
-          </nav.item>
-        </BsNav>
-      `);
-      assert.dom('a').hasClass('disabled');
-    });
-  });
-
   module('<LinkTo> properties', function () {
     test('simple route link', async function (assert) {
       await render(hbs`


### PR DESCRIPTION
We don't want to support curly invocation of `LinkTo`, so removing tests. Also `(query-params)` helpers seems to be dropped from Ember 4, so this is helping to get CI green again.

I think the change is fine, so I'll merge without review. The question is if we want to tag this PR as breaking? After all the yielded link-to components use Ember's original one, which is not supposed to be used with curlies anyway. Do we actually consider any use of curly invocation still supported (as long as Ember supports it? @jelhan thoughts?