### PR TITLE
drop private @class argument of <BsModal>

### DIFF
--- a/addon/components/bs-modal.hbs
+++ b/addon/components/bs-modal.hbs
@@ -26,7 +26,6 @@
   ) as |Dialog|}}
     {{#if this._renderInPlace}}
       <Dialog
-        class={{@class}}
         {{create-ref "modalElement"}}
         ...attributes
       >
@@ -48,7 +47,6 @@
     {{else}}
       {{#in-element this.destinationElement insertBefore=null}}
         <Dialog
-          class={{@class}}
           {{create-ref "modalElement"}}
           ...attributes
         >

--- a/tests/integration/components/bs-modal-test.js
+++ b/tests/integration/components/bs-modal-test.js
@@ -144,16 +144,6 @@ module('Integration | Component | bs-modal', function (hooks) {
     assert.dom('.modal').hasAttribute('aria-labelledby', modalTitleId);
   });
 
-  test('it passes along class attribute', async function (assert) {
-    await render(hbs`
-      <BsModal @fade={{false}} @class="custom">
-        template block text
-      </BsModal>
-    `);
-
-    assert.dom('.modal.custom').exists({ count: 1 });
-  });
-
   test('it passes along HTML attributes', async function (assert) {
     await render(hbs`
       <BsModal @fade={{false}} class="custom" role="alert" data-test>


### PR DESCRIPTION
The `@class` argument of `<BsModal>` was added a long-time ago when that component was refactored to a tag-less component. It was not documented as a public API. A consumer can use `class` attribute instead. I think it is time to remove it.

There are some other components as well for which we have private `@class` argument:

- `<BsAccordion::Item::Body>`
- `<BsDropdown::Menu>`
- `<BsLinkTo>`
- `<BsNavbar::LinkTo>`
- `<BsPopover>` and `<BsPopover::Element>`
- `<BsTooltip>` and <BsTooltip::Element>`

For `<BsAccordion::Item::Body>`, `<BsDropdown::Menu>`, `<BsPopover>`, `<BsPopover::Element>`, `<BsTooltip>` and `<BsTooltip::Element>` I created pull requests to drop it as well: #1756, #1758, #1759 and #1760

For `<BsLinkTo>` and `<BsNavbar::LinkTo>` we can not drop the `@class` argument because we need to set the class on a yielded component instance.
https://github.com/kaliber5/ember-bootstrap/blob/f2ca93d7bf3ebd50de695f1c2800f7694e9bb07d/addon/components/bs-nav.hbs#L6
https://github.com/kaliber5/ember-bootstrap/blob/f2ca93d7bf3ebd50de695f1c2800f7694e9bb07d/addon/components/bs-navbar.hbs#L8

For `<BsLinkTo>` we could reduce the number of cases in which we need to use `@class` argument. Created a pull request to use class attribute for one case, in which it was possible. #1757