### PR TITLE
Update ember-style-modifier to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-popper-modifier": "^2.0.0",
     "ember-ref-bucket": "^4.0.0",
     "ember-render-helpers": "^0.2.0",
-    "ember-style-modifier": "^0.7.0",
+    "ember-style-modifier": "^0.8.0",
     "findup-sync": "^5.0.0",
     "fs-extra": "^10.0.0",
     "resolve": "^1.18.1",


### PR DESCRIPTION
This version fixes deprecations for ember 3.28. IE:
- deprecate.js:136 DEPRECATION: ember-modifier (in StyleModifier at Error
    at StyleModifier.get [as args] 
- DEPRECATION: ember-modifier (in StyleModifier at Error
    at new ClassBasedModifier