### PR TITLE
Needs peerDependency on ember-source

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,9 @@
     "striptags": "3.2.0",
     "webpack": "5.68.0"
   },
+  "peerDependencies": {
+    "ember-source": ">=3.24"
+  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },


### PR DESCRIPTION
`ember-bootstrap` depends on `@ember/render-modifiers`:

https://github.com/kaliber5/ember-bootstrap/blob/fdd5c22788ea0080e6e7bb83c20539c8048de367/package.json#L51-L52

And `@ember/render-modifiers` has a peerDependency on `ember-source`:

https://github.com/emberjs/ember-render-modifiers/blob/7dcc032d4f968c17fba6d10345550845f99cea1b/package.json#L73

Which means that `ember-bootstrap` should satisfies this peer dependency. Given that we know `ember-source` should only be provided by the top-level app, this means `ember-bootstrap` should list `ember-source` in `peerDependencies` (as opposed to listing it in `dependencies`).

## General observations

1. In principle, every ember addon really has an unstated peer dependency on ember-source. Historically we just let them "magically" get access even without declaring it.

    But in an effort to gradually move the ecosystem toward fully declaring their dependencies in a way that is legible to package managers, new features like `@embroider/macros` dependencySatisfies are strict about it.

2. Most apps will not experience any breakage either way. `@ember/render-modifiers` will typically be able to see the app's copy of `ember-source` because both will end up as peers in a single top-level `node_modules` directory. 

    So while a strict interpretation of the problem would suggest that adding a new peerDependency is a breaking change, and `@ember/render-modifiers` should have done a semver major when they added this peerDep and now `ember-bootstrap` should do a semver major also, I don't necessarily think that's super important. As a practical matter, virtually every existing package that uses ember-bootstrap *does* have access to ember-source, so adding this peerDep now is just a formalization of the status quo.

3. So why should we bother at all? The lack of this peer dep is a problem for people with more complicated setups, including monorepos with multiple different ember apps on different versions of ember, or people trying to adopt more strict package managers.

    I noticed the issue because this undeclared peerDep *does* break a test case in embroider's monorepo. It manifests as the dependencySatisfies macro in `@ember/render-modifiers` not being able to locate ember-source, because its parent package (ember-bootstrap) doesn't declare any dependency on it, and our test infrastructure only provides declared dependencies, not accidental ones.

4. A nice side-benefit of this pattern is that it creates a formalized place to declare your minimum supported Ember version. 
 