### PR TITLE
drop @class argument of <BsAccordion::Item::Body>

### DIFF
--- a/addon/components/bs-accordion/item/body.hbs
+++ b/addon/components/bs-accordion/item/body.hbs
@@ -1,5 +1,5 @@
 <BsCollapse @collapsed={{@collapsed}} role="tabpanel">
-  <div class="{{if (macroCondition (macroGetOwnConfig "isBS4")) "card-body"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-body"}} {{@class}}">
+  <div class="{{if (macroCondition (macroGetOwnConfig "isBS4")) "card-body"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-body"}}">
     {{yield}}
   </div>
 </BsCollapse>


### PR DESCRIPTION
The `@class` argument of `<BsAccordion::ItemBody>` is not documented as public API. It also feels wrong to support such an argument. I think we should drop it.

There is no clear migration path for applications relying on it .The `<BsAccordion::ItemBody>` does not support splat attributes yet. We could splat to the same element. But I think we should consider first if that makes sens long-term. We could also apply splat attributes to `<BsCollapse>` element. I haven't had the time to explore what makes more sense.

As the argument is not documented, I would not consider it a breaking change.