### PR TITLE
drop support for outdated versions of peer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,6 @@ jobs:
           - scenario: ember-release
             browser: Firefox
             bootstrap: 5
-          - scenario: tracked-toolbox-v1
-            bootstrap: 5
-          - scenario: glimmer-component-v1
-            bootstrap: 5
     steps:
       - name: Checkout code
         uses: wyvox/action@v1

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -39,7 +39,7 @@
     "release": "pnpm exec release-it"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^2.0.0 || ^3.0.0",
+    "@ember/render-modifiers": "^3.0.0",
     "@embroider/macros": "^1.0.0",
     "@embroider/util": "^1.0.0",
     "broccoli-debug": "^0.6.3",
@@ -51,18 +51,18 @@
     "ember-cli-build-config-editor": "^0.5.1",
     "ember-cli-htmlbars": "^7.0.0",
     "ember-cli-version-checker": "^5.1.2",
-    "ember-concurrency": "^2.1.2 || ^3.0.0 || ^4.0.0",
-    "ember-element-helper": "^0.6.0 || ^0.7.0 || ^0.8.0",
+    "ember-concurrency": "^4.0.0",
+    "ember-element-helper": "^0.8.0",
     "ember-focus-trap": "^1.0.0",
     "ember-on-helper": "^0.1.0",
-    "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "ember-ref-bucket": "^4.0.0 || ^5.0.0",
+    "ember-popper-modifier": "^4.0.0",
+    "ember-ref-bucket": "^5.0.0",
     "ember-render-helpers": "^2.0.0",
-    "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+    "ember-style-modifier": "^4.0.0",
     "findup-sync": "^5.0.0",
     "resolve": "^1.18.1",
     "silent-error": "^1.0.1",
-    "tracked-toolbox": "^1.2.3 || ^2.0.0"
+    "tracked-toolbox": "^2.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
   ember-bootstrap:
     dependencies:
       '@ember/render-modifiers':
-        specifier: ^2.0.0 || ^3.0.0
+        specifier: ^3.0.0
         version: 3.0.0(@glint/template@1.7.3)(ember-source@6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5))
       '@embroider/macros':
         specifier: ^1.0.0
@@ -270,10 +270,10 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2
       ember-concurrency:
-        specifier: ^2.1.2 || ^3.0.0 || ^4.0.0
+        specifier: ^4.0.0
         version: 4.0.6(@babel/core@7.28.5)(@glint/template@1.7.3)
       ember-element-helper:
-        specifier: ^0.6.0 || ^0.7.0 || ^0.8.0
+        specifier: ^0.8.0
         version: 0.8.8
       ember-focus-trap:
         specifier: ^1.0.0
@@ -285,10 +285,10 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       ember-popper-modifier:
-        specifier: ^2.0.0 || ^3.0.0 || ^4.0.0
+        specifier: ^4.0.0
         version: 4.1.1(@glint/template@1.7.3)(ember-source@6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5))(webpack@5.103.0)
       ember-ref-bucket:
-        specifier: ^4.0.0 || ^5.0.0
+        specifier: ^5.0.0
         version: 5.0.8(@babel/core@7.28.5)(@glint/template@1.7.3)(webpack@5.103.0)
       ember-render-helpers:
         specifier: ^2.0.0
@@ -297,7 +297,7 @@ importers:
         specifier: '>=4.8.0'
         version: 6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)
       ember-style-modifier:
-        specifier: ^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+        specifier: ^4.0.0
         version: 4.5.1(@babel/core@7.28.5)(@ember/string@4.0.1)
       findup-sync:
         specifier: ^5.0.0
@@ -309,7 +309,7 @@ importers:
         specifier: ^1.0.1
         version: 1.1.1
       tracked-toolbox:
-        specifier: ^1.2.3 || ^2.0.0
+        specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.28.5)(ember-source@6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5))
     devDependencies:
       '@babel/eslint-parser':

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -67,23 +67,6 @@ module.exports = async function () {
           // FAIL_ON_DEPRECATION: true,
         },
       },
-      {
-        name: 'tracked-toolbox-v1',
-        npm: {
-          devDependencies: {
-            bootstrap: bootstrapVersion,
-            'tracked-toolbox': '^1.2.3',
-          },
-        },
-      },
-      {
-        name: 'glimmer-component-v1',
-        npm: {
-          devDependencies: {
-            '@glimmer/component': '^1.1.2',
-          },
-        },
-      },
       embroiderSafe({
         npm: {
           devDependencies: {


### PR DESCRIPTION
This simplifies the support matrix by limiting support to the latest versions of the peer dependencies. We don't have any code specific to older versions of the peer dependencies per my knowledge.

This is a breaking change. It is the first step in preparing the next major version.