### PR TITLE
Call onShow(n)/onHide/onHidden when controlling tooltips and popovers programmatically

### DIFF
--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -670,17 +670,17 @@ export default class ContextualHelp extends Component {
       this.triggerTargetElement = this.getTriggerTargetElement();
       this.addListeners();
       if (this.visible) {
-        next(this, this.show, true);
+        next(this, this.show);
       }
     });
   }
 
   @action
-  showOrHide(visible) {
-    if (visible) {
-      this.show();
+  showOrHide() {
+    if (this.args.visible) {
+      next(this, this.show);
     } else {
-      this.hide();
+      next(this, this.hide);
     }
   }
 

--- a/addon/components/bs-popover.hbs
+++ b/addon/components/bs-popover.hbs
@@ -27,3 +27,4 @@
   {{/let}}
 {{/if}}
 {{did-insert this.setup}}
+{{did-update this.showOrHide @visible}}

--- a/addon/components/bs-tooltip.hbs
+++ b/addon/components/bs-tooltip.hbs
@@ -30,3 +30,4 @@
   {{/let}}
 {{/if}}
 {{did-insert this.setup}}
+{{did-update this.showOrHide @visible}}

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -299,7 +299,7 @@ module('Integration | Component | bs-popover', function (hooks) {
     );
     await click('#target');
     assert.ok(showAction.calledOnce, 'show action has been called');
-    assert.notOk(shownAction.calledOnce, 'show action has not been called');
+    assert.ok(shownAction.notCalled, 'show action has not been called');
     assert.dom('.popover').doesNotExist('popover is not visible');
   });
 
@@ -344,7 +344,7 @@ module('Integration | Component | bs-popover', function (hooks) {
     await click('#target');
     await click('#target');
     assert.ok(hideAction.calledOnce, 'hide action has been called');
-    assert.notOk(hiddenAction.calledOnce, 'hidden action has not been called');
+    assert.ok(hiddenAction.notCalled, 'hidden action has not been called');
     assert.dom('.popover').exists({ count: 1 }, 'popover is visible');
   });
 

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -260,6 +260,94 @@ module('Integration | Component | bs-popover', function (hooks) {
     assert.dom('#wrapper .popover').exists({ count: 1 }, 'Popover exists in place.');
   });
 
+  test('it calls onShow/onShown actions when showing popover by event [fade=false]', async function (assert) {
+    let showAction = sinon.spy();
+    this.set('show', showAction);
+    let shownAction = sinon.spy();
+    this.set('shown', shownAction);
+    await render(
+      hbs`<div id="target"><BsPopover @title="Dummy" @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
+    );
+    await click('#target');
+    assert.ok(showAction.calledOnce, 'show action has been called');
+    assert.ok(shownAction.calledOnce, 'shown action has been called');
+  });
+
+  test('it calls onShow/onShown actions when showing popover programmatically [fade=false]', async function (assert) {
+    let showAction = sinon.spy();
+    this.set('show', showAction);
+    let shownAction = sinon.spy();
+    this.set('shown', shownAction);
+    this.set('visible', false);
+    await render(
+      hbs`<div id="target"><BsPopover @title="Dummy" @visible={{this.visible}} @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
+    );
+    this.set('visible', true);
+    await settled();
+    assert.ok(showAction.calledOnce, 'show action has been called');
+    assert.ok(shownAction.calledOnce, 'shown action has been called');
+  });
+
+  test('it aborts showing if onShow action returns false', async function (assert) {
+    let showAction = sinon.stub();
+    showAction.returns(false);
+    this.set('show', showAction);
+    let shownAction = sinon.spy();
+    this.set('shown', shownAction);
+    await render(
+      hbs`<div id="target"><BsPopover @title="Dummy" @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
+    );
+    await click('#target');
+    assert.ok(showAction.calledOnce, 'show action has been called');
+    assert.notOk(shownAction.calledOnce, 'show action has not been called');
+    assert.dom('.popover').doesNotExist('popover is not visible');
+  });
+
+  test('it calls onHide/onHidden actions when hiding popover by event [fade=false]', async function (assert) {
+    let hideAction = sinon.spy();
+    this.set('hide', hideAction);
+    let hiddenAction = sinon.spy();
+    this.set('hidden', hiddenAction);
+    await render(
+      hbs`<div id="target"><BsPopover @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
+    );
+    await click('#target');
+    await click('#target');
+    assert.ok(hideAction.calledOnce, 'hide action has been called');
+    assert.ok(hiddenAction.calledOnce, 'hidden action was called');
+  });
+
+  test('it calls onHide/onHidden actions when hiding popover programmatically [fade=false]', async function (assert) {
+    let hideAction = sinon.spy();
+    this.set('hide', hideAction);
+    let hiddenAction = sinon.spy();
+    this.set('hidden', hiddenAction);
+    this.set('visible', true);
+    await render(
+      hbs`<div id="target"><BsPopover @visible={{this.visible}} @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
+    );
+    this.set('visible', false);
+    await settled();
+    assert.ok(hideAction.calledOnce, 'hide action has been called');
+    assert.ok(hiddenAction.calledOnce, 'hidden action was called');
+  });
+
+  test('it aborts hiding if onHide action returns false', async function (assert) {
+    let hideAction = sinon.stub();
+    hideAction.returns(false);
+    this.set('hide', hideAction);
+    let hiddenAction = sinon.spy();
+    this.set('hidden', hiddenAction);
+    await render(
+      hbs`<div id="target"><BsPopover @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
+    );
+    await click('#target');
+    await click('#target');
+    assert.ok(hideAction.calledOnce, 'hide action has been called');
+    assert.notOk(hiddenAction.calledOnce, 'hidden action has not been called');
+    assert.dom('.popover').exists({ count: 1 }, 'popover is visible');
+  });
+
   test('it passes accessibility checks', async function (assert) {
     await render(hbs`
       <button type="button">

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -143,7 +143,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     assert.dom('.tooltip').doesNotExist('tooltip is not visible');
   });
 
-  test('it calls onShow/onShown actions when showing tooltip [fade=false]', async function (assert) {
+  test('it calls onShow/onShown actions when showing tooltip by event [fade=false]', async function (assert) {
     let showAction = sinon.spy();
     this.actions.show = showAction;
     let shownAction = sinon.spy();
@@ -153,7 +153,22 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     );
     await triggerEvent('#target', 'mouseenter');
     assert.ok(showAction.calledOnce, 'show action has been called');
-    assert.ok(shownAction.calledOnce, 'show action has been called');
+    assert.ok(shownAction.calledOnce, 'shown action has been called');
+  });
+
+  test('it calls onShow/onShown actions when showing tooltip programmatically [fade=false]', async function (assert) {
+    let showAction = sinon.spy();
+    this.actions.show = showAction;
+    let shownAction = sinon.spy();
+    this.actions.shown = shownAction;
+    this.set('show', false);
+    await render(
+      hbs`<div id="target"><BsTooltip @title="Dummy" @visible={{this.show}} @fade={{false}} @onShow={{action "show"}} @onShown={{action "shown"}} /></div>`
+    );
+    this.set('show', true);
+    await settled();
+    assert.ok(showAction.calledOnce, 'show action has been called');
+    assert.ok(shownAction.calledOnce, 'shown action has been called');
   });
 
   test('it aborts showing if onShow action returns false', async function (assert) {
@@ -171,7 +186,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     assert.dom('.tooltip').doesNotExist('tooltip is not visible');
   });
 
-  test('it calls onHide/onHidden actions when hiding tooltip [fade=false]', async function (assert) {
+  test('it calls onHide/onHidden actions when hiding tooltip by event [fade=false]', async function (assert) {
     let hideAction = sinon.spy();
     this.actions.hide = hideAction;
     let hiddenAction = sinon.spy();
@@ -181,6 +196,21 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     );
     await triggerEvent('#target', 'mouseenter');
     await triggerEvent('#target', 'mouseleave');
+    assert.ok(hideAction.calledOnce, 'hide action has been called');
+    assert.ok(hiddenAction.calledOnce, 'hidden action was called');
+  });
+
+  test('it calls onHide/onHidden actions when hiding tooltip programmatically [fade=false]', async function (assert) {
+    let hideAction = sinon.spy();
+    this.actions.hide = hideAction;
+    let hiddenAction = sinon.spy();
+    this.actions.hidden = hiddenAction;
+    this.set('show', true);
+    await render(
+      hbs`<div id="target"><BsTooltip @visible={{this.show}} @title="Dummy" @fade={{false}} @onHide={{action "hide"}} @onHidden={{action "hidden"}} /></div>`
+    );
+    this.set('show', false);
+    await settled();
     assert.ok(hideAction.calledOnce, 'hide action has been called');
     assert.ok(hiddenAction.calledOnce, 'hidden action was called');
   });

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -145,11 +145,11 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it calls onShow/onShown actions when showing tooltip by event [fade=false]', async function (assert) {
     let showAction = sinon.spy();
-    this.actions.show = showAction;
+    this.set('show', showAction);
     let shownAction = sinon.spy();
-    this.actions.shown = shownAction;
+    this.set('shown', shownAction);
     await render(
-      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onShow={{action "show"}} @onShown={{action "shown"}} /></div>`
+      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
     );
     await triggerEvent('#target', 'mouseenter');
     assert.ok(showAction.calledOnce, 'show action has been called');
@@ -158,14 +158,14 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it calls onShow/onShown actions when showing tooltip programmatically [fade=false]', async function (assert) {
     let showAction = sinon.spy();
-    this.actions.show = showAction;
+    this.set('show', showAction);
     let shownAction = sinon.spy();
-    this.actions.shown = shownAction;
-    this.set('show', false);
+    this.set('shown', shownAction);
+    this.set('visible', false);
     await render(
-      hbs`<div id="target"><BsTooltip @title="Dummy" @visible={{this.show}} @fade={{false}} @onShow={{action "show"}} @onShown={{action "shown"}} /></div>`
+      hbs`<div id="target"><BsTooltip @title="Dummy" @visible={{this.visible}} @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
     );
-    this.set('show', true);
+    this.set('visible', true);
     await settled();
     assert.ok(showAction.calledOnce, 'show action has been called');
     assert.ok(shownAction.calledOnce, 'shown action has been called');
@@ -174,11 +174,11 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('it aborts showing if onShow action returns false', async function (assert) {
     let showAction = sinon.stub();
     showAction.returns(false);
-    this.actions.show = showAction;
+    this.set('show', showAction);
     let shownAction = sinon.spy();
-    this.actions.shown = shownAction;
+    this.set('shown', shownAction);
     await render(
-      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onShow={{action "show"}} @onShown={{action "shown"}} /></div>`
+      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onShow={{this.show}} @onShown={{this.shown}} /></div>`
     );
     await triggerEvent('#target', 'mouseenter');
     assert.ok(showAction.calledOnce, 'show action has been called');
@@ -188,11 +188,11 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it calls onHide/onHidden actions when hiding tooltip by event [fade=false]', async function (assert) {
     let hideAction = sinon.spy();
-    this.actions.hide = hideAction;
+    this.set('hide', hideAction);
     let hiddenAction = sinon.spy();
-    this.actions.hidden = hiddenAction;
+    this.set('hidden', hiddenAction);
     await render(
-      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onHide={{action "hide"}} @onHidden={{action "hidden"}} /></div>`
+      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
     );
     await triggerEvent('#target', 'mouseenter');
     await triggerEvent('#target', 'mouseleave');
@@ -202,14 +202,14 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it calls onHide/onHidden actions when hiding tooltip programmatically [fade=false]', async function (assert) {
     let hideAction = sinon.spy();
-    this.actions.hide = hideAction;
+    this.set('hide', hideAction);
     let hiddenAction = sinon.spy();
-    this.actions.hidden = hiddenAction;
-    this.set('show', true);
+    this.set('hidden', hiddenAction);
+    this.set('visible', true);
     await render(
-      hbs`<div id="target"><BsTooltip @visible={{this.show}} @title="Dummy" @fade={{false}} @onHide={{action "hide"}} @onHidden={{action "hidden"}} /></div>`
+      hbs`<div id="target"><BsTooltip @visible={{this.visible}} @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
     );
-    this.set('show', false);
+    this.set('visible', false);
     await settled();
     assert.ok(hideAction.calledOnce, 'hide action has been called');
     assert.ok(hiddenAction.calledOnce, 'hidden action was called');
@@ -218,11 +218,11 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('it aborts hiding if onHide action returns false', async function (assert) {
     let hideAction = sinon.stub();
     hideAction.returns(false);
-    this.actions.hide = hideAction;
+    this.set('hide', hideAction);
     let hiddenAction = sinon.spy();
-    this.actions.hidden = hiddenAction;
+    this.set('hidden', hiddenAction);
     await render(
-      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onHide={{action "hide"}} @onHidden={{action "hidden"}} /></div>`
+      hbs`<div id="target"><BsTooltip @title="Dummy" @fade={{false}} @onHide={{this.hide}} @onHidden={{this.hidden}} /></div>`
     );
     await triggerEvent('#target', 'mouseenter');
     await triggerEvent('#target', 'mouseleave');


### PR DESCRIPTION
Fixes #1438 

The implementation is not really beautiful, as we still rely on those render-modifiers/helpers. But a complete refactor was out of scope for this quick fix.