### PR TITLE
drop @class argument of <BsPopover> and <BsPopover::Element>

### DIFF
--- a/addon/components/bs-popover.hbs
+++ b/addon/components/bs-popover.hbs
@@ -13,7 +13,6 @@
       @autoPlacement={{this.autoPlacement}}
       @viewportElement={{this.viewportElement}}
       @viewportPadding={{this.viewportPadding}}
-      @class={{@class}}
 
       {{create-ref "overlayElement"}}
       ...attributes

--- a/addon/components/bs-popover/element.hbs
+++ b/addon/components/bs-popover/element.hbs
@@ -1,6 +1,6 @@
 {{#if @renderInPlace}}
   <div
-    class="popover {{@class}} {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
+    class="popover {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
     role="tooltip"
     ...attributes
     {{popper-tooltip @popperTarget this.popperOptions}}
@@ -15,7 +15,7 @@
 {{else}}
   {{#in-element @destinationElement insertBefore=null}}
     <div
-      class="popover {{@class}} {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
+      class="popover {{if this.fade "fade"}} {{this.actualPlacementClass}} {{if this.showHelp "show"}}"
       role="tooltip"
       ...attributes
       {{popper-tooltip @popperTarget this.popperOptions}}

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -12,7 +12,6 @@ import {
 import { assertPositioning, setupForPositioning } from '../../helpers/contextual-help';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
-import { gte } from 'ember-compatibility-helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
 
@@ -212,13 +211,7 @@ module('Integration | Component | bs-popover', function (hooks) {
     assert.dom('.popover').exists('popover visible again');
   });
 
-  test('it passes along class attribute', async function (assert) {
-    await render(hbs`<div id="target"><BsPopover @title="Dummy" @class="wide">test</BsPopover></div>`);
-    await click('#target');
-    assert.dom('.popover').hasClass('wide');
-  });
-
-  (gte('3.4.0') ? test : skip)('it passes all HTML attribute', async function (assert) {
+  test('it passes all HTML attribute', async function (assert) {
     await render(
       hbs`<div id="target"><BsPopover @title="Dummy" class="wide" data-test role="foo">test</BsPopover></div>`
     );

--- a/tests/integration/components/bs-popover-test.js
+++ b/tests/integration/components/bs-popover-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | bs-popover', function (hooks) {
   test('it has correct markup', async function (assert) {
     // Template block usage:
     await render(hbs`
-      <BsPopover @id="popover-element" @fade={{true}} @title="dummy title" @class="wide" @visible={{true}}>
+      <BsPopover @id="popover-element" @fade={{true}} @title="dummy title" @visible={{true}} class="wide">
         template block text
       </BsPopover>
     `);


### PR DESCRIPTION
This seems to be the very same case as #1759 