### PR TITLE
drop @class argument of <BsTooltip> and <BsTooltip::Element>

### DIFF
--- a/addon/components/bs-tooltip.hbs
+++ b/addon/components/bs-tooltip.hbs
@@ -12,7 +12,6 @@
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}
       @viewportPadding={{this.viewportPadding}}
-      @class={{@class}}
 
       {{create-ref "overlayElement"}}
       ...attributes

--- a/addon/components/bs-tooltip/element.hbs
+++ b/addon/components/bs-tooltip/element.hbs
@@ -1,6 +1,6 @@
 {{#if @renderInPlace}}
   <div
-    class="tooltip {{@class}} {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
+    class="tooltip {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
     role="tooltip"
     ...attributes
     {{popper-tooltip @popperTarget this.popperOptions}}
@@ -14,7 +14,7 @@
 {{else}}
   {{#in-element @destinationElement insertBefore=null}}
     <div
-      class="tooltip {{@class}} {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
+      class="tooltip {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
       role="tooltip"
       ...attributes
       {{popper-tooltip @popperTarget this.popperOptions}}

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -13,7 +13,6 @@ import {
 import { assertPositioning, setupForPositioning } from '../../helpers/contextual-help';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
-import { gte } from 'ember-compatibility-helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
 
@@ -502,13 +501,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     assert.dom('.tooltip').doesNotExist('tooltip is not visible');
   });
 
-  test('it passes along class attribute', async function (assert) {
-    await render(hbs`<div id="target"><BsTooltip @title="Dummy" @class="wide" /></div>`);
-    await triggerEvent('#target', 'mouseenter');
-    assert.dom('.tooltip').hasClass('wide');
-  });
-
-  (gte('3.4.0') ? test : skip)('it passes all HTML attribute', async function (assert) {
+  test('it passes all HTML attribute', async function (assert) {
     await render(hbs`<div id="target"><BsTooltip @title="Dummy" class="wide" data-test role="foo" /></div>`);
     await triggerEvent('#target', 'mouseenter');
     assert.dom('.tooltip').hasClass('wide');


### PR DESCRIPTION
As for the other cases the `@class` argument is not documented as public API. In this case a consumer can use `class` attribute instead.

The `<BsTooltip>` and `<BsTooltip::Element>` components are not yielded. So no need to keep it in order to set class on yielded component instance.