### PR TITLE
drop support for Node 18 and other EOL versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -88,7 +88,7 @@
     "webpack": "5.103.0"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || 22.* || >= 24"
   },
   "ember": {
     "edition": "octane"

--- a/ember-bootstrap/README.md
+++ b/ember-bootstrap/README.md
@@ -27,7 +27,7 @@ Ember Bootstrap works and is fully [tested](https://github.com/kaliber5/ember-bo
 - Ember CLI 4.8 or above
 - Bootstrap 4 and 5
 - all modern evergreen browsers (Chrome, Firefox, Safari, Edge)
-- node.js 18+
+- node.js 20+
 - FastBoot 1.0+
 - Embroider: we strive (and test) for maximum compatibility with Embroider, including the most aggressive setting
   (`staticComponents`) for tree shaking and code splitting. However as Embroider itself is still considered beta software,

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -104,7 +104,7 @@
     "ember-modifier": "^3.2.7 || ^4.0.0"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || 22.* || >= 24"
   },
   "ember": {
     "edition": "octane"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -108,7 +108,7 @@
     "webpack": "5.103.0"
   },
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || 22.* || >= 24"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This may not be a breaking change if we migrate to a v2 addon in the same release. But let's track it as a breaking change for now. We can still remove it from the changelog before release.