### PR TITLE
Update ember-element-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "*.js": "eslint --cache --fix"
   },
   "resolutions": {
-    "ember-cli-htmlbars/semver": "~7.3.0",
-    "@embroider/util": "^1.0.0"
+    "ember-cli-htmlbars/semver": "~7.3.0"
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.0",
@@ -66,7 +65,7 @@
     "ember-cli-version-checker": "^5.1.2",
     "ember-concurrency": "^2.1.2",
     "ember-decorators": "^6.1.0",
-    "ember-element-helper": "^0.5.0",
+    "ember-element-helper": "^0.6.0",
     "ember-focus-trap": "^1.0.0",
     "ember-in-element-polyfill": "^1.0.1",
     "ember-named-blocks-polyfill": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,7 +1108,7 @@
     lodash "^4.17.21"
     resolve "^1.20.0"
 
-"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0", "@embroider/util@^1.0.0":
+"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0", "@embroider/util@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.0.0.tgz#e15cc055a71019a75265f77485328d25a2843d5d"
   integrity sha512-WQ6Dg3K5MXRbGP7N8yl1x63djohB4rbBE4qQMriA5blg2cav/eiNT2Vgh//Ft9j+auz46o4lzGmWVtzqVLWgeg==
@@ -5401,7 +5401,6 @@ ember-cli-fastboot-testing@0.6.0:
 
 "ember-cli-fastboot@https://gitpkg.now.sh/ember-fastboot/ember-cli-fastboot/packages/ember-cli-fastboot?4ad4eeb66bb9d46c0b14b6ed4601a5b5c2de7a5e":
   version "3.2.0-beta.2"
-  uid f223a6eeb46da4cf254567d58997acf5f78d066d
   resolved "https://gitpkg.now.sh/ember-fastboot/ember-cli-fastboot/packages/ember-cli-fastboot?4ad4eeb66bb9d46c0b14b6ed4601a5b5c2de7a5e#f223a6eeb46da4cf254567d58997acf5f78d066d"
   dependencies:
     broccoli-concat "^3.7.1"
@@ -5429,7 +5428,7 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars@^5.1.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
   integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==
@@ -5793,14 +5792,14 @@ ember-disable-prototype-extensions@1.1.3:
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
 
-ember-element-helper@^0.5.0:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.5.5.tgz#4a9ecb4dce57ee7f5ceb868a53c7b498c729f056"
-  integrity sha512-Tu3hsI+/mjHBUvw62Qi+YDZtKkn59V66CjwbgfNTZZ7aHf4gFm1ow4zJ4WLnpnie8p9FvOmIUxwl5HvgPJIcFA==
+ember-element-helper@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.6.0.tgz#6e6d0e86fadc9c8e5ccad306f498e8ef61b61c4e"
+  integrity sha512-sS3VIGdzF81lQrlMvFC8H71vwGrOl7b3+LK+9GTpLI555YF1b4sLmNylLkhaXv8UVEZUmsPHedVJY00Xarrc3Q==
   dependencies:
-    "@embroider/util" "^0.39.1 || ^0.40.0 || ^0.41.0"
-    ember-cli-babel "^7.17.2"
-    ember-cli-htmlbars "^5.1.0"
+    "@embroider/util" "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.0.1"
 
 ember-export-application-global@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This should be the [missing piece](https://github.com/kaliber5/ember-bootstrap/pull/1736#discussion_r794752843) for a stable 5.0.0 release, updating all embroider dependencies to 1.0.

cc @jelhan 