### PR TITLE
support @glimmer/component v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
             bootstrap: 5
           - scenario: tracked-toolbox-v1
             bootstrap: 5
+          - scenario: glimmer-component-v1
+            bootstrap: 5
     steps:
       - name: Checkout code
         uses: wyvox/action@v1

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -98,7 +98,7 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "@glimmer/component": "^1.0.4",
+    "@glimmer/component": "^1.0.4 || ^2.0.0",
     "@glimmer/tracking": "^1.0.4",
     "ember-source": ">=4.8.0",
     "ember-modifier": "^3.2.7 || ^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         specifier: ^1.0.0
         version: 1.13.4(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(@glint/template@1.7.3)(ember-cli-htmlbars@7.0.0(@babel/core@7.28.5)(ember-source@6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)))(ember-modifier@4.2.2(@babel/core@7.28.5)))(@glint/template@1.7.3)(ember-source@6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5))
       '@glimmer/component':
-        specifier: ^1.0.4
+        specifier: ^1.0.4 || ^2.0.0
         version: 1.1.2(@babel/core@7.28.5)
       '@glimmer/tracking':
         specifier: ^1.0.4

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -76,6 +76,14 @@ module.exports = async function () {
           },
         },
       },
+      {
+        name: 'glimmer-component-v1',
+        npm: {
+          devDependencies: {
+            '@glimmer/component': '^1.1.2',
+          },
+        },
+      },
       embroiderSafe({
         npm: {
           devDependencies: {

--- a/test-app/tests/integration/components/bs-carousel-test.gts
+++ b/test-app/tests/integration/components/bs-carousel-test.gts
@@ -19,6 +19,7 @@ import { tracked } from '@glimmer/tracking';
 import type { RenderingTestContext } from '@ember/test-helpers';
 import Component from '@glimmer/component';
 import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
 
 const TRANSITION_DURATION = 50;
 
@@ -567,7 +568,7 @@ module('Integration | Component | bs-carousel', function (hooks) {
     }
 
     class CustomSlide extends Component<CustomSlideSignature> {
-      constructor(owner: unknown, args: CustomSlideSignature['Args']) {
+      constructor(owner: Owner, args: CustomSlideSignature['Args']) {
         super(owner, args);
         this.args.registerChild?.(this);
 


### PR DESCRIPTION
We want to drop the peer dependency on `@glimmer/component` in mid-term. But that doesn't seem to be easy. We have to failed attempts: #2198 and #2236 Let's widen the existing peer dependency to fix the incompatibility with `@glimmer/component` v2 first.

Fixes #2194 