### PR TITLE
Fix iOS mouseover listener leak when tooltip/popover is destroyed while visible

### DIFF
--- a/ember-bootstrap/addon/components/bs-contextual-help.ts
+++ b/ember-bootstrap/addon/components/bs-contextual-help.ts
@@ -598,13 +598,7 @@ export default abstract class ContextualHelp<
 
     this.showHelp = false;
 
-    // if this is a touch-enabled device we remove the extra
-    // empty mouseover listeners we added for iOS support
-    if ('ontouchstart' in document.documentElement) {
-      for (const child of document.body.children) {
-        child.removeEventListener('mouseover', noop);
-      }
-    }
+    this._removeiOSMouseoverListeners();
 
     if (this.usesTransition && this.overlayElement) {
       transitionEnd(this.overlayElement, this.transitionDuration).then(
@@ -641,6 +635,22 @@ export default abstract class ContextualHelp<
         }
       }
     });
+  }
+
+  /**
+   * Remove the empty mouseover listeners added to body's children for iOS support.
+   *
+   * @method _removeiOSMouseoverListeners
+   * @private
+   * @see https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
+   * @see https://github.com/twbs/bootstrap/pull/22481
+   */
+  _removeiOSMouseoverListeners() {
+    if ('ontouchstart' in document.documentElement) {
+      for (const child of document.body.children) {
+        child.removeEventListener('mouseover', noop);
+      }
+    }
   }
 
   /**
@@ -765,5 +775,6 @@ export default abstract class ContextualHelp<
   willDestroy() {
     super.willDestroy();
     this.removeListeners();
+    this._removeiOSMouseoverListeners();
   }
 }

--- a/test-app/tests/integration/components/bs-tooltip-test.gts
+++ b/test-app/tests/integration/components/bs-tooltip-test.gts
@@ -772,4 +772,51 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     await a11yAudit();
     assert.ok(true, 'A11y audit passed');
   });
+
+  test('it cleans up iOS mouseover listeners on destroy', async function (assert) {
+    // Simulate a touch-enabled device so the iOS workaround code path is exercised
+    const hadOntouchstart = 'ontouchstart' in document.documentElement;
+    if (!hadOntouchstart) {
+      // Setting to null makes `'ontouchstart' in document.documentElement` return true
+      (document.documentElement as HTMLElement & { ontouchstart: unknown }).ontouchstart = null;
+    }
+
+    const bodyChild = document.body.children[0]!;
+    const removeListenerSpy = sinon.spy(bodyChild, 'removeEventListener');
+
+    class State {
+      @tracked show = true;
+    }
+    const state = new State();
+
+    try {
+      await render(
+        <template>
+          {{#if state.show}}
+            <button type='button'>
+              Test
+              <BsTooltip @title='Dummy' @visible={{true}} />
+            </button>
+          {{/if}}
+        </template>,
+      );
+      await settled();
+
+      // Destroy the component by removing it from the DOM.
+      // This triggers willDestroy() without calling hide() first,
+      // which previously leaked the iOS mouseover listeners.
+      state.show = false;
+      await settled();
+
+      assert.ok(
+        removeListenerSpy.calledWith('mouseover'),
+        'iOS mouseover listeners are removed when component is destroyed without hide()',
+      );
+    } finally {
+      removeListenerSpy.restore();
+      if (!hadOntouchstart) {
+        delete (document.documentElement as HTMLElement & { ontouchstart?: unknown }).ontouchstart;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

On touch-enabled devices (iOS), `bs-contextual-help` adds empty `mouseover` listeners to all `document.body` children in `_show()` as a [workaround for broken iOS event delegation](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html) (mirroring [Bootstrap's own fix](https://github.com/twbs/bootstrap/pull/22481)).

These listeners were only cleaned up in `hide()`, but if the component is destroyed without `hide()` being called — for example during a route transition while a tooltip is visible — the listeners leak permanently. Over time this can accumulate thousands of stale event listeners, degrading performance and memory.

**Fix:** Extract the iOS listener cleanup into `_removeiOSMouseoverListeners()` and call it from both `hide()` and `willDestroy()`, ensuring cleanup regardless of how the component is torn down.

## Changes

- **`ember-bootstrap/addon/components/bs-contextual-help.ts`**: Extract iOS cleanup into `_removeiOSMouseoverListeners()` method, call it from `hide()` and `willDestroy()`
- **`test-app/tests/integration/components/bs-tooltip-test.gts`**: Add test that verifies iOS mouseover listeners are cleaned up when the component is destroyed without `hide()` being called

## Test plan

- [ ] Existing tests pass (no behavior change for the `hide()` path)
- [ ] New test verifies cleanup on destroy: simulates a touch device, renders a visible tooltip, destroys it via DOM removal (not `hide()`), and asserts `removeEventListener('mouseover', ...)` was called on body children