### PR TITLE
pass class as attribute to <BsLinkTo> if possible

### DIFF
--- a/addon/components/bs-navbar/link-to.hbs
+++ b/addon/components/bs-navbar/link-to.hbs
@@ -4,8 +4,8 @@
   @models={{@models}}
   @query={{@query}}
   @disabled={{@disabled}}
-  @class={{@class}}
   {{on 'click' this.onClick}}
+  class={{@class}}
   ...attributes
 >
   {{yield}}


### PR DESCRIPTION
We can not entirely drop the `@class` argument of `<BsLinkTo>`. In some cases we need to set a class on a yielded component instance. For example here: https://github.com/kaliber5/ember-bootstrap/blob/f2ca93d7bf3ebd50de695f1c2800f7694e9bb07d/addon/components/bs-nav.hbs#L6 But we should pass it as class attribute in all other cases.