### PR TITLE
drop support for Ember < 5.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,7 @@ jobs:
         allow-failure:
           - false
         scenario:
-          - ember-lts-4.8
-          - ember-lts-5.4
+          - ember-lts-5.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/ember-bootstrap/README.md
+++ b/ember-bootstrap/README.md
@@ -23,8 +23,8 @@ To switch Bootstrap version or preprocessor, see the [setup documentation](http:
 
 Ember Bootstrap works and is fully [tested](https://github.com/kaliber5/ember-bootstrap/actions?query=workflow%3ACI+branch%3Amaster) with
 
-- Ember.js 4.8 or above
-- Ember CLI 4.8 or above
+- Ember.js 5.12 or above
+- Ember CLI 5.12 or above
 - Bootstrap 4 and 5
 - all modern evergreen browsers (Chrome, Firefox, Safari, Edge)
 - node.js 18+

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -100,7 +100,7 @@
   "peerDependencies": {
     "@glimmer/component": "^1.0.4 || ^2.0.0",
     "@glimmer/tracking": "^1.0.4",
-    "ember-source": ">=4.8.0",
+    "ember-source": ">= 5.12.0",
     "ember-modifier": "^3.2.7 || ^4.0.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,7 +294,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.28.5)
       ember-source:
-        specifier: '>=4.8.0'
+        specifier: '>= 5.12.0'
         version: 6.8.2(@glimmer/component@1.1.2(@babel/core@7.28.5))(rsvp@4.8.5)
       ember-style-modifier:
         specifier: ^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -12,24 +12,10 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-4.8',
+        name: 'ember-lts-5.12',
         npm: {
           devDependencies: {
-            'ember-source': '~4.8.0',
-            // @ember/render-modifiers v3 does not support ember < 4.12
-            '@ember/render-modifiers': '^2.0.0',
-            // ember-resolver 11 is required for ember < 4.12
-            // See: https://github.com/ember-cli/ember-resolver/releases/tag/v12.0.0
-            'ember-resolver': '11.0.1',
-            bootstrap: bootstrapVersion,
-          },
-        },
-      },
-      {
-        name: 'ember-lts-5.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.4.0',
+            'ember-source': '~5.12.0',
             bootstrap: bootstrapVersion,
           },
         },


### PR DESCRIPTION
This drops support for Ember < 5.12. Strictly speaking Ember 5.12 already reached its end of life (EOL) in October 2025. But it is still widely used. I feel we should continue supporting the latest version of the v5 cycle to prevent a fragmented community.