### PR TITLE
move BOOSTRAPVERSION env variable to test-app

### DIFF
--- a/ember-bootstrap/index.js
+++ b/ember-bootstrap/index.js
@@ -40,10 +40,6 @@ module.exports = {
       );
     }
 
-    if (process.env.BOOTSTRAPVERSION) {
-      // override bootstrapVersion config when environment variable is set
-      options.bootstrapVersion = parseInt(process.env.BOOTSTRAPVERSION);
-    }
     this.bootstrapOptions = options;
 
     this.validateDependencies();

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -7,7 +7,9 @@ module.exports = function (defaults) {
   const trees = {};
 
   const options = {
-    'ember-bootstrap': {},
+    'ember-bootstrap': {
+      bootstrapVersion: parseInt(process.env.BOOTSTRAPVERSION) || 5,
+    },
     'ember-cli-babel': {
       includePolyfill: !!process.env.BABELPOLYFILL,
       enableTypeScriptTransform: true,


### PR DESCRIPTION
Ember Bootstrap allowed setting the bootstrap version via `BOOTSTRAPVERSION` environment variable. This was not documented. And was not a public API. Theoretically consumers were able to use it. But likely the test app was the only one using the functionality to set the Bootstrap version depending on the test scenario.

This change moves the logic to the test app to which it belongs.