### PR TITLE
drop private @class argument of <BsDropdown::Menu>

### DIFF
--- a/addon/components/bs-dropdown/menu.hbs
+++ b/addon/components/bs-dropdown/menu.hbs
@@ -1,7 +1,7 @@
 {{#if this._isOpen}}
   {{#if this._renderInPlace}}
     <div
-      class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}} {{@class}}"
+      class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}}"
       tabindex="-1"
       ...attributes
       {{popper-tooltip this.toggleElement this.popperOptions}}
@@ -21,7 +21,7 @@
   {{else}}
     {{#in-element this.destinationElement insertBefore=null}}
       <div
-        class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}} {{@class}}"
+        class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}}"
         tabindex="-1"
         ...attributes
         {{popper-tooltip this.toggleElement this.popperOptions}}


### PR DESCRIPTION
The argument was not documented. Therefore it is not a breaking change.

We don't need it to yield a component instance with a class. The `@class` argument is not set on the only case in which we yield that component: https://github.com/kaliber5/ember-bootstrap/blob/f2ca93d7bf3ebd50de695f1c2800f7694e9bb07d/addon/components/bs-dropdown.hbs#L20-L26

I think we should get rid of it to clean-up the API a little bit.