### PR TITLE
Ignore deprecations from ember-popper-modifier

### DIFF
--- a/tests/helpers/contextual-help.js
+++ b/tests/helpers/contextual-help.js
@@ -1,8 +1,7 @@
-import { assign } from '@ember/polyfills';
 import { getContext } from '@ember/test-helpers';
 
 export function setupForPositioning(align = 'left') {
-  assign(getContext().element.querySelector('#wrapper').style, {
+  Object.assign(getContext().element.querySelector('#wrapper').style, {
     position: 'absolute',
     bottom: 0,
     [align]: 0,
@@ -12,13 +11,13 @@ export function setupForPositioning(align = 'left') {
     overflow: 'hidden',
   });
 
-  assign(document.getElementById('ember-testing').style, {
+  Object.assign(document.getElementById('ember-testing').style, {
     transform: 'none',
   });
 
   // popper.js v1 seems to have issues with the positioning of our testing container since ember-qunit v5
   // Could be related to https://github.com/popperjs/popper-core/issues/670
-  assign(document.getElementById('ember-testing-container').style, {
+  Object.assign(document.getElementById('ember-testing-container').style, {
     position: 'relative',
     top: 0,
   });

--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -7,11 +7,8 @@ let expectedDeprecations = new Set();
 
 // Ignore deprecations that are not caused by our own code, and which we cannot fix easily.
 const ignoredDeprecations = [
-  // @todo remove when we can land https://github.com/emberjs/ember-render-modifiers/pull/33 here
-  /Versions of modifier manager capabilities prior to 3\.22 have been deprecated/,
-  /Usage of the Ember Global is deprecated./,
-  /import .* directly from/,
-  /Use of `assign` has been deprecated/,
+  // @todo remove when https://github.com/alexlafroscia/ember-popper-modifier/issues/452 is fixed
+  /ember-modifier/,
 ];
 
 export default function setupNoDeprecations({ beforeEach, afterEach }) {


### PR DESCRIPTION
Due to our strict no-deprecations setup this fails CI. See https://github.com/alexlafroscia/ember-popper-modifier/issues/452.

Removed the other ignored deprecations, as these were not needed anymore.