### PR TITLE
simplify @embroider/macros config by removing isNotBS5 alias for isBS4

### DIFF
--- a/ember-bootstrap/addon/components/bs-button.hbs
+++ b/ember-bootstrap/addon/components/bs-button.hbs
@@ -1,7 +1,7 @@
 <button
   disabled={{this.__disabled}}
   type={{if @attrTypePrivateWorkaround @attrTypePrivateWorkaround "button"}}
-  class="btn {{if @active 'active'}} {{if (macroCondition (macroGetOwnConfig 'isNotBS5')) (if this.block 'btn-block')}} {{bs-size-class 'btn' @size}} {{bs-type-class 'btn' @type default="secondary" outline=@outline}}"
+  class="btn {{if @active 'active'}} {{if (macroCondition (macroGetOwnConfig 'isBS4')) (if this.block 'btn-block')}} {{bs-size-class 'btn' @size}} {{bs-type-class 'btn' @type default="secondary" outline=@outline}}"
   ...attributes
   {{on "click" this.handleClick}}
   {{did-update this.resetState @reset}}

--- a/ember-bootstrap/addon/components/bs-form/element.hbs
+++ b/ember-bootstrap/addon/components/bs-form/element.hbs
@@ -1,7 +1,7 @@
 {{! @glint-nocheck }}
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div
-  class="{{if (macroCondition (macroGetOwnConfig "isNotBS5")) "form-group"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) (if (bs-eq @formLayout "vertical") "mb-3")}} {{if (bs-eq @formLayout "horizontal") (if (macroCondition (macroGetOwnConfig "isBS5")) "row mb-3" "row")}}"
+  class="{{if (macroCondition (macroGetOwnConfig "isBS4")) "form-group"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) (if (bs-eq @formLayout "vertical") "mb-3")}} {{if (bs-eq @formLayout "horizontal") (if (macroCondition (macroGetOwnConfig "isBS5")) "row mb-3" "row")}}"
   ...attributes
   {{create-ref "mainNode"}}
   {{on "focusout" this.showValidationOnHandler}}

--- a/ember-bootstrap/addon/macros-config.ts
+++ b/ember-bootstrap/addon/macros-config.ts
@@ -1,6 +1,5 @@
 export interface EmberBootstrapMacrosConfig {
   isBS4: boolean;
   isBS5: boolean;
-  isNotBS5: boolean;
   version: string;
 }

--- a/ember-bootstrap/index.js
+++ b/ember-bootstrap/index.js
@@ -43,8 +43,6 @@ module.exports = {
       bootstrapVersion === 4;
     this.options['@embroider/macros'].setOwnConfig.isBS5 =
       bootstrapVersion === 5;
-    this.options['@embroider/macros'].setOwnConfig.isNotBS5 =
-      bootstrapVersion !== 5;
     this.options['@embroider/macros'].setOwnConfig.version =
       require('./package.json').version;
   },


### PR DESCRIPTION
The `@embroider/marcos` own configuration contained a `isNotBS5` configuration. Ember Bootstrap only supports Bootstrap 4 and 5. Therefore, `isNotBS5` is an alias of `isBS4`. Let's remove that one to simplify the code.